### PR TITLE
Ensure uniqueness of parsed SequenceContainer objects

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -35,6 +35,8 @@ Release notes for the `space_packet_parser` library
   e.g. `space_packet_parser.xarr.create_dataset([packets1, packets2, ...], definition)`
 - BUGFIX: update list of allowed float encodings to match XTCE spec
 - Add benchmark tests and documentation overview of benchmarks.
+- Add checking to ensure that every object in the `XtcePacketDefinition` attributes `containers`, `parameters`, and
+  `parameter_types` is also referenced in the nested objects in `containers`
 
 ### v5.0.1 (released)
 - BUGFIX: Allow raw_value representation for enums with falsy raw values. Previously these defaulted to the enum label.

--- a/space_packet_parser/cli.py
+++ b/space_packet_parser/cli.py
@@ -80,11 +80,11 @@ def describe_xtce(
 
     # Recursively add nodes based on the inheritors of each container
     def add_nodes(tree_node, parent_key):
-        children = definition._sequence_container_cache[parent_key].inheritors
+        children = definition.containers[parent_key].inheritors
         for child_key in children:
             # Create a new child node (name + comparisons used to distinguish between containers)
             child_node = tree_node.add(
-                f"{child_key} {definition._sequence_container_cache[child_key].restriction_criteria}")
+                f"{child_key} {definition.containers[child_key].restriction_criteria}")
             # Recursively add any children of this child
             add_nodes(child_node, child_key)
 
