### PR TITLE
CI: Run pre-commit and not just ruff

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,12 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
-      - name: Install ruff
-        run: pip install . ruff
-      - name: Run ruff
-        run: ruff check
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit
+        run: |
+          pre-commit install
+          pre-commit run --all
 
   ci-tests:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This runs all of the pre-commit checks, not just the ruff command explicitly.