### PR TITLE
BUGFIX: update allowed float encodings to match XTCE standard

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -27,6 +27,7 @@ Release notes for the `space_packet_parser` library
   some common tasks and utilities.
 - Add function to directly create an `xarray.DataSet` from a packet file and XTCE definition.
   e.g. `space_packet_parser.xarr.create_dataset([packets1, packets2, ...], definition)`
+- BUGFIX: update list of allowed float encodings to match XTCE spec
 
 ### v5.0.1 (released)
 - BUGFIX: Allow raw_value representation for enums with falsy raw values. Previously these defaulted to the enum label.

--- a/space_packet_parser/encodings.py
+++ b/space_packet_parser/encodings.py
@@ -1,7 +1,7 @@
 """DataEncoding definitions"""
 # Standard
-import struct
 import logging
+import struct
 import warnings
 from abc import ABCMeta, abstractmethod
 from typing import Optional, Union

--- a/space_packet_parser/encodings.py
+++ b/space_packet_parser/encodings.py
@@ -603,14 +603,14 @@ class IntegerDataEncoding(NumericDataEncoding):
 
 class FloatDataEncoding(NumericDataEncoding):
     """<xtce:FloatDataEncoding>"""
-    _supported_encodings = ['IEEE-754', 'MIL-1750A']
+    _supported_encodings = ['IEEE754_1985', 'IEEE754', 'MILSTD_1750A']
     _data_return_class = packets.FloatParameter
 
     def __init__(
             self,
             size_in_bits: int,
             *,
-            encoding: str = 'IEEE-754',
+            encoding: str = 'IEEE754',
             byte_order: str = 'mostSignificantByteFirst',
             default_calibrator: Optional[calibrators.Calibrator] = None,
             context_calibrators: Optional[list[calibrators.ContextCalibrator]] = None
@@ -622,7 +622,7 @@ class FloatDataEncoding(NumericDataEncoding):
         size_in_bits : int
             Size of the encoded value, in bits.
         encoding : str
-            Encoding method of the float data. Must be either 'IEEE-754' or 'MIL-1750A'. Defaults to IEEE-754.
+            Encoding method of the float data. Must be either 'IEEE754' or 'MILSTD_1750A'. Defaults to IEEE754.
         byte_order : str
             Description of the byte order. Default is 'mostSignificantByteFirst' (big endian).
         default_calibrator : Optional[Calibrator]
@@ -635,15 +635,15 @@ class FloatDataEncoding(NumericDataEncoding):
         if encoding not in self._supported_encodings:
             raise ValueError(f"Invalid encoding type {encoding} for float data. "
                              f"Must be one of {self._supported_encodings}.")
-        if encoding == 'MIL-1750A' and size_in_bits != 32:
+        if encoding == 'MILSTD_1750A' and size_in_bits != 32:
             raise ValueError("MIL-1750A encoded floats must be 32 bits, per the MIL-1750A spec. See "
                              "https://www.xgc-tek.com/manuals/mil-std-1750a/c191.html#AEN324")
-        if encoding == 'IEEE-754' and size_in_bits not in (16, 32, 64):
-            raise ValueError(f"Invalid size_in_bits value for IEEE-754 FloatDataEncoding, {size_in_bits}. "
+        if encoding in ('IEEE754', 'IEEE754_1985') and size_in_bits not in (16, 32, 64):
+            raise ValueError(f"Invalid size_in_bits value for IEEE754 FloatDataEncoding, {size_in_bits}. "
                              "Must be 16, 32, or 64.")
         super().__init__(size_in_bits=size_in_bits, encoding=encoding, byte_order=byte_order,
                          default_calibrator=default_calibrator, context_calibrators=context_calibrators)
-        if self.encoding == "MIL-1750A":
+        if self.encoding == "MILSTD_1750A":
             def _mil_parse_func(mil_bytes: bytes):
                 """Parsing function for MIL-1750A floats"""
                 # MIL 1750A floats are always 32 bit
@@ -716,7 +716,7 @@ class FloatDataEncoding(NumericDataEncoding):
         : cls
         """
         size_in_bits = int(element.attrib['sizeInBits'])
-        encoding = element.get("encoding", "IEEE-754")
+        encoding = element.get("encoding", "IEEE754")
         byte_order = element.get("byteOrder", "mostSignificantByteFirst")
         default_calibrator = cls.get_default_calibrator(element, ns)
         context_calibrators = cls.get_context_calibrators(element, ns)

--- a/space_packet_parser/encodings.py
+++ b/space_packet_parser/encodings.py
@@ -1,7 +1,8 @@
 """DataEncoding definitions"""
 # Standard
-import logging
 import struct
+import logging
+import warnings
 from abc import ABCMeta, abstractmethod
 from typing import Optional, Union
 
@@ -604,7 +605,7 @@ class IntegerDataEncoding(NumericDataEncoding):
 class FloatDataEncoding(NumericDataEncoding):
     """<xtce:FloatDataEncoding>"""
     _allowed_encodings = ['IEEE754_1985', 'IEEE754', 'MILSTD_1750A', 'DEC', 'IBM', 'TI']
-    _supported_encodings = _allowed_encodings[:3] # this should be expanded if/when support for other float types is added
+    _supported_encodings = _allowed_encodings[:3] # expand this if/when support for other float types is added
     _data_return_class = packets.FloatParameter
 
     def __init__(
@@ -633,6 +634,14 @@ class FloatDataEncoding(NumericDataEncoding):
             List of ContextCalibrator objects, containing match criteria and corresponding calibrators to use in
             various scenarios, based on other parameters.
         """
+        if encoding == "IEEE-754":
+            warnings.warn("Float encoding 'IEEE-754' (with a dash) is not supported by the XTCE spec; "
+                          "use 'IEEE754' instead")
+            encoding = "IEEE754"
+        elif encoding == "MIL-1750A":
+            warnings.warn("Float encoding 'MIL-1750A' is not supported by the XTCE spec; use "
+                          "'MILSTD_1750A' instead")
+            encoding = "MILSTD_1750A"
         if encoding not in self._allowed_encodings:
             raise ValueError(f"Invalid encoding type {encoding} for float data. "
                              f"Must be one of {self._allowed_encodings}.")

--- a/space_packet_parser/encodings.py
+++ b/space_packet_parser/encodings.py
@@ -603,7 +603,8 @@ class IntegerDataEncoding(NumericDataEncoding):
 
 class FloatDataEncoding(NumericDataEncoding):
     """<xtce:FloatDataEncoding>"""
-    _supported_encodings = ['IEEE754_1985', 'IEEE754', 'MILSTD_1750A']
+    _allowed_encodings = ['IEEE754_1985', 'IEEE754', 'MILSTD_1750A', 'DEC', 'IBM', 'TI']
+    _supported_encodings = _allowed_encodings[:3] # this should be expanded if/when support for other float types is added
     _data_return_class = packets.FloatParameter
 
     def __init__(
@@ -632,9 +633,12 @@ class FloatDataEncoding(NumericDataEncoding):
             List of ContextCalibrator objects, containing match criteria and corresponding calibrators to use in
             various scenarios, based on other parameters.
         """
-        if encoding not in self._supported_encodings:
+        if encoding not in self._allowed_encodings:
             raise ValueError(f"Invalid encoding type {encoding} for float data. "
-                             f"Must be one of {self._supported_encodings}.")
+                             f"Must be one of {self._allowed_encodings}.")
+        if encoding not in self._supported_encodings:
+            raise NotImplementedError(f"Although the XTCE spec allows {encoding}-encoded floats, "
+                                      "parsing them is not currently supported.")
         if encoding == 'MILSTD_1750A' and size_in_bits != 32:
             raise ValueError("MIL-1750A encoded floats must be 32 bits, per the MIL-1750A spec. See "
                              "https://www.xgc-tek.com/manuals/mil-std-1750a/c191.html#AEN324")

--- a/tests/test_data/ctim/ctim_xtce_v1.xml
+++ b/tests/test_data/ctim/ctim_xtce_v1.xml
@@ -48,8 +48,8 @@
             <xtce:IntegerParameterType name="D32Type" sizeInBits="32" signed="false">
                 <xtce:IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
             </xtce:IntegerParameterType>
-            <xtce:FloatParameterType name="F32Type" sizeInBits="32" encoding="IEEE-754">
-                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE-754"/>
+            <xtce:FloatParameterType name="F32Type" sizeInBits="32" encoding="IEEE754">
+                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
             </xtce:FloatParameterType>
             <xtce:IntegerParameterType name="I16Type" sizeInBits="16" signed="true">
                 <xtce:IntegerDataEncoding sizeInBits="16" encoding="signed"/>

--- a/tests/test_data/jpss/contrived_inheritance_structure.xml
+++ b/tests/test_data/jpss/contrived_inheritance_structure.xml
@@ -75,17 +75,17 @@
                 <xtce:UnitSet>
                     <xtce:Unit>m</xtce:Unit>
                 </xtce:UnitSet>
-                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE-754"/>
+                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
             </xtce:FloatParameterType>
             <xtce:FloatParameterType name="ADGPSVEL_Type">
                 <xtce:UnitSet>
                     <xtce:Unit>m/s</xtce:Unit>
                 </xtce:UnitSet>
-                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE-754"/>
+                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
             </xtce:FloatParameterType>
             <xtce:FloatParameterType name="ADCFAQ_Type">
                 <xtce:UnitSet/>
-                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE-754"/>
+                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
             </xtce:FloatParameterType>
         </xtce:ParameterTypeSet>
         <xtce:ParameterSet>

--- a/tests/test_data/jpss/jpss1_geolocation_xtce_v1.xml
+++ b/tests/test_data/jpss/jpss1_geolocation_xtce_v1.xml
@@ -75,17 +75,17 @@
                 <xtce:UnitSet>
                     <xtce:Unit>m</xtce:Unit>
                 </xtce:UnitSet>
-                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE-754"/>
+                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
             </xtce:FloatParameterType>
             <xtce:FloatParameterType name="ADGPSVEL_Type">
                 <xtce:UnitSet>
                     <xtce:Unit>m/s</xtce:Unit>
                 </xtce:UnitSet>
-                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE-754"/>
+                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
             </xtce:FloatParameterType>
             <xtce:FloatParameterType name="ADCFAQ_Type">
                 <xtce:UnitSet/>
-                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE-754"/>
+                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
             </xtce:FloatParameterType>
         </xtce:ParameterTypeSet>
         <xtce:ParameterSet>

--- a/tests/test_data/test_xtce.xml
+++ b/tests/test_data/test_xtce.xml
@@ -77,17 +77,17 @@
                 <xtce:UnitSet>
                     <xtce:Unit>m</xtce:Unit>
                 </xtce:UnitSet>
-                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE-754"/>
+                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
             </xtce:FloatParameterType>
             <xtce:FloatParameterType name="ADGPSVEL_Type">
                 <xtce:UnitSet>
                     <xtce:Unit>m/s</xtce:Unit>
                 </xtce:UnitSet>
-                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE-754"/>
+                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
             </xtce:FloatParameterType>
             <xtce:FloatParameterType name="ADCFAQ_Type">
                 <xtce:UnitSet/>
-                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE-754"/>
+                <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
             </xtce:FloatParameterType>
         </xtce:ParameterTypeSet>
         <xtce:ParameterSet>

--- a/tests/unit/test_xtcedef.py
+++ b/tests/unit/test_xtcedef.py
@@ -968,7 +968,7 @@ def test_integer_data_encoding(xml_string: str, expectation):
     ('xml_string', 'expectation'),
     [
         ("""
-<xtce:FloatDataEncoding xmlns:xtce="http://www.omg.org/space/xtce" sizeInBits="4" encoding="IEEE-754"/>
+<xtce:FloatDataEncoding xmlns:xtce="http://www.omg.org/space/xtce" sizeInBits="4" encoding="IEEE754"/>
 """,
          ValueError()),
         ("""
@@ -982,7 +982,7 @@ def test_integer_data_encoding(xml_string: str, expectation):
 </xtce:FloatDataEncoding>
 """,
          encodings.FloatDataEncoding(
-             size_in_bits=16, encoding='IEEE-754',
+             size_in_bits=16, encoding='IEEE754',
              default_calibrator=calibrators.PolynomialCalibrator([
                  calibrators.PolynomialCoefficient(0.012155, 1), calibrators.PolynomialCoefficient(2.54, 0)
              ]))),
@@ -1027,7 +1027,7 @@ def test_integer_data_encoding(xml_string: str, expectation):
 </xtce:FloatDataEncoding>
 """,
          encodings.FloatDataEncoding(
-             size_in_bits=16, encoding='IEEE-754',
+             size_in_bits=16, encoding='IEEE754',
              default_calibrator=calibrators.PolynomialCalibrator([
                  calibrators.PolynomialCoefficient(0.012155, 1), calibrators.PolynomialCoefficient(2.54, 0)
              ]),
@@ -1523,7 +1523,7 @@ def test_integer_parameter_parsing(parameter_type, raw_data, current_pos, expect
 </xtce:FloatParameterType>
 """,
          parameters.FloatParameterType(name='TEST_INT_Type', unit='smoot',
-                                       encoding=encodings.FloatDataEncoding(size_in_bits=16, encoding='IEEE-754'))),
+                                       encoding=encodings.FloatDataEncoding(size_in_bits=16, encoding='IEEE754'))),
         ("""
 <xtce:FloatParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_INT_Type">
     <xtce:UnitSet>
@@ -1636,63 +1636,63 @@ def test_float_parameter_type(xml_string: str, expectation):
         # Test values taken from: https://www.xgc-tek.com/manuals/mil-std-1750a/c191.html#AEN324
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
-            encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
+            encodings.FloatDataEncoding(32, encoding="MILSTD_1750A")),
          b'\x7f\xff\xff\x7f',
          0.9999998 * (2 ** 127)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
-            encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
+            encodings.FloatDataEncoding(32, encoding="MILSTD_1750A")),
          b'\x40\x00\x00\x7f',
          0.5 * (2 ** 127)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
-            encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
+            encodings.FloatDataEncoding(32, encoding="MILSTD_1750A")),
          b'\x50\x00\x00\x04',
          0.625 * (2 ** 4)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
-            encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
+            encodings.FloatDataEncoding(32, encoding="MILSTD_1750A")),
          b'\x40\x00\x00\x01',
          0.5 * (2 ** 1)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
-            encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
+            encodings.FloatDataEncoding(32, encoding="MILSTD_1750A")),
          b'\x40\x00\x00\x00',
          0.5 * (2 ** 0)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