@@ -92,16 +92,16 @@ def describe_xtce(
 
     console.print(Panel(tree, title="XTCE Container Layout", border_style="cyan", expand=False))
     if sequence_containers:
-        console.print(Panel(pretty.Pretty(definition._sequence_container_cache),
-                            title=f"Sequence Containers ({len(definition._sequence_container_cache)})",
+        console.print(Panel(pretty.Pretty(definition.containers),
+                            title=f"Sequence Containers ({len(definition.containers)})",
                             border_style="blue", expand=False))
     if parameters:
-        console.print(Panel(pretty.Pretty(definition._parameter_cache),
-                            title=f"Parameters ({len(definition._parameter_cache)})",
+        console.print(Panel(pretty.Pretty(definition.parameters),
+                            title=f"Parameters ({len(definition.parameters)})",
                             border_style="green", expand=False))
     if parameter_types:
-        console.print(Panel(pretty.Pretty(definition._parameter_type_cache),
-                            title=f"Parameter Types ({len(definition._parameter_type_cache)})",
+        console.print(Panel(pretty.Pretty(definition.parameter_types),
+                            title=f"Parameter Types ({len(definition.parameter_types)})",
                             border_style="magenta", expand=False))
 
 

--- a/space_packet_parser/common.py
+++ b/space_packet_parser/common.py
@@ -42,6 +42,7 @@ class XmlObject(metaclass=ABCMeta):
             tree: Optional[ElementTree.ElementTree],
             parameter_lookup: Optional[dict[str, any]],
             parameter_type_lookup: Optional[dict[str, any]],
+            container_lookup: Optional[dict[str, any]],
     ) -> 'XmlObject':
         """Create an object from an XML element
 
@@ -63,6 +64,8 @@ class XmlObject(metaclass=ABCMeta):
             Parameters dict for parsing that requires knowledge of existing parameters
         parameter_type_lookup: Optional[dict[str, parameters.ParameterType]]
             Parameter type dict for parsing that requires knowledge of existing parameter types
+        container_lookup: Optional[dict[str, parameters.ContainerType]]
+            Container type dict for parsing that requires knowledge of existing containers
 
         Returns
         -------

--- a/space_packet_parser/xtce/calibrators.py
+++ b/space_packet_parser/xtce/calibrators.py
@@ -22,7 +22,8 @@ class Calibrator(common.AttrComparable, common.XmlObject, metaclass=ABCMeta):
             ns: dict,
             tree: Optional[ElementTree.Element] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
-            parameter_type_lookup: Optional[dict[str, any]] = None
+            parameter_type_lookup: Optional[dict[str, any]] = None,
+            container_lookup: Optional[dict[str, any]] = None,
     ) -> 'Calibrator':
         """Abstract classmethod to create a default_calibrator object from an XML element.
 
@@ -37,6 +38,8 @@ class Calibrator(common.AttrComparable, common.XmlObject, metaclass=ABCMeta):
         parameter_lookup: Optional[dict]
             Ignored
         parameter_type_lookup: Optional[dict]
+            Ignored
+        container_lookup: Optional[dict[str, SequenceContainer]]
             Ignored
 
         Returns
@@ -97,7 +100,8 @@ class SplineCalibrator(Calibrator):
             ns: dict,
             tree: Optional[ElementTree.Element] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
-            parameter_type_lookup: Optional[dict[str, any]] = None
+            parameter_type_lookup: Optional[dict[str, any]] = None,
+            container_lookup: Optional[dict[str, any]] = None
     ) -> 'SplineCalibrator':
         """Create a spline default_calibrator object from an <xtce:SplineCalibrator> XML element.
 
@@ -112,6 +116,8 @@ class SplineCalibrator(Calibrator):
         parameter_lookup: Optional[dict]
             Ignored
         parameter_type_lookup: Optional[dict]
+            Ignored
+        container_lookup: Optional[dict[str, SequenceContainer]]
             Ignored
 
         Returns
@@ -264,7 +270,8 @@ class PolynomialCalibrator(Calibrator):
             ns: dict,
             tree: Optional[ElementTree.Element] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
-            parameter_type_lookup: Optional[dict[str, any]] = None
+            parameter_type_lookup: Optional[dict[str, any]] = None,
+            container_lookup: Optional[dict[str, any]] = None
     ) -> 'PolynomialCalibrator':
         """Create a polynomial default_calibrator object from an <xtce:PolynomialCalibrator> XML element.
 
@@ -279,6 +286,8 @@ class PolynomialCalibrator(Calibrator):
         parameter_lookup: Optional[dict]
             Ignored
         parameter_type_lookup: Optional[dict]
+            Ignored
+        container_lookup: Optional[dict[str, SequenceContainer]]
             Ignored
 
         Returns
@@ -344,7 +353,8 @@ class MathOperationCalibrator(Calibrator):
             ns: dict,
             tree: Optional[ElementTree.Element] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
-            parameter_type_lookup: Optional[dict[str, any]] = None
+            parameter_type_lookup: Optional[dict[str, any]] = None,
+            container_lookup: Optional[dict[str, any]] = None
     ) -> 'MathOperationCalibrator':
         """Create a math operation default_calibrator from an <xtce:MathOperationCalibrator> XML element.
 
@@ -359,6 +369,8 @@ class MathOperationCalibrator(Calibrator):
         parameter_lookup: Optional[dict]
             Ignored
         parameter_type_lookup: Optional[dict]
+            Ignored
+        container_lookup: Optional[dict[str, SequenceContainer]]
             Ignored
 
         Returns
@@ -451,7 +463,8 @@ class ContextCalibrator(common.AttrComparable, common.XmlObject):
             ns: dict,
             tree: Optional[ElementTree.Element] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
-            parameter_type_lookup: Optional[dict[str, any]] = None
+            parameter_type_lookup: Optional[dict[str, any]] = None,
+            container_lookup: Optional[dict[str, any]] = None
     ) -> 'ContextCalibrator':
         """Create a ContextCalibrator object from an <xtce:ContextCalibrator> XML element
 
@@ -466,6 +479,8 @@ class ContextCalibrator(common.AttrComparable, common.XmlObject):
         parameter_lookup: Optional[dict]
             Ignored
         parameter_type_lookup: Optional[dict]
+            Ignored
+        container_lookup: Optional[dict[str, SequenceContainer]]
             Ignored
 
         Returns

--- a/space_packet_parser/xtce/comparisons.py
+++ b/space_packet_parser/xtce/comparisons.py
@@ -100,7 +100,8 @@ class Comparison(MatchCriteria):
             ns: dict,
             tree: Optional[ElementTree.Element] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
-            parameter_type_lookup: Optional[dict[str, any]] = None
+            parameter_type_lookup: Optional[dict[str, any]] = None,
+            container_lookup: Optional[dict[str, any]] = None
     ) -> 'Comparison':
         """Create
 
@@ -115,6 +116,8 @@ class Comparison(MatchCriteria):
         parameter_lookup: Optional[dict]
             Ignored
         parameter_type_lookup: Optional[dict]
+            Ignored
+        container_lookup: Optional[dict[str, SequenceContainer]]
             Ignored
 
         Returns
@@ -296,7 +299,8 @@ class Condition(MatchCriteria):
             ns: dict,
             tree: Optional[ElementTree.Element] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
-            parameter_type_lookup: Optional[dict[str, any]] = None
+            parameter_type_lookup: Optional[dict[str, any]] = None,
+            container_lookup: Optional[dict[str, any]] = None
     ) -> 'Condition':
         """Classmethod to create a Condition object from an XML element.
 
@@ -311,6 +315,8 @@ class Condition(MatchCriteria):
         parameter_lookup: Optional[dict]
             Ignored
         parameter_type_lookup: Optional[dict]
+            Ignored
+        container_lookup: Optional[dict[str, SequenceContainer]]
             Ignored
 
         Returns
@@ -451,7 +457,8 @@ class BooleanExpression(MatchCriteria):
             ns: dict,
             tree: Optional[ElementTree.Element] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
-            parameter_type_lookup: Optional[dict[str, any]] = None
+            parameter_type_lookup: Optional[dict[str, any]] = None,
+            container_lookup: Optional[dict[str, any]] = None
     ) -> 'BooleanExpression':
         """Abstract classmethod to create a match criteria object from an XML element.
 
@@ -466,6 +473,8 @@ class BooleanExpression(MatchCriteria):
         parameter_lookup: Optional[dict]
             Ignored
         parameter_type_lookup: Optional[dict]
+            Ignored
+        container_lookup: Optional[dict[str, SequenceContainer]]
             Ignored
 
         Returns
@@ -621,6 +630,7 @@ class DiscreteLookup(common.AttrComparable, common.XmlObject):
             tree: Optional[ElementTree.ElementTree] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
             parameter_type_lookup: Optional[dict[str, any]] = None,
+            container_lookup: Optional[dict[str, any]] = None
     ) -> 'DiscreteLookup':
         """Create a DiscreteLookup object from an <xtce:DiscreteLookup> XML element
 
@@ -635,6 +645,8 @@ class DiscreteLookup(common.AttrComparable, common.XmlObject):
         parameter_lookup: Optional[dict]
             Ignored
         parameter_type_lookup: Optional[dict]
+            Ignored
+        container_lookup: Optional[dict[str, SequenceContainer]]
             Ignored
 
         Returns

--- a/space_packet_parser/xtce/encodings.py
+++ b/space_packet_parser/xtce/encodings.py
@@ -360,7 +360,8 @@ class StringDataEncoding(DataEncoding):
             ns: dict,
             tree: Optional[ElementTree.Element] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
-            parameter_type_lookup: Optional[dict[str, any]] = None
+            parameter_type_lookup: Optional[dict[str, any]] = None,
+            container_lookup: Optional[dict[str, any]] = None
     ) -> 'StringDataEncoding':
         """Create a data encoding object from an <xtce:StringDataEncoding> XML element.
 
@@ -392,6 +393,8 @@ class StringDataEncoding(DataEncoding):
         parameter_lookup: Optional[dict]
             Ignored
         parameter_type_lookup: Optional[dict]
+            Ignored
+        container_lookup: Optional[dict[str, SequenceContainer]]
             Ignored
 
         Returns
@@ -682,7 +685,8 @@ class IntegerDataEncoding(NumericDataEncoding):
             ns: dict,
             tree: Optional[ElementTree.Element] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
-            parameter_type_lookup: Optional[dict[str, any]] = None
+            parameter_type_lookup: Optional[dict[str, any]] = None,
+            container_lookup: Optional[dict[str, any]] = None
     ) -> 'IntegerDataEncoding':
         """Create a data encoding object from an <xtce:IntegerDataEncoding> XML element.
 
@@ -697,6 +701,8 @@ class IntegerDataEncoding(NumericDataEncoding):
         parameter_lookup: Optional[dict]
             Ignored
         parameter_type_lookup: Optional[dict]
+            Ignored
+        container_lookup: Optional[dict[str, SequenceContainer]]
             Ignored
 
         Returns
@@ -831,7 +837,8 @@ class FloatDataEncoding(NumericDataEncoding):
             ns: dict,
             tree: Optional[ElementTree.Element] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
-            parameter_type_lookup: Optional[dict[str, any]] = None
+            parameter_type_lookup: Optional[dict[str, any]] = None,
+            container_lookup: Optional[dict[str, any]] = None
     ) -> 'FloatDataEncoding':
         """Create a data encoding object from an <xtce:FloatDataEncoding> XML element.
 
@@ -846,6 +853,8 @@ class FloatDataEncoding(NumericDataEncoding):
         parameter_lookup: Optional[dict]
             Ignored
         parameter_type_lookup: Optional[dict]
+            Ignored
+        container_lookup: Optional[dict[str, SequenceContainer]]
             Ignored
 
         Returns
@@ -954,7 +963,8 @@ class BinaryDataEncoding(DataEncoding):
             ns: dict,
             tree: Optional[ElementTree.Element] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
-            parameter_type_lookup: Optional[dict[str, any]] = None
+            parameter_type_lookup: Optional[dict[str, any]] = None,
+            container_lookup: Optional[dict[str, any]] = None
     ) -> 'BinaryDataEncoding':
         """Create a data encoding object from an <xtce:BinaryDataEncoding> XML element.
 
