### PR TITLE
MNT: Move parameter data types to common module

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -6,8 +6,11 @@ list and release milestones.
 Release notes for the `space_packet_parser` library
 
 ### v6.0.0 (unreleased)
-- BREAKING: `XtcePacketDefinition` no longer accepts a file object as input. 
+- *BREAKING*: `XtcePacketDefinition` no longer accepts a file object as input. 
   Use `spp.xtce.definitions.XtcePacketDefinition.from_document()` or `spp.load_xml()` instead.
+- *BREAKING*: Reorganization of the project into different submodules for more explicit handling
+  of imports. There is now an `space_packet_parser.xtce` module with xtce representations separated
+  into modules underneath that.
 - Add support for creating a packet definition from Python objects and serializing it as XML.
 - BUGFIX: Fix kbps calculation in packet generator for showing progress.
 - Add support for string and float encoded enumerated lookup parameters.

--- a/space_packet_parser/common.py
+++ b/space_packet_parser/common.py
@@ -1,7 +1,7 @@
 """Common mixins"""
 import inspect
 from abc import ABCMeta, abstractmethod
-from typing import Optional, Protocol
+from typing import Optional, Protocol, Union
 
 import lxml.etree as ElementTree
 from lxml.builder import ElementMaker
@@ -91,3 +91,55 @@ class Parseable(Protocol):
     """Defines an object that can be parsed from packet data."""
     def parse(self, packet: packets.CCSDSPacket) -> None:
         """Parse this entry from the packet data and add the necessary items to the packet."""
+
+
+
+BuiltinDataTypes = Union[bytes, float, int, str]
+
+class _Parameter:
+    """Mixin class for storing access to the raw value of a parsed data item.
+
+    The raw value is the closest representation of the data item as it appears in the packet.
+    e.g. bytes for binary data, int for integer data, etc. It has not been calibrated or
+    adjusted in any way and is an easy way for user's to debug the transformations that
+    happened after the fact.
+
+    Notes
+    -----
+    We need to override the __new__ method to store the raw value of the data item
+    on immutable built-in types. So this is just a way of allowing us to inject our
+    own attribute into the built-in types.
+    """
+    def __new__(cls, value: BuiltinDataTypes, raw_value: BuiltinDataTypes = None) -> BuiltinDataTypes:
+        obj = super().__new__(cls, value)
+        # Default to the same value as the parsed value if it isn't provided
+        obj.raw_value = raw_value if raw_value is not None else value
+        return obj
+
+
+class BinaryParameter(_Parameter, bytes):
+    """A class to represent a binary data item."""
+
+
+class BoolParameter(_Parameter, int):
+    """A class to represent a parsed boolean data item."""
+    # A bool is a subclass of int, so all we are really doing here
+    # is making a nice representation using the bool type because
+    # bool can't be subclassed directly.
+    def __repr__(self) -> str:
+        return bool.__repr__(bool(self))
+
+
+class FloatParameter(_Parameter, float):
+    """A class to represent a float data item."""
+
+
+class IntParameter(_Parameter, int):
+    """A class to represent a integer data item."""
+
+
+class StrParameter(_Parameter, str):
+    """A class to represent a string data item."""
+
+
+ParameterDataTypes = Union[BinaryParameter, BoolParameter, FloatParameter, IntParameter, StrParameter]

--- a/space_packet_parser/packets.py
+++ b/space_packet_parser/packets.py
@@ -17,57 +17,7 @@ from enum import IntEnum
 from functools import cached_property
 from typing import BinaryIO, Optional, Union
 
-BuiltinDataTypes = Union[bytes, float, int, str]
 logger = logging.getLogger(__name__)
