### PR TITLE
Add benchmarking to test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ".[xarray]" pytest pytest-cov pytest-randomly
+          pip install ".[xarray]" pytest pytest-cov pytest-randomly pytest-benchmark
       
       - name: Testing
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 coverage_report
 corbertura_report.xml
 tests/test_data/hidden
+*/.benchmarks
 
 # Local Installation Artifacts #
 ################################

--- a/docs/source/benchmarking.md
+++ b/docs/source/benchmarking.md
@@ -1,0 +1,86 @@
+# Benchmarking Performance
+
+Benchmarking packet parsing is challenging because performance is greatly impacted by the complexity of the packet 
+structures being parsed. There are a few measures by which we can assess the performance of Space Packet Parser.
+
+> [!NOTE]
+> Throughout the Space Packet Parser repo and documentation space, 
+> B/kB means bytes/kilobytes and b/kb means bits/kilobits.*
+
+Common factors affecting performance:
+- Presence of calibrators and context calibrators
+- Complexity of container inheritance structure
+- Number and size of fields in a packet
+- Presence of large binary blobs (=high kbps, faster parsing)
+
+## Packets Per Second
+
+This is a metric we are often asked about. Unfortunately, the answer is that it depends on which packets are 
+being parsed: how many fields are in each packet and how much extra work the parser is doing to sort out complex 
+packet structures and evaluate calibrators.
+
+## Kilobits Per Second
+
+This metric is often used when discussing data volumes and downlink bandwidths to make sure that a data processing 
+system can keep up with the data rate from a spacecraft in the time allowed for processing. This number is also 
+affected by packet structures. It will be high for simple packets containing large binary blobs and low for 
+complex packets containing many small fields.
+
+## Results
+
+These tests were run on an Apple Silicon M3 Max processor. 
+
+As a baseline, for relatively simple packets (these are JPSS-1 spacecraft geolocation packets containing attitude 
+and ephemeris data), we benchmarked using 7200 packets with a consistent size of 71B per packet. These packets contain 
+32-bit floats and integers of various sizes.
+
+- **26405-34620 packets per second**
+- **14998-19664 kilobits per second**
+
+Without progress printing (~13ms faster):
+```
+---------------------------------------------------------- benchmark: 1 tests ---------------------------------------------------------
+Name (time in ms)                             Min       Max      Mean   StdDev    Median      IQR  Outliers     OPS  Rounds  Iterations
+---------------------------------------------------------------------------------------------------------------------------------------
+test_benchmark_simple_packet_parsing     195.3229  265.1687  230.5723  26.6511  235.8300  54.4324      10;0  4.3370      20           1
+---------------------------------------------------------------------------------------------------------------------------------------
+
+Legend:
+  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
+  OPS: Operations Per Second, computed as 1 / Mean
+```
+
+With progress printing (showing progress output from Space Packet Parser):
+```
+---------------------------------------------------------- benchmark: 1 tests ---------------------------------------------------------
+Name (time in ms)                             Min       Max      Mean   StdDev    Median      IQR  Outliers     OPS  Rounds  Iterations
+---------------------------------------------------------------------------------------------------------------------------------------
+test_benchmark_simple_packet_parsing     207.9945  272.7036  243.0210  16.8787  239.5151  20.2260       7;0  4.1149      20           1
+---------------------------------------------------------------------------------------------------------------------------------------
+
+Legend:
+  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
+  OPS: Operations Per Second, computed as 1 / Mean
+============================== 1 passed in 5.42s ===============================
+Progress: [====================]100% [Elapsed: 0:00:00.234986, Parsed 511200 bytes (7200 packets) at 17403kb/s (30640pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.238829, Parsed 511200 bytes (7200 packets) at 17123kb/s (30147pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.272674, Parsed 511200 bytes (7200 packets) at 14998kb/s (26405pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.217858, Parsed 511200 bytes (7200 packets) at 18771kb/s (33049pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.266889, Parsed 511200 bytes (7200 packets) at 15323kb/s (26977pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.242260, Parsed 511200 bytes (7200 packets) at 16881kb/s (29720pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.240147, Parsed 511200 bytes (7200 packets) at 17029kb/s (29981pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.249718, Parsed 511200 bytes (7200 packets) at 16376kb/s (28832pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.238504, Parsed 511200 bytes (7200 packets) at 17146kb/s (30188pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.207969, Parsed 511200 bytes (7200 packets) at 19664kb/s (34620pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.271132, Parsed 511200 bytes (7200 packets) at 15083kb/s (26555pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.240643, Parsed 511200 bytes (7200 packets) at 16994kb/s (29919pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.237156, Parsed 511200 bytes (7200 packets) at 17244kb/s (30359pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.231368, Parsed 511200 bytes (7200 packets) at 17675kb/s (31119pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.232334, Parsed 511200 bytes (7200 packets) at 17602kb/s (30989pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.260499, Parsed 511200 bytes (7200 packets) at 15699kb/s (27639pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.240519, Parsed 511200 bytes (7200 packets) at 17003kb/s (29935pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.235573, Parsed 511200 bytes (7200 packets) at 17360kb/s (30563pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.237279, Parsed 511200 bytes (7200 packets) at 17235kb/s (30344pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.234196, Parsed 511200 bytes (7200 packets) at 17462kb/s (30743pkts/s)]
+Progress: [====================]100% [Elapsed: 0:00:00.264275, Parsed 511200 bytes (7200 packets) at 15474kb/s (27244pkts/s)]
+```