@@ -969,6 +979,8 @@ class BinaryDataEncoding(DataEncoding):
         parameter_lookup: Optional[dict]
             Ignored
         parameter_type_lookup: Optional[dict]
+            Ignored
+        container_lookup: Optional[dict[str, SequenceContainer]]
             Ignored
 
         Returns

--- a/space_packet_parser/xtce/parameter_types.py
+++ b/space_packet_parser/xtce/parameter_types.py
@@ -47,6 +47,7 @@ class ParameterType(common.AttrComparable, common.XmlObject, metaclass=ABCMeta):
             tree: Optional[ElementTree.Element] = None,
             parameter_lookup: Optional[dict] = None,
             parameter_type_lookup: Optional[dict] = None,
+            container_lookup: Optional[dict[str, any]] = None
     ) -> 'ParameterType':
         """Create a *ParameterType* from an <xtce:ParameterType> XML element.
 
@@ -61,6 +62,8 @@ class ParameterType(common.AttrComparable, common.XmlObject, metaclass=ABCMeta):
         parameter_lookup: Optional[dict]
             Ignored
         parameter_type_lookup: Optional[dict]
+            Ignored
+        container_lookup : Optional[dict[str, any]]
             Ignored
 
         Returns
@@ -238,7 +241,8 @@ class EnumeratedParameterType(ParameterType):
             ns: dict,
             tree: Optional[ElementTree.Element] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
-            parameter_type_lookup: Optional[dict[str, any]] = None
+            parameter_type_lookup: Optional[dict[str, any]] = None,
+            container_lookup: Optional[dict[str, any]] = None
     ) -> 'EnumeratedParameterType':
         """Create an EnumeratedParameterType from an <xtce:EnumeratedParameterType> XML element.
         Overrides ParameterType.from_parameter_type_xml_element