-
-
-class _Parameter:
-    """Mixin class for storing access to the raw value of a parsed data item.
-
-    The raw value is the closest representation of the data item as it appears in the packet.
-    e.g. bytes for binary data, int for integer data, etc. It has not been calibrated or
-    adjusted in any way and is an easy way for user's to debug the transformations that
-    happened after the fact.
-
-    Notes
-    -----
-    We need to override the __new__ method to store the raw value of the data item
-    on immutable built-in types. So this is just a way of allowing us to inject our
-    own attribute into the built-in types.
-    """
-    def __new__(cls, value: BuiltinDataTypes, raw_value: BuiltinDataTypes = None) -> BuiltinDataTypes:
-        obj = super().__new__(cls, value)
-        # Default to the same value as the parsed value if it isn't provided
-        obj.raw_value = raw_value if raw_value is not None else value
-        return obj
-
-
-class BinaryParameter(_Parameter, bytes):
-    """A class to represent a binary data item."""
-
-
-class BoolParameter(_Parameter, int):
-    """A class to represent a parsed boolean data item."""
-    # A bool is a subclass of int, so all we are really doing here
-    # is making a nice representation using the bool type because
-    # bool can't be subclassed directly.
-    def __repr__(self) -> str:
-        return bool.__repr__(bool(self))
-
-
-class FloatParameter(_Parameter, float):
-    """A class to represent a float data item."""
-
-
-class IntParameter(_Parameter, int):
-    """A class to represent a integer data item."""
-
-
-class StrParameter(_Parameter, str):
-    """A class to represent a string data item."""
-
-
-ParameterDataTypes = Union[BinaryParameter, BoolParameter, FloatParameter, IntParameter, StrParameter]
 
 
 class SequenceFlags(IntEnum):

--- a/space_packet_parser/xtce/parameter_types.py
+++ b/space_packet_parser/xtce/parameter_types.py
@@ -158,7 +158,7 @@ class ParameterType(common.AttrComparable, common.XmlObject, metaclass=ABCMeta):
         raise ValueError(f"No Data Encoding element found for Parameter Type "
                          f"{parameter_type_element.tag}: {parameter_type_element.attrib}")
 
-    def parse_value(self, packet: packets.CCSDSPacket) -> packets.ParameterDataTypes:
+    def parse_value(self, packet: packets.CCSDSPacket) -> common.ParameterDataTypes:
         """Using the parameter type definition and associated data encoding, parse a value from a bit stream starting
         at the current cursor position.
 
@@ -170,7 +170,7 @@ class ParameterType(common.AttrComparable, common.XmlObject, metaclass=ABCMeta):
 
         Returns
         -------
-        parsed_value : packets.ParameterDataTypes
+        parsed_value : common.ParameterDataTypes
             Resulting parsed parameter value
         """
         return self.encoding.parse_value(packet)
@@ -352,7 +352,7 @@ class EnumeratedParameterType(ParameterType):
                          "Supported encodings for enums are FloatDataEncoding, IntegerDataEncoding, "
                          "and StringDataEncoding.")
 
-    def parse_value(self, packet: packets.CCSDSPacket) -> packets.StrParameter:
+    def parse_value(self, packet: packets.CCSDSPacket) -> common.StrParameter:
         """Using the parameter type definition and associated data encoding, parse a value from a bit stream starting
         at the current cursor position.
 
@@ -364,7 +364,7 @@ class EnumeratedParameterType(ParameterType):
 
         Returns
         -------
-        derived_value : packets.StrParameter
+        derived_value : common.StrParameter
             Resulting enum label associated with the (usually integer-)encoded data value.
         """
         raw_enum_value = super().parse_value(packet).raw_value
@@ -378,7 +378,7 @@ class EnumeratedParameterType(ParameterType):
         except KeyError as exc:
             raise ValueError(f"Failed to find the value {raw_enum_value} in "
                              f"enum lookup list {self.enumeration}.") from exc
-        return packets.StrParameter(label, raw_enum_value)
+        return common.StrParameter(label, raw_enum_value)
 
 
 class BinaryParameterType(ParameterType):
@@ -437,7 +437,7 @@ class BooleanParameterType(ParameterType):
         # binary encoded or string encoded data should be truthy/falsy.
         # This implementation defaults to Python's interpretation of True/False for the (raw) parsed value,
         # so non-empty byte strings (the representation for binary and string encoded data) will always be True.
