### PR TITLE
CI: Explicitly output the codecov xml file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
     defaults:
       run:
         shell: bash
+    environment: ci-testing
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,4 +44,4 @@ jobs:
 
       - uses: codecov/codecov-action@v5
         with:
-          use_oidc: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Testing
         run: |
-          pytest --color=yes --cov
+          pytest --color=yes --cov --cov-report=xml
 
       - uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,6 @@ on:
 jobs:
   ci-tests:
     runs-on: ${{ matrix.os }}
-    permissions:
-      # For codecov OIDC verifications
-      id-token: write
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]


### PR DESCRIPTION
Seeing if this explicit output option helps to get coverage sent up. Thinking it may be an empty coverage report 🤷 . Just another shot in the dark here...