--- a/docs/source/benchmarking.md
+++ b/docs/source/benchmarking.md
@@ -1,5 +1,7 @@
 # Benchmarking Performance
 
+## Full Packet Parsing Performance
+
 Benchmarking packet parsing is challenging because performance is greatly impacted by the complexity of the packet 
 structures being parsed. There are a few measures by which we can assess the performance of Space Packet Parser.
 
@@ -13,20 +15,20 @@ Common factors affecting performance:
 - Number and size of fields in a packet
 - Presence of large binary blobs (=high kbps, faster parsing)
 
-## Packets Per Second
+### Packets Per Second
 
 This is a metric we are often asked about. Unfortunately, the answer is that it depends on which packets are 
 being parsed: how many fields are in each packet and how much extra work the parser is doing to sort out complex 
 packet structures and evaluate calibrators.
 
-## Kilobits Per Second
+### Kilobits Per Second
 
 This metric is often used when discussing data volumes and downlink bandwidths to make sure that a data processing 
 system can keep up with the data rate from a spacecraft in the time allowed for processing. This number is also 
 affected by packet structures. It will be high for simple packets containing large binary blobs and low for 
 complex packets containing many small fields.
 
-## Results
+### Results
 
 These tests were run on an Apple Silicon M3 Max processor. 
 