-        return packets.BoolParameter(bool(parsed_value), parsed_value)
+        return common.BoolParameter(bool(parsed_value), parsed_value)
 
 
 class TimeParameterType(ParameterType, metaclass=ABCMeta):

--- a/tests/unit/test_xtce/test_calibrators.py
+++ b/tests/unit/test_xtce/test_calibrators.py
@@ -2,7 +2,7 @@
 import pytest
 import lxml.etree as ElementTree
 
-from space_packet_parser import packets
+from space_packet_parser import common
 from space_packet_parser.exceptions import CalibrationError
 from space_packet_parser.xtce import calibrators, comparisons, XTCE_NSMAP
 
@@ -143,7 +143,7 @@ def test_context_calibrator(elmaker, xml_string, expectation):
                 calibrators.PolynomialCoefficient(coefficient=0.5, exponent=0),
                 calibrators.PolynomialCoefficient(coefficient=1.5, exponent=1)
             ])),
-         {"EXI__FPGAT": packets.IntParameter(700, 600)},
+         {"EXI__FPGAT": common.IntParameter(700, 600)},
          42, True, 63.5),
         (calibrators.ContextCalibrator(
             match_criteria=[
@@ -154,7 +154,7 @@ def test_context_calibrator(elmaker, xml_string, expectation):
                 calibrators.PolynomialCoefficient(coefficient=0.5, exponent=0),
                 calibrators.PolynomialCoefficient(coefficient=1.5, exponent=1),
             ])),
-         {"EXI__FPGAT": packets.FloatParameter(700.0, 3.14)},
+         {"EXI__FPGAT": common.FloatParameter(700.0, 3.14)},
          42, True, 63.5),
         (calibrators.ContextCalibrator(
             match_criteria=[
@@ -174,8 +174,8 @@ def test_context_calibrator(elmaker, xml_string, expectation):
                 calibrators.PolynomialCoefficient(coefficient=0.5, exponent=0),
                 calibrators.PolynomialCoefficient(coefficient=1.5, exponent=1),
             ])),
-         {"P1": packets.FloatParameter(700.0, 100.0),
-          "P2": packets.FloatParameter(700.0, 99)},
+         {"P1": common.FloatParameter(700.0, 100.0),
+          "P2": common.FloatParameter(700.0, 99)},
          42, True, 63.5),
         (calibrators.ContextCalibrator(
             match_criteria=[
@@ -196,8 +196,8 @@ def test_context_calibrator(elmaker, xml_string, expectation):
                 calibrators.PolynomialCoefficient(coefficient=0.5, exponent=0),
                 calibrators.PolynomialCoefficient(coefficient=1.5, exponent=1),
             ])),
-         {"P1": packets.FloatParameter(700.0, 100.0),
-          "P2": packets.FloatParameter(700.0, 99)},
+         {"P1": common.FloatParameter(700.0, 100.0),
+          "P2": common.FloatParameter(700.0, 99)},
          42, False, 63.5),
     ]
 )

--- a/tests/unit/test_xtce/test_comparisons.py
+++ b/tests/unit/test_xtce/test_comparisons.py
@@ -2,7 +2,7 @@
 import pytest
 import lxml.etree as ElementTree
 
-from space_packet_parser import packets
+from space_packet_parser import common
 from space_packet_parser.exceptions import ComparisonError
 from space_packet_parser.xtce import comparisons, XTCE_NSMAP
 
