### PR TITLE
CI: Add id-token write permissions for codecov OIDC

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -14,6 +14,9 @@ jobs:
 
   ci-tests:
     runs-on: ${{ matrix.os }}
+    permissions:
+      # For codecov OIDC verifications
+      id-token: write
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]


### PR DESCRIPTION
Trying to see if this passes the proper url/handshake to codecov's OIDC.