@@ -254,6 +258,8 @@ class EnumeratedParameterType(ParameterType):
         parameter_lookup: Optional[dict]
             Ignored
         parameter_type_lookup: Optional[dict]
+            Ignored
+        container_lookup: Optional[dict[str, any]]
             Ignored
 
         Returns
@@ -487,7 +493,8 @@ class TimeParameterType(ParameterType, metaclass=ABCMeta):
             ns: dict,
             tree: Optional[ElementTree.ElementTree] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
-            parameter_type_lookup: Optional[dict[str, any]] = None
+            parameter_type_lookup: Optional[dict[str, any]] = None,
+            container_lookup: Optional[dict[str, any]] = None
     ) -> ElementTree.Element:
         """Create a *TimeParameterType* from an <xtce:TimeParameterType> XML element.
 
@@ -503,6 +510,7 @@ class TimeParameterType(ParameterType, metaclass=ABCMeta):
             Ignored
         parameter_type_lookup: Optional[dict]
             Ignored
+        container_lookup: Optional[dict[str, any]]
 
         Returns
         -------

--- a/space_packet_parser/xtce/parameters.py
+++ b/space_packet_parser/xtce/parameters.py
@@ -45,6 +45,7 @@ class Parameter(common.Parseable, common.XmlObject):
             parameter_type_lookup: dict[str, parameter_types.ParameterType],
             tree: Optional[ElementTree.ElementTree] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
+            container_lookup: Optional[dict[str, any]] = None
     ) -> 'Parameter':
         """Create a Parameter object from an XML element.
 