-            encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
+            encodings.FloatDataEncoding(32, encoding="MILSTD_1750A")),
          b'\x40\x00\x00\xff',
          0.5 * (2 ** -1)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
-            encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
+            encodings.FloatDataEncoding(32, encoding="MILSTD_1750A")),
          b'\x40\x00\x00\x80',
          0.5 * (2 ** -128)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
-            encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
+            encodings.FloatDataEncoding(32, encoding="MILSTD_1750A")),
          b'\x00\x00\x00\x00',
          0.0 * (2 ** 0)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
-            encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
+            encodings.FloatDataEncoding(32, encoding="MILSTD_1750A")),
          b'\x80\x00\x00\x00',
          -1.0 * (2 ** 0)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
-            encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
+            encodings.FloatDataEncoding(32, encoding="MILSTD_1750A")),
          b'\xBF\xFF\xFF\x80',
          -0.5000001 * (2 ** -128)),
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
-            encodings.FloatDataEncoding(32, encoding="MIL-1750A")),
+            encodings.FloatDataEncoding(32, encoding="MILSTD_1750A")),
          b'\x9F\xFF\xFF\x04',
          -0.7500001 * (2 ** 4)),
         # Little endian version of previous test
         (parameters.FloatParameterType(
             'MIL_1750A_FLOAT',
-            encodings.FloatDataEncoding(32, encoding="MIL-1750A", byte_order="leastSignificantByteFirst")),
+            encodings.FloatDataEncoding(32, encoding="MILSTD_1750A", byte_order="leastSignificantByteFirst")),
          b'\x04\xFF\xFF\x9F',
          -0.7500001 * (2 ** 4)),
     ]