@@ -84,3 +86,31 @@ Progress: [====================]100% [Elapsed: 0:00:00.237279, Parsed 511200 byt
 Progress: [====================]100% [Elapsed: 0:00:00.234196, Parsed 511200 bytes (7200 packets) at 17462kb/s (30743pkts/s)]
 Progress: [====================]100% [Elapsed: 0:00:00.264275, Parsed 511200 bytes (7200 packets) at 15474kb/s (27244pkts/s)]
 ```
+
+## Parsing Individual Values Benchmarking
+
+In addition to the benchmarks discussed above, we also benchmarked the low level operations that make up most 
+of the parsing work. The parser relies on two fundamental methods: `read_as_int(nbits)` and `read_as_bytes(nbits)`,
+each of which is capable of reading an arbitrary number of bits from a byte string. That is, the binary data being 
+parsed need not be byte aligned or even an integer number of bytes.
+
+```
+-------------------------------------------------------------------------------------------------------- benchmark: 5 tests --------------------------------------------------------------------------------------------------------
+Name (time in ns)                                              Min                 Max                Mean             StdDev              Median                IQR            Outliers  OPS (Mops/s)            Rounds  Iterations
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+test_benchmark__read_as_bytes__aligned                    231.4160 (1.0)      237.2910 (1.0)      234.8330 (1.0)       3.0527 (1.0)      235.7920 (1.0)       4.4063 (1.0)           1;0        4.2583 (1.0)           3        1000
+test_benchmark__read_as_int__aligned                      253.0000 (1.09)     302.1660 (1.27)     273.4720 (1.16)     25.5934 (8.38)     265.2500 (1.12)     36.8745 (8.37)          1;0        3.6567 (0.86)          3        1000
+test_benchmark__read_as_int__non_aligned                  361.6250 (1.56)     379.7910 (1.60)     371.4720 (1.58)      9.1789 (3.01)     373.0000 (1.58)     13.6245 (3.09)          1;0        2.6920 (0.63)          3        1000
+test_benchmark__read_as_bytes__non_aligned_full_bytes     417.5420 (1.80)     439.2500 (1.85)     425.0833 (1.81)     12.2772 (4.02)     418.4580 (1.77)     16.2810 (3.69)          1;0        2.3525 (0.55)          3        1000
+test_benchmark__read_as_bytes__partial_bytes              441.6660 (1.91)     460.8340 (1.94)     452.3473 (1.93)      9.7707 (3.20)     454.5420 (1.93)     14.3760 (3.26)          1;0        2.2107 (0.52)          3        1000
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+```
+
+The results are as expected:
+
+- The most efficient parsing is byte-aligned parsing of objects that are integer number of bytes in length. 
+- Parsing integers is slower than raw bytes due to the conversion from bytes to int.
+- The most expensive operation is parsing a bytes object that is an odd number of bits (e.g. 6 bits). This is due 
+  to the padding operation required to return a bytes object from such a call.
+- The only surprise is that non-aligned integers parse faster than non-aligned full bytes. Ironically this is due
+  to a check that we perform during byte parsing to return faster if the request _is_ byte aligned.

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -28,6 +28,7 @@ Release notes for the `space_packet_parser` library
 - Add function to directly create an `xarray.DataSet` from a packet file and XTCE definition.
   e.g. `space_packet_parser.xarr.create_dataset([packets1, packets2, ...], definition)`
 - BUGFIX: update list of allowed float encodings to match XTCE spec
+- Add benchmark tests and documentation overview of benchmarks.
 
 ### v5.0.1 (released)
 - BUGFIX: Allow raw_value representation for enums with falsy raw values. Previously these defaulted to the enum label.

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -6,4 +6,5 @@
    developers.md
    changelog.md
    browser-demo.rst
+   benchmarking.md
    autoapi/index.rst

--- a/examples/parsing_and_plotting_idex_waveforms_from_socket.py
+++ b/examples/parsing_and_plotting_idex_waveforms_from_socket.py
@@ -162,11 +162,11 @@ if __name__ == "__main__":
                     for scitype, waveform in data.items()
                 }
                 plot_full_event(parsed_waveform_data)
-    except StopIteration:
+    except socket.timeout:
         parsed_waveform_data: dict[int, list] = {
             scitype: parse_waveform_data(waveform, scitype)
             for scitype, waveform in data.items()
         }
-        plot_full_event(data)
+        plot_full_event(parsed_waveform_data)
         print("\nEncountered the end of the binary file.")
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ numpy = { version = "^2.0.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"
+pytest-benchmark = "*"
 pytest-randomly = "*"
 pytest-cov = "*"
 pyyaml = "*"
@@ -76,6 +77,7 @@ build-backend = "poetry.core.masonry.api"
 filterwarnings = [
     "error",
     "ignore:You are encoding a BooleanParameterType:UserWarning",
+    "ignore:Number of bits parsed:UserWarning"
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",
-    "ignore:You are encoding a BooleanParameterType:UserWarning",
-    "ignore:Number of bits parsed:UserWarning"
+    "ignore:You are encoding a BooleanParameterType:UserWarning"
 ]
 
 [tool.ruff]

--- a/tests/benchmark/test_benchmarks.py
+++ b/tests/benchmark/test_benchmarks.py
@@ -1,0 +1,81 @@
+"""Benchmarking test suite for Space Packet Parser
+
+Each test in this suite tests a specific metric over time
+"""
+import pytest
+from space_packet_parser import definitions
+from space_packet_parser.packets import CCSDSPacket
+from typing import Iterable
+
+
+@pytest.mark.benchmark(
+    warmup=True
+)
+def test_benchmark_complex_xtce_definition_parsing(benchmark, suda_test_data_dir):
+    """Benchmark the time it takes to parse a specific, relatively complex XTCE packet definition document"""
+    definition: definitions.XtcePacketDefinition = benchmark(
+        definitions.XtcePacketDefinition,
+        suda_test_data_dir / "suda_combined_science_definition.xml"
+    )
+    print(definition.named_parameters)
+    print(definition.named_parameter_types)
+
+
+@pytest.mark.benchmark
+def test_benchmark_simple_packet_parsing(benchmark, jpss_test_data_dir):
+    """Benchmark the time it takes to parse 7200 simple JPSS geolocation packets from a flat packet definition"""
+    packet_definition = definitions.XtcePacketDefinition(jpss_test_data_dir / "jpss1_geolocation_xtce_v1.xml")
+    packet_data = jpss_test_data_dir / "J01_G011_LZ_2021-04-09T00-00-00Z_V01.DAT1"
+
+    # Open reusable filehandler
+    packet_fh = packet_data.open("rb")
+
+    try:
+        def _setup():
+            """Function that sets up for each benchmark round"""
+            packet_fh.seek(0)
+            packet_generator = packet_definition.packet_generator(packet_fh)
+            return (), {"generator": packet_generator}  # args, kwargs for benchmarked function
+
+        def _make_packet_list(generator: Iterable[CCSDSPacket]):
+            """Function wrapper for list that takes the generator as a kwarg"""
+            return list(generator)
+
+        # The setup function is run before each "round" so "iterations" is automatically set to 1 and cannot be changed
+        packets: list = benchmark.pedantic(_make_packet_list, setup=_setup, rounds=20, warmup_rounds=1)
+
+        # Make sure the result actually makes sense
+        assert len(packets) == 7200
+    finally:
+        # Ensure filehandler is closed
+        packet_fh.close()
+
+
+@pytest.mark.benchmark
+def test_benchmark_complex_packet_parsing(benchmark, idex_test_data_dir):
+    """Benchmark the time it takes to parse IDEX packets, which have a polymorphic structure"""
+    packet_definition = definitions.XtcePacketDefinition(idex_test_data_dir / "idex_combined_science_definition.xml")
+    packet_data = idex_test_data_dir / "sciData_2023_052_14_45_05"
+
+    # Open reusable filehandler
+    packet_fh = packet_data.open("rb")
+
+    try:
+        def _setup():
+            """Function that sets up for each benchmark round"""
+            packet_fh.seek(0)
+            packet_generator = packet_definition.packet_generator(packet_fh, show_progress=True)
+            return (), {"generator": packet_generator}  # args, kwargs for benchmarked function
+
+        def _make_packet_list(generator: Iterable[CCSDSPacket]):
+            """Function wrapper for list that takes the generator as a kwarg"""
+            return list(generator)
+
+        # The setup function is run before each "round" so "iterations" is automatically set to 1 and cannot be changed
+        packets: list = benchmark.pedantic(_make_packet_list, setup=_setup, rounds=20, warmup_rounds=1)
+
+        # Make sure the result actually makes sense
+        assert len(packets) == 78
+    finally:
+        # Ensure filehandler is closed
+        packet_fh.close()

--- a/tests/benchmark/test_fast_benchmarks.py
+++ b/tests/benchmark/test_fast_benchmarks.py
@@ -1,0 +1,131 @@
+"""Fast benchmarks"""
+import pytest
+
+from space_packet_parser import packets
+
+@pytest.mark.benchmark
+def test_benchmark__read_as_int__aligned(benchmark):
+    """Benchmark performance of reading byte-aligned ints from a bytes object
+
+    This test essentially makes a packet with a long user data section of alternating ones and zeros
+    """
+    rounds = 3
+    warmup_rounds = 1
+    test_byte = b'\x55'  # 01 01 01 01
+    n_iterations = 1000
+    nbits = 16
+    expected_value = 21845  # 01010101 01010101
+    n_test_byte_repeats = ((rounds + warmup_rounds) * n_iterations * nbits // 8) + 1
+    raw_packet = packets.create_ccsds_packet(data=test_byte * n_test_byte_repeats)
+    # parse the header to move the bit cursor
+    _ = raw_packet.header_values
+
+    value = benchmark.pedantic(raw_packet.read_as_int, args=(nbits, ),
+                               rounds=rounds,
+                               iterations=n_iterations,
+                               warmup_rounds=warmup_rounds)
+
+    assert value == expected_value
+
+
+@pytest.mark.benchmark
+def test_benchmark__read_as_int__non_aligned(benchmark):
+    """Benchmark performance of reading non-byte-aligned ints from a bytes object
+
+    This test essentially makes a packet with a long user data section of alternating ones and zeros
+    """
+    rounds = 3
+    warmup_rounds = 1
+    test_byte = b'\x55'  # 01 01 01 01
+    n_iterations = 1000
+    nbits = 18
+    expected_value = 87381 # 01010101 01010101 01
+    n_test_byte_repeats = ((rounds + warmup_rounds) * n_iterations * nbits // 8) + 1
+    raw_packet = packets.create_ccsds_packet(data=test_byte * n_test_byte_repeats)
+    # parse the header to move the bit cursor
+    _ = raw_packet.header_values
+
+    value = benchmark.pedantic(raw_packet.read_as_int, args=(nbits, ),
+                               rounds=rounds,
+                               iterations=n_iterations,
+                               warmup_rounds=warmup_rounds)
+
+    assert value == expected_value
+
+
+@pytest.mark.benchmark
+def test_benchmark__read_as_bytes__aligned(benchmark):
+    """Benchmark performance of reading full, aligned, bytes from a bytes object
+
+    This test essentially makes a packet with a long user data section of alternating ones and zeros
+    """
+    rounds = 3
+    warmup_rounds = 1
+    test_byte = b'\x55'  # 01 01 01 01
+    n_iterations = 1000
+    nbits = 16
+    expected_value = b'\x55\x55'  # 01010101 01010101
+    n_test_byte_repeats = ((rounds + warmup_rounds) * n_iterations * nbits // 8) + 1
+    raw_packet = packets.create_ccsds_packet(data=test_byte * n_test_byte_repeats)
+    # parse the header to move the bit cursor
+    _ = raw_packet.header_values
+
+    value = benchmark.pedantic(raw_packet.read_as_bytes, args=(nbits, ),
+                               rounds=rounds,
+                               iterations=n_iterations,
+                               warmup_rounds=warmup_rounds)
+
+    assert value == expected_value
+
+
+@pytest.mark.benchmark
+def test_benchmark__read_as_bytes__non_aligned_full_bytes(benchmark):
+    """Benchmark performance of reading full bytes, not-byte-aligned (offset by 1 bit), from a bytes object
+
+    This test essentially makes a packet with a long user data section of alternating ones and zeros
+    """
+    rounds = 3
+    warmup_rounds = 1
+    test_byte = b'\x55'  # 01 01 01 01
+    n_iterations = 1000
+    nbits = 16
+    expected_value = b'\xaa\xaa'  # 10101010 10101010
+    n_test_byte_repeats = ((rounds + warmup_rounds) * n_iterations * nbits // 8) + 1
+    raw_packet = packets.create_ccsds_packet(data=test_byte * n_test_byte_repeats)
+    raw_packet.pos += 1  # Move cursor to non-aligned position
+    # parse the header to move the bit cursor
+    _ = raw_packet.header_values
+
+    value = benchmark.pedantic(raw_packet.read_as_bytes, args=(nbits, ),
+                               rounds=rounds,
+                               iterations=n_iterations,
+                               warmup_rounds=warmup_rounds)
+
+    assert value == expected_value
+
+
+@pytest.mark.benchmark
+def test_benchmark__read_as_bytes__partial_bytes(benchmark):
+    """Benchmark performance of reading partial bytes from a bytes object, resulting
+    in padded values.
+
+    This test essentially makes a packet with a long user data section of alternating ones and zeros
+    """
+    rounds = 3
+    warmup_rounds = 1
+    test_byte = b'\x55'  # 01 01 01 01
+    n_iterations = 1000
+    nbits = 6
+    expected_value = b'\x15'  # 00 01 01 01 (MSB padded with 2 bits)
+    n_test_byte_repeats = ((rounds + warmup_rounds) * n_iterations * nbits // 8) + 1
+    raw_packet = packets.create_ccsds_packet(data=test_byte * n_test_byte_repeats)
+
+    # parse the header to move the bit cursor
+    _ = raw_packet.header_values
+
+    value = benchmark.pedantic(raw_packet.read_as_bytes, args=(nbits, ),
+                               rounds=rounds,
+                               iterations=n_iterations,
+                               warmup_rounds=warmup_rounds)
+
+    assert value == expected_value

--- a/tests/benchmark/test_slow_benchmarks.py
+++ b/tests/benchmark/test_slow_benchmarks.py
@@ -3,9 +3,9 @@
 Each test in this suite tests a specific metric over time
 """
 import pytest
-from space_packet_parser import definitions
-from space_packet_parser.packets import CCSDSPacket
 from typing import Iterable
+
+from space_packet_parser import definitions, packets
 
 
 @pytest.mark.benchmark(
@@ -37,15 +37,15 @@ def test_benchmark_simple_packet_parsing(benchmark, jpss_test_data_dir):
             packet_generator = packet_definition.packet_generator(packet_fh)
             return (), {"generator": packet_generator}  # args, kwargs for benchmarked function
 
-        def _make_packet_list(generator: Iterable[CCSDSPacket]):
+        def _make_packet_list(generator: Iterable[packets.CCSDSPacket]):
             """Function wrapper for list that takes the generator as a kwarg"""
             return list(generator)
 
         # The setup function is run before each "round" so "iterations" is automatically set to 1 and cannot be changed
-        packets: list = benchmark.pedantic(_make_packet_list, setup=_setup, rounds=20, warmup_rounds=1)
+        packet_list: list = benchmark.pedantic(_make_packet_list, setup=_setup, rounds=20, warmup_rounds=1)
 
         # Make sure the result actually makes sense
-        assert len(packets) == 7200
+        assert len(packet_list) == 7200
     finally:
         # Ensure filehandler is closed
         packet_fh.close()
@@ -67,15 +67,15 @@ def test_benchmark_complex_packet_parsing(benchmark, idex_test_data_dir):
             packet_generator = packet_definition.packet_generator(packet_fh, show_progress=True)
             return (), {"generator": packet_generator}  # args, kwargs for benchmarked function
 
-        def _make_packet_list(generator: Iterable[CCSDSPacket]):
+        def _make_packet_list(generator: Iterable[packets.CCSDSPacket]):
             """Function wrapper for list that takes the generator as a kwarg"""
             return list(generator)
 
         # The setup function is run before each "round" so "iterations" is automatically set to 1 and cannot be changed
-        packets: list = benchmark.pedantic(_make_packet_list, setup=_setup, rounds=20, warmup_rounds=1)
+        packet_list: list = benchmark.pedantic(_make_packet_list, setup=_setup, rounds=20, warmup_rounds=1)
 
         # Make sure the result actually makes sense
-        assert len(packets) == 78
+        assert len(packet_list) == 78
     finally:
         # Ensure filehandler is closed
         packet_fh.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,3 +37,9 @@ def clarreo_test_data_dir(test_data_dir):
 def suda_test_data_dir(test_data_dir):
     """SUDA test data directory"""
     return test_data_dir / 'suda'
+
+
+@pytest.fixture
+def idex_test_data_dir(test_data_dir):
+    """IDEX test data directory"""
+    return test_data_dir / 'idex'


### PR DESCRIPTION
This PR adds benchmark tests using `pytest-benchmark`. The benchmark tests are included in the `tests/benchmark` directory and are run as part of the normal test suite.

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [NA] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [ ] The changelog.md has been updated