@@ -59,6 +60,8 @@ class Parameter(common.Parseable, common.XmlObject):
         parameter_lookup: Optional[dict]
             Ignored
         parameter_type_lookup: dict[str, ParameterType]
+            Ignored
+        container_lookup: Optional[dict[str, SequenceContainer]]
             Ignored
 
         Returns

--- a/tests/benchmark/test_xtce_parsing_benchmarks.py
+++ b/tests/benchmark/test_xtce_parsing_benchmarks.py
@@ -1,0 +1,17 @@
+"""Benchmark test for how fast we can parse a large XTCE definition file"""
+import pytest
+
+from space_packet_parser import definitions
+
+
+@pytest.mark.benchmark
+def test_benchmark_ctim_xtce_parsing(ctim_test_data_dir, benchmark):
+    """This XTCE file is quite large and at one point took several seconds to parse.
+
+    We've got that number to under .1s and aim to keep it that way
+    """
+    xtce_document = ctim_test_data_dir / "ctim_xtce_v1.xml"
+    packet_definition = benchmark(definitions.XtcePacketDefinition.from_xtce, xtce_document)
+    print("Number of containers:", len(packet_definition.containers))
+    print("Number of parameters:", len(packet_definition.parameters))
+    print("Number of parameter types:", len(packet_definition.parameter_types))

--- a/tests/integration/test_xtce_based_parsing/test_inheritance_restrictions.py
+++ b/tests/integration/test_xtce_based_parsing/test_inheritance_restrictions.py
@@ -1,6 +1,6 @@
 """Test RestrictionCriteria being used creatively with JPSS data"""
 from space_packet_parser import packets
-from space_packet_parser.xtce import definitions
+from space_packet_parser.xtce import definitions, containers
 
 
 def test_jpss_xtce_packet_parsing(jpss_test_data_dir):

--- a/tests/test_data/idex/idex_combined_science_definition.xml
+++ b/tests/test_data/idex/idex_combined_science_definition.xml
@@ -43,12 +43,6 @@
         </xtce:UnitSet>
         <xtce:IntegerDataEncoding encoding="unsigned" sizeInBits="16"/>
       </xtce:FloatParameterType>