@@ -1730,7 +1730,7 @@ def test_float_parameter_parsing(parameter_type, raw_data, expected):
         ("""
 <xtce:EnumeratedParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_ENUM_Type">
     <xtce:UnitSet/>
-    <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE-754"/>
+    <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
     <xtce:EnumerationList>
         <xtce:Enumeration label="BOOT_POR" value="0.0"/>
         <xtce:Enumeration label="BOOT_RETURN" value="1.1"/>
@@ -1741,7 +1741,7 @@ def test_float_parameter_parsing(parameter_type, raw_data, expected):
 </xtce:EnumeratedParameterType>
 """,
          parameters.EnumeratedParameterType(name='TEST_ENUM_Type',
-                                            encoding=encodings.FloatDataEncoding(size_in_bits=32, encoding='IEEE-754'),
+                                            encoding=encodings.FloatDataEncoding(size_in_bits=32, encoding='IEEE754'),
                                             # NOTE: Duplicate final value is on purpose to make sure we handle that case
                                             enumeration={0.0: 'BOOT_POR', 1.1: 'BOOT_RETURN', 2.2: 'OP_LOW', 3.3: 'OP_HIGH',
                                                          4.4: 'OP_HIGH'})),
@@ -1823,7 +1823,7 @@ def test_enumerated_parameter_type(xml_string: str, expectation):
         (parameters.EnumeratedParameterType(name='TEST_FLOAT_ENUM',
                                             encoding=encodings.FloatDataEncoding(
                                                 size_in_bits=32,
-                                                encoding='IEEE-754',
+                                                encoding='IEEE754',
                                                 byte_order="mostSignificantByteFirst"),
                                             # NOTE: Duplicate final value is on purpose to make sure we handle that case
                                             enumeration={0.0: 'BOOT_POR', 3.5: 'BOOT_RETURN', 2.2: 'OP_LOW',
@@ -2160,7 +2160,7 @@ def test_boolean_parameter_parsing(parameter_type, raw_data, current_pos, expect
          parameters.AbsoluteTimeParameterType(
              name='TEST_PARAM_Type', unit='s',
              encoding=encodings.FloatDataEncoding(
-                 size_in_bits=32, encoding="IEEE-754",
+                 size_in_bits=32, encoding="IEEE754",
                  default_calibrator=calibrators.PolynomialCalibrator(
                      coefficients=[
                          calibrators.PolynomialCoefficient(147.884, 0),
@@ -2209,7 +2209,7 @@ def test_absolute_time_parameter_type(xml_string, expectation):
         (parameters.AbsoluteTimeParameterType(
             name='TEST_PARAM_Type', unit='s',
             encoding=encodings.FloatDataEncoding(
-                size_in_bits=32, encoding="IEEE-754",
+                size_in_bits=32, encoding="IEEE754",
                 default_calibrator=calibrators.PolynomialCalibrator(
                     coefficients=[
                         calibrators.PolynomialCoefficient(147.884, 0),


### PR DESCRIPTION
## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [ ] Deprecated/superseded code is removed or marked with deprecation warning
  - N/A
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated

This PR resolves the issue I raised in my comment [here](https://github.com/medley56/space_packet_parser/pull/68#discussion_r1942092917).