@@ -14,82 +14,82 @@ from space_packet_parser.xtce import comparisons, XTCE_NSMAP
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="==" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.FloatParameter(678, 3)}, None, True),
+         {'MSN__PARAM': common.FloatParameter(678, 3)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="eq" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.FloatParameter(668, 3)}, None, False),
+         {'MSN__PARAM': common.FloatParameter(668, 3)}, None, False),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="!=" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.FloatParameter(678, 3)}, None, False),
+         {'MSN__PARAM': common.FloatParameter(678, 3)}, None, False),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="neq" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.FloatParameter(658, 3)}, None, True),
+         {'MSN__PARAM': common.FloatParameter(658, 3)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="&lt;" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.FloatParameter(679, 3)}, None, False),
+         {'MSN__PARAM': common.FloatParameter(679, 3)}, None, False),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="lt" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.FloatParameter(670, 3)}, None, True),
+         {'MSN__PARAM': common.FloatParameter(670, 3)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="&gt;" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.FloatParameter(678, 3)}, None, False),
+         {'MSN__PARAM': common.FloatParameter(678, 3)}, None, False),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="gt" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.FloatParameter(679, 3)}, None, True),
+         {'MSN__PARAM': common.FloatParameter(679, 3)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="&lt;=" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.FloatParameter(660, 3)}, None, True),
+         {'MSN__PARAM': common.FloatParameter(660, 3)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="leq" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.FloatParameter(690, 3)}, None, False),
+         {'MSN__PARAM': common.FloatParameter(690, 3)}, None, False),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="&gt;=" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.FloatParameter(660, 3)}, None, False),
+         {'MSN__PARAM': common.FloatParameter(660, 3)}, None, False),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="geq" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.FloatParameter(690, 3)}, None, True),
+         {'MSN__PARAM': common.FloatParameter(690, 3)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="==" value="678" parameterRef="MSN__PARAM" useCalibratedValue="false"/>
 """,
-         {'MSN__PARAM': packets.FloatParameter(690, 678)}, None, True),
+         {'MSN__PARAM': common.FloatParameter(690, 678)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="==" value="678" parameterRef="MSN__PARAM" useCalibratedValue="true"/>
 """,
-         {'MSN__PARAM': packets.FloatParameter(678, 3)}, None, True),
+         {'MSN__PARAM': common.FloatParameter(678, 3)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="==" value="foostring" parameterRef="MSN__PARAM" useCalibratedValue="false"/>
 """,
-         {'MSN__PARAM': packets.StrParameter('calibratedfoostring', 'foostring')}, None, True),
+         {'MSN__PARAM': common.StrParameter('calibratedfoostring', 'foostring')}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="==" value="3.14" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': packets.FloatParameter(3.14, 1)}, None, True),
+         {'MSN__PARAM': common.FloatParameter(3.14, 1)}, None, True),
         ("""
 <xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce" 
     comparisonOperator="==" value="3.0" parameterRef="REFERENCE_TO_OWN_RAW_VAL"/>
@@ -140,8 +140,8 @@ def test_comparison(elmaker, xml_string, test_parsed_data, current_parsed_value,
     <xtce:ParameterInstanceRef parameterRef="P2"/>
 </xtce:Condition>
 """,
-         {'P1': packets.IntParameter(700, 4),
-          'P2': packets.IntParameter(678, 3)}, True),
+         {'P1': common.IntParameter(700, 4),
+          'P2': common.IntParameter(678, 3)}, True),
         ("""
 <xtce:Condition xmlns:xtce="http://www.omg.org/space/xtce">
     <xtce:ParameterInstanceRef parameterRef="P1"/>
@@ -149,7 +149,7 @@ def test_comparison(elmaker, xml_string, test_parsed_data, current_parsed_value,
     <xtce:Value>4</xtce:Value>
 </xtce:Condition>
 """,
-         {'P1': packets.IntParameter(700, 4)}, True),
+         {'P1': common.IntParameter(700, 4)}, True),
         ("""
 <xtce:Condition xmlns:xtce="http://www.omg.org/space/xtce">
     <xtce:ParameterInstanceRef parameterRef="P1"/>
@@ -157,8 +157,8 @@ def test_comparison(elmaker, xml_string, test_parsed_data, current_parsed_value,
     <xtce:ParameterInstanceRef parameterRef="P2"/>
 </xtce:Condition>
 """,
-         {'P1': packets.IntParameter(700, 4),
-          'P2': packets.IntParameter(678, 3)}, False),
+         {'P1': common.IntParameter(700, 4),
+          'P2': common.IntParameter(678, 3)}, False),
         ("""
 <xtce:Condition xmlns:xtce="http://www.omg.org/space/xtce">
     <xtce:ParameterInstanceRef parameterRef="P1" useCalibratedValue="false"/>
@@ -166,8 +166,8 @@ def test_comparison(elmaker, xml_string, test_parsed_data, current_parsed_value,
     <xtce:ParameterInstanceRef parameterRef="P2" useCalibratedValue="false"/>
 </xtce:Condition>
 """,
-         {'P1': packets.StrParameter('abcd'),
-          'P2': packets.StrParameter('abcd')}, True),
+         {'P1': common.StrParameter('abcd'),
+          'P2': common.StrParameter('abcd')}, True),
         ("""
 <xtce:Condition xmlns:xtce="http://www.omg.org/space/xtce">
     <xtce:ParameterInstanceRef parameterRef="P1"/>
@@ -175,8 +175,8 @@ def test_comparison(elmaker, xml_string, test_parsed_data, current_parsed_value,
     <xtce:ParameterInstanceRef parameterRef="P2"/>
 </xtce:Condition>
 """,
-         {'P1': packets.FloatParameter(3.14, 1),
-          'P2': packets.FloatParameter(3.14, 180)}, True),
+         {'P1': common.FloatParameter(3.14, 1),
+          'P2': common.FloatParameter(3.14, 180)}, True),
     ]
 )
 def test_condition(elmaker, xml_string, test_parsed_data, expected_condition_result):
@@ -217,10 +217,10 @@ def test_condition(elmaker, xml_string, test_parsed_data, expected_condition_res
     </xtce:ORedConditions>
 </xtce:BooleanExpression>
 """,
-         {'P': packets.IntParameter(0, 4),
-          'P2': packets.IntParameter(700, 4),
-          'P3': packets.IntParameter(701, 4),
-          'P4': packets.IntParameter(98, 4)}, True),
+         {'P': common.IntParameter(0, 4),
+          'P2': common.IntParameter(700, 4),
+          'P3': common.IntParameter(701, 4),
+          'P4': common.IntParameter(98, 4)}, True),
         ("""
 <xtce:BooleanExpression xmlns:xtce="http://www.omg.org/space/xtce">
     <xtce:ANDedConditions>
@@ -249,12 +249,12 @@ def test_condition(elmaker, xml_string, test_parsed_data, expected_condition_res
     </xtce:ANDedConditions>
 </xtce:BooleanExpression>
 """,
-         {'P': packets.IntParameter(100, 4),
-          'P0': packets.IntParameter(678, 4),
-          'P1': packets.IntParameter(500, 4),
-          'P2': packets.IntParameter(700, 4),
-          'P3': packets.IntParameter(701, 4),
-          'P4': packets.IntParameter(99, 4)}, True),
+         {'P': common.IntParameter(100, 4),
+          'P0': common.IntParameter(678, 4),
+          'P1': common.IntParameter(500, 4),
+          'P2': common.IntParameter(700, 4),
+          'P3': common.IntParameter(701, 4),
+          'P4': common.IntParameter(99, 4)}, True),
     ]
 )
 def test_boolean_expression(elmaker, xml_string, test_parsed_data, expected_result):
@@ -281,13 +281,13 @@ def test_boolean_expression(elmaker, xml_string, test_parsed_data, expected_resu
     <xtce:Comparison useCalibratedValue="false" parameterRef="P1" value="1"/>
 </xtce:DiscreteLookup>
 """,
-         {'P1': packets.IntParameter(678, 1)}, 10),
+         {'P1': common.IntParameter(678, 1)}, 10),
         ("""
 <xtce:DiscreteLookup value="10" xmlns:xtce="http://www.omg.org/space/xtce">
     <xtce:Comparison useCalibratedValue="false" parameterRef="P1" value="1"/>
 </xtce:DiscreteLookup>
 """,
-         {'P1': packets.IntParameter(678, 0)}, None),
+         {'P1': common.IntParameter(678, 0)}, None),
         ("""
 <xtce:DiscreteLookup value="11" xmlns:xtce="http://www.omg.org/space/xtce">
     <xtce:ComparisonList>
@@ -297,8 +297,8 @@ def test_boolean_expression(elmaker, xml_string, test_parsed_data, expected_resu
 </xtce:DiscreteLookup>
 """,
          {
-             'MSN__PARAM1': packets.IntParameter(680, 3),
-             'MSN__PARAM2': packets.IntParameter(3000, 3),
+             'MSN__PARAM1': common.IntParameter(680, 3),
+             'MSN__PARAM2': common.IntParameter(3000, 3),
          }, 11),
     ]
 )

--- a/tests/unit/test_xtce/test_parameters.py
+++ b/tests/unit/test_xtce/test_parameters.py
@@ -5,7 +5,7 @@ import pytest
 import lxml.etree as ElementTree
 
 import space_packet_parser.xtce.parameter_types
-from space_packet_parser import packets
+from space_packet_parser import common, packets
 from space_packet_parser.xtce import parameters, encodings, comparisons, calibrators, definitions, XTCE_NSMAP
 
 
@@ -213,9 +213,9 @@ def test_unsupported_parameter_type_error(test_data_dir):
 def test_string_parameter_parsing(parameter_type, raw_data, current_pos, expected_raw, expected_derived):
     """Test parsing a string parameter"""
     # pre parsed data to reference for lookups
-    packet = packets.CCSDSPacket(raw_data=raw_data, **{'P1': packets.FloatParameter(7.55, 7),
-                                                       'P2': packets.IntParameter(100, 99),
-                                                       'STR_LEN': packets.IntParameter(8)})
+    packet = packets.CCSDSPacket(raw_data=raw_data, **{'P1': common.FloatParameter(7.55, 7),
+                                                       'P2': common.IntParameter(100, 99),
+                                                       'STR_LEN': common.IntParameter(8)})
     # Artificially set the current position of the packet data read so far
     packet.raw_data.pos = current_pos
     value = parameter_type.parse_value(packet)
@@ -325,7 +325,7 @@ def test_string_parameter_parsing(parameter_type, raw_data, current_pos, expecte
 def test_integer_parameter_parsing(parameter_type, raw_data, current_pos, expected):
     """Testing parsing an integer parameters"""
     # pre parsed data to reference for lookups
-    packet = packets.CCSDSPacket(raw_data=raw_data, PKT_APID=packets.IntParameter(1101))
+    packet = packets.CCSDSPacket(raw_data=raw_data, PKT_APID=common.IntParameter(1101))
     packet.raw_data.pos = current_pos
     value = parameter_type.parse_value(packet)
     assert value == expected
@@ -431,7 +431,7 @@ def test_integer_parameter_parsing(parameter_type, raw_data, current_pos, expect
 def test_float_parameter_parsing(parameter_type, raw_data, expected):
     """Test parsing float parameters"""
     # pre parsed data to reference for lookups
-    packet = packets.CCSDSPacket(raw_data=raw_data, **{'PKT_APID': packets.IntParameter(1101)})
+    packet = packets.CCSDSPacket(raw_data=raw_data, **{'PKT_APID': common.IntParameter(1101)})
     value = parameter_type.parse_value(packet)
     # NOTE: These results are compared with a relative tolerance due to the imprecise storage of floats
     assert value == pytest.approx(expected, rel=1E-7)
@@ -538,8 +538,8 @@ def test_binary_parameter_parsing(parameter_type, raw_data, expected):
     """Test parsing binary parameters"""
     # pre parsed data to reference for lookups
     packet = packets.CCSDSPacket(raw_data=raw_data, **{
-        'P1': packets.FloatParameter(7.4, 1),
-        'BIN_LEN': packets.IntParameter(2)})
+        'P1': common.FloatParameter(7.4, 1),
+        'BIN_LEN': common.IntParameter(2)})
     value = parameter_type.parse_value(packet)
     assert value == expected
 


### PR DESCRIPTION
They are not related to packets directly and are used in several different modules for parsing. They could probably go in parameter_types, but that could potentially lead to confusion about whether it is an XTCE StringParameterType or a data value of StrParameter. The generic place is in common, since these are really subclasses of builtins.

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