-      <xtce:FloatParameterType name="CHECKSUM_Type">
-        <xtce:UnitSet>
-          <xtce:Unit>dn</xtce:Unit>
-        </xtce:UnitSet>
-        <xtce:IntegerDataEncoding encoding="unsigned" sizeInBits="32"/>
-      </xtce:FloatParameterType>
       <xtce:IntegerParameterType name="IDX__SCI0AID_Type">
         <xtce:UnitSet/>
         <xtce:IntegerDataEncoding encoding="unsigned" sizeInBits="32"/>
@@ -932,9 +926,6 @@
         <xtce:AliasSet>
           <xtce:Alias nameSpace="itemName" alias="SHFINE"/>
         </xtce:AliasSet>
-        <xtce:ParameterProperties dataSource="telemetered"/>
-      </xtce:Parameter>
-      <xtce:Parameter shortDescription="CRC 16 Checksum" name="CHECKSUM" parameterTypeRef="CHECKSUM_Type">
         <xtce:ParameterProperties dataSource="telemetered"/>
       </xtce:Parameter>
       <xtce:Parameter name="IDX__SCI0AID" parameterTypeRef="IDX__SCI0AID_Type" shortDescription="Accountability Identifier">

--- a/tests/test_data/jpss/contrived_inheritance_structure.xml
+++ b/tests/test_data/jpss/contrived_inheritance_structure.xml
@@ -210,6 +210,11 @@
                     </xtce:RestrictionCriteria>
                 </xtce:BaseContainer>
             </xtce:SequenceContainer>
+            <xtce:SequenceContainer name="UNUSED" shortDescription="This tests including the SecondaryHeaderContainer in multiple other entry lists">
+                <xtce:EntryList>
+                    <xtce:ContainerRefEntry containerRef="SecondaryHeaderContainer"/>
+                </xtce:EntryList>
+            </xtce:SequenceContainer>
         </xtce:ContainerSet>
     </xtce:TelemetryMetaData>
 </xtce:SpaceSystem>

--- a/tests/test_data/suda/suda_combined_science_definition.xml
+++ b/tests/test_data/suda/suda_combined_science_definition.xml
@@ -43,12 +43,6 @@
         </xtce:UnitSet>
         <xtce:IntegerDataEncoding encoding="unsigned" sizeInBits="16"/>
       </xtce:FloatParameterType>
-      <xtce:FloatParameterType name="CHECKSUM_Type">
-        <xtce:UnitSet>
-          <xtce:Unit>dn</xtce:Unit>
-        </xtce:UnitSet>
-        <xtce:IntegerDataEncoding encoding="unsigned" sizeInBits="32"/>
-      </xtce:FloatParameterType>
       <xtce:IntegerParameterType name="IDX__SCI0AID_Type">
         <xtce:UnitSet/>
         <xtce:IntegerDataEncoding encoding="unsigned" sizeInBits="32"/>
@@ -932,9 +926,6 @@
         <xtce:AliasSet>
           <xtce:Alias nameSpace="itemName" alias="SHFINE"/>
         </xtce:AliasSet>
-        <xtce:ParameterProperties dataSource="telemetered"/>
-      </xtce:Parameter>
-      <xtce:Parameter shortDescription="CRC 16 Checksum" name="CHECKSUM" parameterTypeRef="CHECKSUM_Type">
         <xtce:ParameterProperties dataSource="telemetered"/>
       </xtce:Parameter>
       <xtce:Parameter name="IDX__SCI0AID" parameterTypeRef="IDX__SCI0AID_Type" shortDescription="Accountability Identifier">


### PR DESCRIPTION
Modify the parsing of XTCE documents to ensure that SequenceContainer objects are kept unique and reused instead of parsed and stored multiple times.

This PR adds checks to the parsing of ParameterSet, ParemeterTypeSet, and ContainerSet to ensure that the objects we parse out of those elements are uniquely represented in the resulting definition object. We also issue warnings for parameters and parameter types that are defined but not used.

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
