### PR TITLE
Handle all namespace cases - default, prefixed, no namespace.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,9 @@ on:
 jobs:
   ci-tests:
     runs-on: ${{ matrix.os }}
-    permissions:
-      # For codecov OIDC verifications
-      id-token: write
+#    permissions:
+#      # For codecov OIDC verifications
+#      id-token: write
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
@@ -21,7 +21,7 @@ jobs:
     defaults:
       run:
         shell: bash
-
+    environment: ci-testing
     steps:
       - uses: actions/checkout@v4
         with:
@@ -40,8 +40,10 @@ jobs:
 
       - name: Testing
         run: |
-          pytest --color=yes --cov
+          pytest --color=yes --cov --cov-report=xml
 
       - uses: codecov/codecov-action@v5
-        with:
-          use_oidc: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+#        with:
+#          use_oidc: true

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -35,8 +35,7 @@ Release notes for the `space_packet_parser` library
   e.g. `space_packet_parser.xarr.create_dataset([packets1, packets2, ...], definition)`
 - BUGFIX: update list of allowed float encodings to match XTCE spec
 - Add benchmark tests and documentation overview of benchmarks.
-- Add checking to ensure that every object in the `XtcePacketDefinition` attributes `containers`, `parameters`, and
-  `parameter_types` is also referenced in the nested objects in `containers`
+- Improve XML namespace handling when parsing and serializing XTCE.
 
 ### v5.0.1 (released)
 - BUGFIX: Allow raw_value representation for enums with falsy raw values. Previously these defaulted to the enum label.

--- a/space_packet_parser/xtce/__init__.py
+++ b/space_packet_parser/xtce/__init__.py
@@ -2,6 +2,20 @@
 
 This module contains Python object representations of XTCE UML/XML models
 """
+DEFAULT_XTCE_NS_PREFIX = "xtce"  # Standard XTCE prefix using in xmlns:prefix="url" attribute
 
-XTCE_URI = "http://www.omg.org/space/xtce"
-XTCE_NSMAP = {'xtce': XTCE_URI}
+XTCE_1_2_XSD_URL = "https://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd"
+XTCE_1_2_XMLNS = "https://www.omg.org/spec/XTCE/20180204"
+
+XTCE_1_1_XSD_URL = "https://www.omg.org/spec/XTCE/20061101/06-11-06.xsd"
+XTCE_1_1_XMLNS = "https://www.omg.org/spec/XTCE/20061101"
+
+# Note: There is no XSD available from omg.org for XTCE 1.0
+
+XTCE_URI = XTCE_1_2_XMLNS
+DEFAULT_XTCE_NSMAP = {
+    DEFAULT_XTCE_NS_PREFIX: XTCE_1_2_XMLNS,
+    "xsi": 'http://www.w3.org/2001/XMLSchema-instance'
+}
+
+

--- a/space_packet_parser/xtce/parameters.py
+++ b/space_packet_parser/xtce/parameters.py
@@ -41,7 +41,6 @@ class Parameter(common.Parseable, common.XmlObject):
             cls,
             element: ElementTree.Element,
             *,
-            ns: dict,
             parameter_type_lookup: dict[str, parameter_types.ParameterType],
             tree: Optional[ElementTree.ElementTree] = None,
             parameter_lookup: Optional[dict[str, any]] = None,
@@ -53,8 +52,6 @@ class Parameter(common.Parseable, common.XmlObject):
         ----------
         element : ElementTree.Element
             XML element
-        ns : dict
-            XML namespace dict
         tree: Optional[ElementTree.Element]
             Ignored
         parameter_lookup: Optional[dict]
@@ -78,8 +75,8 @@ class Parameter(common.Parseable, common.XmlObject):
         parameter_short_description = element.attrib['shortDescription'] if (
                 'shortDescription' in element.attrib
         ) else None
-        parameter_long_description = element.find('xtce:LongDescription', ns).text if (
-                element.find('xtce:LongDescription', ns) is not None
+        parameter_long_description = element.find('LongDescription').text if (
+                element.find('LongDescription') is not None
         ) else None
 
         return cls(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,15 +3,29 @@ from pathlib import Path
 import sys
 
 import pytest
+from lxml import etree
 from lxml.builder import ElementMaker
 
-from space_packet_parser.xtce import XTCE_URI, XTCE_NSMAP
+from space_packet_parser import common
+from space_packet_parser.xtce import DEFAULT_XTCE_NSMAP, DEFAULT_XTCE_NS_PREFIX, XTCE_1_2_XMLNS
 
 
 @pytest.fixture(scope="session")
 def elmaker():
     """ElementMaker for testing XML element creation"""
-    return ElementMaker(namespace=XTCE_URI, nsmap=XTCE_NSMAP)
+    return ElementMaker(namespace=XTCE_1_2_XMLNS, nsmap=DEFAULT_XTCE_NSMAP)
+
+
+@pytest.fixture
+def xtce_parser():
+    """Parser for testing that knows about the standard testing namespace we use"""
+    el = common.NamespaceAwareElement
+    el.set_nsmap(DEFAULT_XTCE_NSMAP)
+    el.set_ns_prefix(DEFAULT_XTCE_NS_PREFIX)
+    xtce_element_lookup = etree.ElementDefaultClassLookup(element=el)
+    xtce_parser = etree.XMLParser()
+    xtce_parser.set_element_class_lookup(xtce_element_lookup)
+    return xtce_parser
 
 
 @pytest.fixture

--- a/tests/test_data/test_xtce.xml
+++ b/tests/test_data/test_xtce.xml
@@ -1,8 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="Space Packet Parser"
+<xtce:SpaceSystem name="SpacePacketParser"
+                  xmlns:xtce="http://www.omg.org/spec/XTCE/20180204"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd">
-    <xtce:Header date="2024-03-05T13:36:00MST" version="1.0" author="Gavin Medley"/>
+                  xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204
+                                      https://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd">
+    <xtce:Header date="2024-03-05T13:36:00MST" version="1.0" validationStatus="Working"/>
     <xtce:TelemetryMetaData>
         <xtce:ParameterTypeSet>
             <xtce:IntegerParameterType name="VERSION_Type" signed="false">

--- a/tests/test_data/test_xtce_default_namespace.xml
+++ b/tests/test_data/test_xtce_default_namespace.xml
@@ -1,0 +1,209 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SpaceSystem name="SpacePacketParser"
+             xmlns="http://www.omg.org/spec/XTCE/20180204"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204
+                                 https://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd">
+    <Header date="2024-03-05T13:36:00MST" version="1.0" validationStatus="Working"/>
+    <TelemetryMetaData>
+        <ParameterTypeSet>
+            <IntegerParameterType name="VERSION_Type" signed="false">
+                <UnitSet/>
+                <IntegerDataEncoding sizeInBits="3"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="TYPE_Type" signed="false">
+                <UnitSet/>
+                <IntegerDataEncoding sizeInBits="1"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="SEC_HDR_FLG_Type" signed="false">
+                <UnitSet/>
+                <IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="PKT_APID_Type" signed="false">
+                <UnitSet/>
+                <IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="SEQ_FLGS_Type" signed="false">
+                <UnitSet/>
+                <IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="SRC_SEQ_CTR_Type" signed="false">
+                <UnitSet/>
+                <IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="PKT_LEN_Type" signed="false">
+                <UnitSet/>
+                <IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+            </IntegerParameterType>
+            <FloatParameterType name="DOY_Type">
+                <UnitSet>
+                    <Unit>day</Unit>
+                </UnitSet>
+                <IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+            </FloatParameterType>
+            <FloatParameterType name="MSEC_Type">
+                <UnitSet>
+                    <Unit>ms</Unit>
+                </UnitSet>
+                <IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+            </FloatParameterType>
+            <FloatParameterType name="USEC_Type">
+                <UnitSet>
+                    <Unit>us</Unit>
+                </UnitSet>
+                <IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+            </FloatParameterType>
+            <IntegerParameterType name="ADASCID_Type" signed="false">
+                <UnitSet/>
+                <IntegerDataEncoding sizeInBits="8" encoding="unsigned"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="ADAETDAY_Type" signed="false">
+                <UnitSet>
+                    <Unit>day</Unit>
+                </UnitSet>
+                <IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="ADAETMS_Type" signed="false">
+                <UnitSet>
+                    <Unit>ms</Unit>
+                </UnitSet>
+                <IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="ADAETUS_Type" signed="false">
+                <UnitSet>
+                    <Unit>us</Unit>
+                </UnitSet>
+                <IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+            </IntegerParameterType>
+            <FloatParameterType name="ADGPSPOS_Type">
+                <UnitSet>
+                    <Unit>m</Unit>
+                </UnitSet>
+                <FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
+            </FloatParameterType>
+            <FloatParameterType name="ADGPSVEL_Type">
+                <UnitSet>
+                    <Unit>m/s</Unit>
+                </UnitSet>
+                <FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
+            </FloatParameterType>
+            <FloatParameterType name="ADCFAQ_Type">
+                <UnitSet/>
+                <FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
+            </FloatParameterType>
+        </ParameterTypeSet>
+        <ParameterSet>
+            <Parameter name="VERSION" parameterTypeRef="VERSION_Type">
+                <LongDescription>Not really used. We aren't changing the version of CCSDS that we use.</LongDescription>
+            </Parameter>
+            <Parameter name="TYPE" parameterTypeRef="TYPE_Type">
+                <LongDescription>Indicates whether this packet is CMD or TLM. TLM is 0.</LongDescription>
+            </Parameter>
+            <Parameter name="SEC_HDR_FLG" parameterTypeRef="SEC_HDR_FLG_Type">
+                <LongDescription>Always 1 - indicates that there is a secondary header.</LongDescription>
+            </Parameter>
+            <Parameter name="PKT_APID" parameterTypeRef="PKT_APID_Type">
+                <LongDescription>Unique to each packet type.</LongDescription>
+            </Parameter>
+            <Parameter name="SEQ_FLGS" parameterTypeRef="SEQ_FLGS_Type">
+                <LongDescription>Always set to 1.</LongDescription>
+            </Parameter>
+            <Parameter name="SRC_SEQ_CTR" parameterTypeRef="SRC_SEQ_CTR_Type">
+                <LongDescription>Increments from 0 at reset for each packet issued of that APID. Rolls over at 14b.</LongDescription>
+            </Parameter>
+            <Parameter name="PKT_LEN" parameterTypeRef="PKT_LEN_Type">
+                <LongDescription>Number of bytes of the data field following the primary header -1. (To get the length of the whole packet, add 7)</LongDescription>
+            </Parameter>
+            <Parameter name="DOY" parameterTypeRef="DOY_Type" shortDescription="Secondary Header Day of Year">
+                <LongDescription>CCSDS Packet 2nd Header Day of Year in days.</LongDescription>
+            </Parameter>
+            <Parameter name="MSEC" parameterTypeRef="MSEC_Type" shortDescription="Secondary Header Coarse Time (millisecond)">
+                <LongDescription>CCSDS Packet 2nd Header Coarse Time in milliseconds.</LongDescription>
+            </Parameter>
+            <Parameter name="USEC" parameterTypeRef="USEC_Type" shortDescription="Secondary Header Fine Time (microsecond)">
+                <LongDescription>CCSDS Packet 2nd Header Fine Time in microseconds.</LongDescription>
+            </Parameter>
+            <Parameter name="ADAESCID" parameterTypeRef="ADASCID_Type" shortDescription="Spacecraft ID"/>
+            <Parameter name="ADAET1DAY" parameterTypeRef="ADAETDAY_Type" shortDescription="Ephemeris Valid Time, Days Since 1/1/1958"/>
+            <Parameter name="ADAET1MS" parameterTypeRef="ADAETMS_Type" shortDescription="Ephemeris Valid Time, Milliseconds of Day"/>
+            <Parameter name="ADAET1US" parameterTypeRef="ADAETUS_Type" shortDescription="Ephemeris Valid Time, Microseconds of Milliseconds"/>
+            <Parameter name="ADGPSPOSX" parameterTypeRef="ADGPSPOS_Type" shortDescription="Ephemeris Position (ECEF) X"/>
+            <Parameter name="ADGPSPOSY" parameterTypeRef="ADGPSPOS_Type" shortDescription="Ephemeris Position (ECEF) Y"/>
+            <Parameter name="ADGPSPOSZ" parameterTypeRef="ADGPSPOS_Type" shortDescription="Ephemeris Position (ECEF) Z"/>
+            <Parameter name="ADGPSVELX" parameterTypeRef="ADGPSVEL_Type" shortDescription="Ephemeris Velocity (ECEF) X"/>
+            <Parameter name="ADGPSVELY" parameterTypeRef="ADGPSVEL_Type" shortDescription="Ephemeris Velocity (ECEF) Y"/>
+            <Parameter name="ADGPSVELZ" parameterTypeRef="ADGPSVEL_Type" shortDescription="Ephemeris Velocity (ECEF) Z"/>
+            <Parameter name="ADAET2DAY" parameterTypeRef="ADAETDAY_Type" shortDescription="Attitude Valid Time, Days Since 1/1/1958"/>
+            <Parameter name="ADAET2MS" parameterTypeRef="ADAETMS_Type" shortDescription="Attitude Valid Time, Milliseconds of Day"/>
+            <Parameter name="ADAET2US" parameterTypeRef="ADAETUS_Type" shortDescription="Attitude Valid Time, Microseconds of Milliseconds"/>
+            <Parameter name="ADCFAQ1" parameterTypeRef="ADCFAQ_Type" shortDescription="Control Frame Attitude Q1 (i)"/>
+            <Parameter name="ADCFAQ2" parameterTypeRef="ADCFAQ_Type" shortDescription="Control Frame Attitude Q2 (j)"/>
+            <Parameter name="ADCFAQ3" parameterTypeRef="ADCFAQ_Type" shortDescription="Control Frame Attitude Q3 (k)"/>
+            <Parameter name="ADCFAQ4" parameterTypeRef="ADCFAQ_Type" shortDescription="Control Frame Attitude Q4 (scalar)"/>
+        </ParameterSet>
+        <ContainerSet>
+            <SequenceContainer name="CCSDSPacket" abstract="true">
+                <LongDescription>Super-container for telemetry and command packets</LongDescription>
+                <EntryList>
+                    <ParameterRefEntry parameterRef="VERSION"/>
+                    <ParameterRefEntry parameterRef="TYPE"/>
+                    <ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+                    <ParameterRefEntry parameterRef="PKT_APID"/>
+                    <ParameterRefEntry parameterRef="SEQ_FLGS"/>
+                    <ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+                    <ParameterRefEntry parameterRef="PKT_LEN"/>
+                </EntryList>
+            </SequenceContainer>
+            <SequenceContainer name="CCSDSTelemetryPacket" abstract="true">
+                <LongDescription>Super-container for all telemetry packets</LongDescription>
+                <EntryList/>
+                <BaseContainer containerRef="CCSDSPacket">
+                    <RestrictionCriteria>
+                        <ComparisonList>
+                            <Comparison parameterRef="VERSION" value="0" useCalibratedValue="false"/>
+                            <Comparison parameterRef="TYPE" value="0" useCalibratedValue="false"/>
+                        </ComparisonList>
+                    </RestrictionCriteria>
+                </BaseContainer>
+            </SequenceContainer>
+            <SequenceContainer name="SecondaryHeaderContainer" abstract="true">
+                <LongDescription>Container for telemetry secondary header items</LongDescription>
+                <EntryList>
+                    <ParameterRefEntry parameterRef="DOY"/>
+                    <ParameterRefEntry parameterRef="MSEC"/>
+                    <ParameterRefEntry parameterRef="USEC"/>
+                </EntryList>
+            </SequenceContainer>
+            <SequenceContainer name="JPSS_ATT_EPHEM" shortDescription="Spacecraft Attitude and Ephemeris">
+                <LongDescription>Spacecraft Attitude and Ephemeris packet used to geolocate mission data</LongDescription>
+                <EntryList>
+                    <ContainerRefEntry containerRef="SecondaryHeaderContainer"/>
+                    <ParameterRefEntry parameterRef="ADAESCID"/>
+                    <ParameterRefEntry parameterRef="ADAET1DAY"/>
+                    <ParameterRefEntry parameterRef="ADAET1MS"/>
+                    <ParameterRefEntry parameterRef="ADAET1US"/>
+                    <ParameterRefEntry parameterRef="ADGPSPOSX"/>
+                    <ParameterRefEntry parameterRef="ADGPSPOSY"/>
+                    <ParameterRefEntry parameterRef="ADGPSPOSZ"/>
+                    <ParameterRefEntry parameterRef="ADGPSVELX"/>
+                    <ParameterRefEntry parameterRef="ADGPSVELY"/>
+                    <ParameterRefEntry parameterRef="ADGPSVELZ"/>
+                    <ParameterRefEntry parameterRef="ADAET2DAY"/>
+                    <ParameterRefEntry parameterRef="ADAET2MS"/>
+                    <ParameterRefEntry parameterRef="ADAET2US"/>
+                    <ParameterRefEntry parameterRef="ADCFAQ1"/>
+                    <ParameterRefEntry parameterRef="ADCFAQ2"/>
+                    <ParameterRefEntry parameterRef="ADCFAQ3"/>
+                    <ParameterRefEntry parameterRef="ADCFAQ4"/>
+                </EntryList>
+                <BaseContainer containerRef="CCSDSTelemetryPacket">
+                    <RestrictionCriteria>
+                        <ComparisonList>
+                            <Comparison parameterRef="PKT_APID" value="11" useCalibratedValue="false"/>
+                        </ComparisonList>
+                    </RestrictionCriteria>
+                </BaseContainer>
+            </SequenceContainer>
+        </ContainerSet>
+    </TelemetryMetaData>
+</SpaceSystem>

--- a/tests/test_data/test_xtce_no_namespace.xml
+++ b/tests/test_data/test_xtce_no_namespace.xml
@@ -1,0 +1,209 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SpaceSystem name="SpacePacketParser"
+             xmlns="http://www.omg.org/spec/XTCE/20180204"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204
+                                 https://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd">
+    <Header date="2024-03-05T13:36:00MST" version="1.0" validationStatus="Working"/>
+    <TelemetryMetaData>
+        <ParameterTypeSet>
+            <IntegerParameterType name="VERSION_Type" signed="false">
+                <UnitSet/>
+                <IntegerDataEncoding sizeInBits="3"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="TYPE_Type" signed="false">
+                <UnitSet/>
+                <IntegerDataEncoding sizeInBits="1"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="SEC_HDR_FLG_Type" signed="false">
+                <UnitSet/>
+                <IntegerDataEncoding sizeInBits="1" encoding="unsigned"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="PKT_APID_Type" signed="false">
+                <UnitSet/>
+                <IntegerDataEncoding sizeInBits="11" encoding="unsigned"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="SEQ_FLGS_Type" signed="false">
+                <UnitSet/>
+                <IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="SRC_SEQ_CTR_Type" signed="false">
+                <UnitSet/>
+                <IntegerDataEncoding sizeInBits="14" encoding="unsigned"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="PKT_LEN_Type" signed="false">
+                <UnitSet/>
+                <IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+            </IntegerParameterType>
+            <FloatParameterType name="DOY_Type">
+                <UnitSet>
+                    <Unit>day</Unit>
+                </UnitSet>
+                <IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+            </FloatParameterType>
+            <FloatParameterType name="MSEC_Type">
+                <UnitSet>
+                    <Unit>ms</Unit>
+                </UnitSet>
+                <IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+            </FloatParameterType>
+            <FloatParameterType name="USEC_Type">
+                <UnitSet>
+                    <Unit>us</Unit>
+                </UnitSet>
+                <IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+            </FloatParameterType>
+            <IntegerParameterType name="ADASCID_Type" signed="false">
+                <UnitSet/>
+                <IntegerDataEncoding sizeInBits="8" encoding="unsigned"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="ADAETDAY_Type" signed="false">
+                <UnitSet>
+                    <Unit>day</Unit>
+                </UnitSet>
+                <IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="ADAETMS_Type" signed="false">
+                <UnitSet>
+                    <Unit>ms</Unit>
+                </UnitSet>
+                <IntegerDataEncoding sizeInBits="32" encoding="unsigned"/>
+            </IntegerParameterType>
+            <IntegerParameterType name="ADAETUS_Type" signed="false">
+                <UnitSet>
+                    <Unit>us</Unit>
+                </UnitSet>
+                <IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+            </IntegerParameterType>
+            <FloatParameterType name="ADGPSPOS_Type">
+                <UnitSet>
+                    <Unit>m</Unit>
+                </UnitSet>
+                <FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
+            </FloatParameterType>
+            <FloatParameterType name="ADGPSVEL_Type">
+                <UnitSet>
+                    <Unit>m/s</Unit>
+                </UnitSet>
+                <FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
+            </FloatParameterType>
+            <FloatParameterType name="ADCFAQ_Type">
+                <UnitSet/>
+                <FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
+            </FloatParameterType>
+        </ParameterTypeSet>
+        <ParameterSet>
+            <Parameter name="VERSION" parameterTypeRef="VERSION_Type">
+                <LongDescription>Not really used. We aren't changing the version of CCSDS that we use.</LongDescription>
+            </Parameter>
+            <Parameter name="TYPE" parameterTypeRef="TYPE_Type">
+                <LongDescription>Indicates whether this packet is CMD or TLM. TLM is 0.</LongDescription>
+            </Parameter>
+            <Parameter name="SEC_HDR_FLG" parameterTypeRef="SEC_HDR_FLG_Type">
+                <LongDescription>Always 1 - indicates that there is a secondary header.</LongDescription>
+            </Parameter>
+            <Parameter name="PKT_APID" parameterTypeRef="PKT_APID_Type">
+                <LongDescription>Unique to each packet type.</LongDescription>
+            </Parameter>
+            <Parameter name="SEQ_FLGS" parameterTypeRef="SEQ_FLGS_Type">
+                <LongDescription>Always set to 1.</LongDescription>
+            </Parameter>
+            <Parameter name="SRC_SEQ_CTR" parameterTypeRef="SRC_SEQ_CTR_Type">
+                <LongDescription>Increments from 0 at reset for each packet issued of that APID. Rolls over at 14b.</LongDescription>
+            </Parameter>
+            <Parameter name="PKT_LEN" parameterTypeRef="PKT_LEN_Type">
+                <LongDescription>Number of bytes of the data field following the primary header -1. (To get the length of the whole packet, add 7)</LongDescription>
+            </Parameter>
+            <Parameter name="DOY" parameterTypeRef="DOY_Type" shortDescription="Secondary Header Day of Year">
+                <LongDescription>CCSDS Packet 2nd Header Day of Year in days.</LongDescription>
+            </Parameter>
+            <Parameter name="MSEC" parameterTypeRef="MSEC_Type" shortDescription="Secondary Header Coarse Time (millisecond)">
+                <LongDescription>CCSDS Packet 2nd Header Coarse Time in milliseconds.</LongDescription>
+            </Parameter>
+            <Parameter name="USEC" parameterTypeRef="USEC_Type" shortDescription="Secondary Header Fine Time (microsecond)">
+                <LongDescription>CCSDS Packet 2nd Header Fine Time in microseconds.</LongDescription>
+            </Parameter>
+            <Parameter name="ADAESCID" parameterTypeRef="ADASCID_Type" shortDescription="Spacecraft ID"/>
+            <Parameter name="ADAET1DAY" parameterTypeRef="ADAETDAY_Type" shortDescription="Ephemeris Valid Time, Days Since 1/1/1958"/>
+            <Parameter name="ADAET1MS" parameterTypeRef="ADAETMS_Type" shortDescription="Ephemeris Valid Time, Milliseconds of Day"/>
+            <Parameter name="ADAET1US" parameterTypeRef="ADAETUS_Type" shortDescription="Ephemeris Valid Time, Microseconds of Milliseconds"/>
+            <Parameter name="ADGPSPOSX" parameterTypeRef="ADGPSPOS_Type" shortDescription="Ephemeris Position (ECEF) X"/>
+            <Parameter name="ADGPSPOSY" parameterTypeRef="ADGPSPOS_Type" shortDescription="Ephemeris Position (ECEF) Y"/>
+            <Parameter name="ADGPSPOSZ" parameterTypeRef="ADGPSPOS_Type" shortDescription="Ephemeris Position (ECEF) Z"/>
+            <Parameter name="ADGPSVELX" parameterTypeRef="ADGPSVEL_Type" shortDescription="Ephemeris Velocity (ECEF) X"/>
+            <Parameter name="ADGPSVELY" parameterTypeRef="ADGPSVEL_Type" shortDescription="Ephemeris Velocity (ECEF) Y"/>
+            <Parameter name="ADGPSVELZ" parameterTypeRef="ADGPSVEL_Type" shortDescription="Ephemeris Velocity (ECEF) Z"/>
+            <Parameter name="ADAET2DAY" parameterTypeRef="ADAETDAY_Type" shortDescription="Attitude Valid Time, Days Since 1/1/1958"/>
+            <Parameter name="ADAET2MS" parameterTypeRef="ADAETMS_Type" shortDescription="Attitude Valid Time, Milliseconds of Day"/>
+            <Parameter name="ADAET2US" parameterTypeRef="ADAETUS_Type" shortDescription="Attitude Valid Time, Microseconds of Milliseconds"/>
+            <Parameter name="ADCFAQ1" parameterTypeRef="ADCFAQ_Type" shortDescription="Control Frame Attitude Q1 (i)"/>
+            <Parameter name="ADCFAQ2" parameterTypeRef="ADCFAQ_Type" shortDescription="Control Frame Attitude Q2 (j)"/>
+            <Parameter name="ADCFAQ3" parameterTypeRef="ADCFAQ_Type" shortDescription="Control Frame Attitude Q3 (k)"/>
+            <Parameter name="ADCFAQ4" parameterTypeRef="ADCFAQ_Type" shortDescription="Control Frame Attitude Q4 (scalar)"/>
+        </ParameterSet>
+        <ContainerSet>
+            <SequenceContainer name="CCSDSPacket" abstract="true">
+                <LongDescription>Super-container for telemetry and command packets</LongDescription>
+                <EntryList>
+                    <ParameterRefEntry parameterRef="VERSION"/>
+                    <ParameterRefEntry parameterRef="TYPE"/>
+                    <ParameterRefEntry parameterRef="SEC_HDR_FLG"/>
+                    <ParameterRefEntry parameterRef="PKT_APID"/>
+                    <ParameterRefEntry parameterRef="SEQ_FLGS"/>
+                    <ParameterRefEntry parameterRef="SRC_SEQ_CTR"/>
+                    <ParameterRefEntry parameterRef="PKT_LEN"/>
+                </EntryList>
+            </SequenceContainer>
+            <SequenceContainer name="CCSDSTelemetryPacket" abstract="true">
+                <LongDescription>Super-container for all telemetry packets</LongDescription>
+                <EntryList/>
+                <BaseContainer containerRef="CCSDSPacket">
+                    <RestrictionCriteria>
+                        <ComparisonList>
+                            <Comparison parameterRef="VERSION" value="0" useCalibratedValue="false"/>
+                            <Comparison parameterRef="TYPE" value="0" useCalibratedValue="false"/>
+                        </ComparisonList>
+                    </RestrictionCriteria>
+                </BaseContainer>
+            </SequenceContainer>
+            <SequenceContainer name="SecondaryHeaderContainer" abstract="true">
+                <LongDescription>Container for telemetry secondary header items</LongDescription>
+                <EntryList>
+                    <ParameterRefEntry parameterRef="DOY"/>
+                    <ParameterRefEntry parameterRef="MSEC"/>
+                    <ParameterRefEntry parameterRef="USEC"/>
+                </EntryList>
+            </SequenceContainer>
+            <SequenceContainer name="JPSS_ATT_EPHEM" shortDescription="Spacecraft Attitude and Ephemeris">
+                <LongDescription>Spacecraft Attitude and Ephemeris packet used to geolocate mission data</LongDescription>
+                <EntryList>
+                    <ContainerRefEntry containerRef="SecondaryHeaderContainer"/>
+                    <ParameterRefEntry parameterRef="ADAESCID"/>
+                    <ParameterRefEntry parameterRef="ADAET1DAY"/>
+                    <ParameterRefEntry parameterRef="ADAET1MS"/>
+                    <ParameterRefEntry parameterRef="ADAET1US"/>
+                    <ParameterRefEntry parameterRef="ADGPSPOSX"/>
+                    <ParameterRefEntry parameterRef="ADGPSPOSY"/>
+                    <ParameterRefEntry parameterRef="ADGPSPOSZ"/>
+                    <ParameterRefEntry parameterRef="ADGPSVELX"/>
+                    <ParameterRefEntry parameterRef="ADGPSVELY"/>
+                    <ParameterRefEntry parameterRef="ADGPSVELZ"/>
+                    <ParameterRefEntry parameterRef="ADAET2DAY"/>
+                    <ParameterRefEntry parameterRef="ADAET2MS"/>
+                    <ParameterRefEntry parameterRef="ADAET2US"/>
+                    <ParameterRefEntry parameterRef="ADCFAQ1"/>
+                    <ParameterRefEntry parameterRef="ADCFAQ2"/>
+                    <ParameterRefEntry parameterRef="ADCFAQ3"/>
+                    <ParameterRefEntry parameterRef="ADCFAQ4"/>
+                </EntryList>
+                <BaseContainer containerRef="CCSDSTelemetryPacket">
+                    <RestrictionCriteria>
+                        <ComparisonList>
+                            <Comparison parameterRef="PKT_APID" value="11" useCalibratedValue="false"/>
+                        </ComparisonList>
+                    </RestrictionCriteria>
+                </BaseContainer>
+            </SequenceContainer>
+        </ContainerSet>
+    </TelemetryMetaData>
+</SpaceSystem>

--- a/tests/unit/test_xtce/test_comparisons.py
+++ b/tests/unit/test_xtce/test_comparisons.py
@@ -4,137 +4,136 @@ import lxml.etree as ElementTree
 
 from space_packet_parser import common
 from space_packet_parser.exceptions import ComparisonError
-from space_packet_parser.xtce import comparisons, XTCE_NSMAP
+from space_packet_parser.xtce import XTCE_1_2_XMLNS, comparisons
 
 
 @pytest.mark.parametrize(
     ('xml_string', 'test_parsed_data', 'current_parsed_value', 'expected_comparison_result'),
     [
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="==" value="678" parameterRef="MSN__PARAM"/>
 """,
          {'MSN__PARAM': common.FloatParameter(678, 3)}, None, True),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="eq" value="678" parameterRef="MSN__PARAM"/>
 """,
          {'MSN__PARAM': common.FloatParameter(668, 3)}, None, False),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="!=" value="678" parameterRef="MSN__PARAM"/>
 """,
          {'MSN__PARAM': common.FloatParameter(678, 3)}, None, False),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="neq" value="678" parameterRef="MSN__PARAM"/>
 """,
          {'MSN__PARAM': common.FloatParameter(658, 3)}, None, True),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="&lt;" value="678" parameterRef="MSN__PARAM"/>
 """,
          {'MSN__PARAM': common.FloatParameter(679, 3)}, None, False),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="lt" value="678" parameterRef="MSN__PARAM"/>
 """,
          {'MSN__PARAM': common.FloatParameter(670, 3)}, None, True),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="&gt;" value="678" parameterRef="MSN__PARAM"/>
 """,
          {'MSN__PARAM': common.FloatParameter(678, 3)}, None, False),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="gt" value="678" parameterRef="MSN__PARAM"/>
 """,
          {'MSN__PARAM': common.FloatParameter(679, 3)}, None, True),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="&lt;=" value="678" parameterRef="MSN__PARAM"/>
 """,
          {'MSN__PARAM': common.FloatParameter(660, 3)}, None, True),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="leq" value="678" parameterRef="MSN__PARAM"/>
 """,
          {'MSN__PARAM': common.FloatParameter(690, 3)}, None, False),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="&gt;=" value="678" parameterRef="MSN__PARAM"/>
 """,
          {'MSN__PARAM': common.FloatParameter(660, 3)}, None, False),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="geq" value="678" parameterRef="MSN__PARAM"/>
 """,
          {'MSN__PARAM': common.FloatParameter(690, 3)}, None, True),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="==" value="678" parameterRef="MSN__PARAM" useCalibratedValue="false"/>
 """,
          {'MSN__PARAM': common.FloatParameter(690, 678)}, None, True),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="==" value="678" parameterRef="MSN__PARAM" useCalibratedValue="true"/>
 """,
          {'MSN__PARAM': common.FloatParameter(678, 3)}, None, True),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="==" value="foostring" parameterRef="MSN__PARAM" useCalibratedValue="false"/>
 """,
          {'MSN__PARAM': common.StrParameter('calibratedfoostring', 'foostring')}, None, True),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="==" value="3.14" parameterRef="MSN__PARAM"/>
 """,
          {'MSN__PARAM': common.FloatParameter(3.14, 1)}, None, True),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="==" value="3.0" parameterRef="REFERENCE_TO_OWN_RAW_VAL"/>
 """,
          {}, 3.0, True),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="==" value="3" parameterRef="REFERENCE_TO_OWN_RAW_VAL"/>
 """,
          {}, 3, True),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="==" value="foostr" parameterRef="REFERENCE_TO_OWN_RAW_VAL"/>
 """,
          {}, "foostr", True),
-        ("""
-<xtce:Comparison xmlns:xtce="http://www.omg.org/space/xtce"
+        (f"""
+<xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="==" value="3.0" parameterRef="REFERENCE_TO_OWN_RAW_VAL"/>
 """,
          {}, 3, ComparisonError("Fails to parse a float string 3.0 into an int")),
     ]
 )
 @pytest.mark.filterwarnings("ignore:Performing a comparison against a current value")
-def test_comparison(elmaker, xml_string, test_parsed_data, current_parsed_value, expected_comparison_result):
+def test_comparison(elmaker, xtce_parser, xml_string, test_parsed_data, current_parsed_value, expected_comparison_result):
     """Test Comparison object"""
-    element = ElementTree.fromstring(xml_string)
+    element = ElementTree.fromstring(xml_string, parser=xtce_parser)
     if isinstance(expected_comparison_result, Exception):
         with pytest.raises(type(expected_comparison_result)):
-            comparison = comparisons.Comparison.from_xml(element, ns=XTCE_NSMAP)
+            comparison = comparisons.Comparison.from_xml(element)
             comparison.evaluate(test_parsed_data, current_parsed_value)
     else:
-        comparison = comparisons.Comparison.from_xml(element, ns=XTCE_NSMAP)
+        comparison = comparisons.Comparison.from_xml(element)
         assert comparison.evaluate(test_parsed_data, current_parsed_value) == expected_comparison_result
         # Recover XML and re-parse it to check it's reproducible
         result_string = ElementTree.tostring(comparison.to_xml(elmaker=elmaker), pretty_print=True).decode()
-        full_circle = comparisons.Comparison.from_xml(ElementTree.fromstring(result_string),
-                                                      ns=XTCE_NSMAP)
+        full_circle = comparisons.Comparison.from_xml(ElementTree.fromstring(result_string, parser=xtce_parser))
         assert full_circle.evaluate(test_parsed_data, current_parsed_value) == expected_comparison_result
 
 
 @pytest.mark.parametrize(
     ('xml_string', 'test_parsed_data', 'expected_condition_result'),
     [
-        ("""
-<xtce:Condition xmlns:xtce="http://www.omg.org/space/xtce">
+        (f"""
+<xtce:Condition xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:ParameterInstanceRef parameterRef="P1"/>
     <xtce:ComparisonOperator>&gt;=</xtce:ComparisonOperator>
     <xtce:ParameterInstanceRef parameterRef="P2"/>
@@ -142,16 +141,16 @@ def test_comparison(elmaker, xml_string, test_parsed_data, current_parsed_value,
 """,
          {'P1': common.IntParameter(700, 4),
           'P2': common.IntParameter(678, 3)}, True),
-        ("""
-<xtce:Condition xmlns:xtce="http://www.omg.org/space/xtce">
+        (f"""
+<xtce:Condition xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:ParameterInstanceRef parameterRef="P1"/>
     <xtce:ComparisonOperator>&gt;=</xtce:ComparisonOperator>
     <xtce:Value>4</xtce:Value>
 </xtce:Condition>
 """,
          {'P1': common.IntParameter(700, 4)}, True),
-        ("""
-<xtce:Condition xmlns:xtce="http://www.omg.org/space/xtce">
+        (f"""
+<xtce:Condition xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:ParameterInstanceRef parameterRef="P1"/>
     <xtce:ComparisonOperator>==</xtce:ComparisonOperator>
     <xtce:ParameterInstanceRef parameterRef="P2"/>
@@ -159,8 +158,8 @@ def test_comparison(elmaker, xml_string, test_parsed_data, current_parsed_value,
 """,
          {'P1': common.IntParameter(700, 4),
           'P2': common.IntParameter(678, 3)}, False),
-        ("""
-<xtce:Condition xmlns:xtce="http://www.omg.org/space/xtce">
+        (f"""
+<xtce:Condition xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:ParameterInstanceRef parameterRef="P1" useCalibratedValue="false"/>
     <xtce:ComparisonOperator>==</xtce:ComparisonOperator>
     <xtce:ParameterInstanceRef parameterRef="P2" useCalibratedValue="false"/>
@@ -168,8 +167,8 @@ def test_comparison(elmaker, xml_string, test_parsed_data, current_parsed_value,
 """,
          {'P1': common.StrParameter('abcd'),
           'P2': common.StrParameter('abcd')}, True),
-        ("""
-<xtce:Condition xmlns:xtce="http://www.omg.org/space/xtce">
+        (f"""
+<xtce:Condition xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:ParameterInstanceRef parameterRef="P1"/>
     <xtce:ComparisonOperator>==</xtce:ComparisonOperator>
     <xtce:ParameterInstanceRef parameterRef="P2"/>
@@ -179,23 +178,22 @@ def test_comparison(elmaker, xml_string, test_parsed_data, current_parsed_value,
           'P2': common.FloatParameter(3.14, 180)}, True),
     ]
 )
-def test_condition(elmaker, xml_string, test_parsed_data, expected_condition_result):
+def test_condition(elmaker, xtce_parser, xml_string, test_parsed_data, expected_condition_result):
     """Test Condition object"""
-    element = ElementTree.fromstring(xml_string)
-    condition = comparisons.Condition.from_xml(element, ns=XTCE_NSMAP)
+    element = ElementTree.fromstring(xml_string, parser=xtce_parser)
+    condition = comparisons.Condition.from_xml(element)
     assert condition.evaluate(test_parsed_data, None) == expected_condition_result
     # Recover XML and re-parse it to check it's reproducible
     result_string = ElementTree.tostring(condition.to_xml(elmaker=elmaker), pretty_print=True).decode()
-    full_circle = comparisons.Condition.from_xml(ElementTree.fromstring(result_string),
-                                                 ns=XTCE_NSMAP)
+    full_circle = comparisons.Condition.from_xml(ElementTree.fromstring(result_string, parser=xtce_parser))
     assert full_circle.evaluate(test_parsed_data) == expected_condition_result
 
 
 @pytest.mark.parametrize(
     ('xml_string', 'test_parsed_data', 'expected_result'),
     [
-        ("""
-<xtce:BooleanExpression xmlns:xtce="http://www.omg.org/space/xtce">
+        (f"""
+<xtce:BooleanExpression xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:ORedConditions>
         <xtce:Condition>
             <xtce:ParameterInstanceRef parameterRef="P"/>
@@ -221,8 +219,8 @@ def test_condition(elmaker, xml_string, test_parsed_data, expected_condition_res
           'P2': common.IntParameter(700, 4),
           'P3': common.IntParameter(701, 4),
           'P4': common.IntParameter(98, 4)}, True),
-        ("""
-<xtce:BooleanExpression xmlns:xtce="http://www.omg.org/space/xtce">
+        (f"""
+<xtce:BooleanExpression xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:ANDedConditions>
         <xtce:Condition>
             <xtce:ParameterInstanceRef parameterRef="P"/>
@@ -257,39 +255,38 @@ def test_condition(elmaker, xml_string, test_parsed_data, expected_condition_res
           'P4': common.IntParameter(99, 4)}, True),
     ]
 )
-def test_boolean_expression(elmaker, xml_string, test_parsed_data, expected_result):
+def test_boolean_expression(elmaker, xtce_parser, xml_string, test_parsed_data, expected_result):
     """Test BooleanExpression object"""
-    element = ElementTree.fromstring(xml_string)
+    element = ElementTree.fromstring(xml_string, parser=xtce_parser)
     if isinstance(expected_result, Exception):
         with pytest.raises(type(expected_result)):
-            comparisons.BooleanExpression.from_xml(element, ns=XTCE_NSMAP)
+            comparisons.BooleanExpression.from_xml(element)
     else:
-        expression = comparisons.BooleanExpression.from_xml(element, ns=XTCE_NSMAP)
+        expression = comparisons.BooleanExpression.from_xml(element)
         assert expression.evaluate(test_parsed_data, current_parsed_value=None) == expected_result
         # Recover XML and re-parse it to check it's reproducible
         result_string = ElementTree.tostring(expression.to_xml(elmaker=elmaker), pretty_print=True).decode()
-        full_circle = comparisons.BooleanExpression.from_xml(ElementTree.fromstring(result_string),
-                                                             ns=XTCE_NSMAP)
+        full_circle = comparisons.BooleanExpression.from_xml(ElementTree.fromstring(result_string, parser=xtce_parser))
         assert full_circle.evaluate(test_parsed_data) == expected_result
 
 
 @pytest.mark.parametrize(
     ('xml_string', 'test_parsed_data', 'expected_lookup_result'),
     [
-        ("""
-<xtce:DiscreteLookup value="10" xmlns:xtce="http://www.omg.org/space/xtce">
+        (f"""
+<xtce:DiscreteLookup value="10" xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:Comparison useCalibratedValue="false" parameterRef="P1" value="1"/>
 </xtce:DiscreteLookup>
 """,
          {'P1': common.IntParameter(678, 1)}, 10),
-        ("""
-<xtce:DiscreteLookup value="10" xmlns:xtce="http://www.omg.org/space/xtce">
+        (f"""
+<xtce:DiscreteLookup value="10" xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:Comparison useCalibratedValue="false" parameterRef="P1" value="1"/>
 </xtce:DiscreteLookup>
 """,
          {'P1': common.IntParameter(678, 0)}, None),
-        ("""
-<xtce:DiscreteLookup value="11" xmlns:xtce="http://www.omg.org/space/xtce">
+        (f"""
+<xtce:DiscreteLookup value="11" xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:ComparisonList>
         <xtce:Comparison comparisonOperator="&gt;=" value="678" parameterRef="MSN__PARAM1"/>
         <xtce:Comparison comparisonOperator="&lt;" value="4096" parameterRef="MSN__PARAM2"/>
@@ -302,13 +299,12 @@ def test_boolean_expression(elmaker, xml_string, test_parsed_data, expected_resu
          }, 11),
     ]
 )
-def test_discrete_lookup(elmaker, xml_string, test_parsed_data, expected_lookup_result):
+def test_discrete_lookup(elmaker, xtce_parser, xml_string, test_parsed_data, expected_lookup_result):
     """Test DiscreteLookup object"""
-    element = ElementTree.fromstring(xml_string)
-    discrete_lookup = comparisons.DiscreteLookup.from_xml(element, ns=XTCE_NSMAP)
+    element = ElementTree.fromstring(xml_string, parser=xtce_parser)
+    discrete_lookup = comparisons.DiscreteLookup.from_xml(element)
     assert discrete_lookup.evaluate(test_parsed_data, current_parsed_value=None) == expected_lookup_result
     # Recover XML and re-parse it to check it's reproducible
     result_string = ElementTree.tostring(discrete_lookup.to_xml(elmaker=elmaker), pretty_print=True).decode()
-    full_circle = comparisons.DiscreteLookup.from_xml(ElementTree.fromstring(result_string),
-                                                      ns=XTCE_NSMAP)
+    full_circle = comparisons.DiscreteLookup.from_xml(ElementTree.fromstring(result_string, parser=xtce_parser))
     assert full_circle.evaluate(test_parsed_data) == expected_lookup_result

--- a/tests/unit/test_xtce/test_parameter_types.py
+++ b/tests/unit/test_xtce/test_parameter_types.py
@@ -2,14 +2,14 @@
 import pytest
 import lxml.etree as ElementTree
 
-from space_packet_parser.xtce import XTCE_NSMAP, parameter_types, encodings, calibrators
+from space_packet_parser.xtce import XTCE_1_2_XMLNS, parameter_types, encodings, calibrators
 
 
 @pytest.mark.parametrize(
     ('xml_string', 'expectation'),
     [
-        ("""
-<xtce:StringParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_STRING_Type">
+        (f"""
+<xtce:StringParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_STRING_Type">
     <xtce:UnitSet/>
     <xtce:StringDataEncoding>
         <xtce:SizeInBits>
@@ -22,8 +22,8 @@ from space_packet_parser.xtce import XTCE_NSMAP, parameter_types, encodings, cal
 """,
          parameter_types.StringParameterType(name='TEST_STRING_Type',
                                                                       encoding=encodings.StringDataEncoding(fixed_raw_length=40))),
-        ("""
-<xtce:StringParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_STRING_Type">
+        (f"""
+<xtce:StringParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_STRING_Type">
     <xtce:StringDataEncoding>
         <xtce:SizeInBits>
             <xtce:Fixed>
@@ -37,8 +37,8 @@ from space_packet_parser.xtce import XTCE_NSMAP, parameter_types, encodings, cal
          parameter_types.StringParameterType(name='TEST_STRING_Type',
                                                                       encoding=encodings.StringDataEncoding(fixed_raw_length=40,
                                                                               leading_length_size=17))),
-        ("""
-<xtce:StringParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_STRING_Type">
+        (f"""
+<xtce:StringParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_STRING_Type">
     <xtce:StringDataEncoding>
         <xtce:SizeInBits>
             <xtce:Fixed>
@@ -54,28 +54,27 @@ from space_packet_parser.xtce import XTCE_NSMAP, parameter_types, encodings, cal
                                                                               termination_character='00'))),
     ]
 )
-def test_string_parameter_type(elmaker, xml_string: str, expectation):
+def test_string_parameter_type(elmaker, xtce_parser, xml_string: str, expectation):
     """Test parsing an StringParameterType from an XML string"""
-    element = ElementTree.fromstring(xml_string)
+    element = ElementTree.fromstring(xml_string, xtce_parser)
 
     if isinstance(expectation, Exception):
         with pytest.raises(type(expectation)):
-            parameter_types.StringParameterType.from_xml(element, ns=XTCE_NSMAP)
+            parameter_types.StringParameterType.from_xml(element)
     else:
-        result = parameter_types.StringParameterType.from_xml(element, ns=XTCE_NSMAP)
+        result = parameter_types.StringParameterType.from_xml(element)
         assert result == expectation
         # Recover XML and re-parse it to check it's recoverable
         result_string = ElementTree.tostring(result.to_xml(elmaker=elmaker), pretty_print=True).decode()
-        full_circle = parameter_types.StringParameterType.from_xml(ElementTree.fromstring(result_string),
-                                                                                            ns=XTCE_NSMAP)
+        full_circle = parameter_types.StringParameterType.from_xml(ElementTree.fromstring(result_string, parser=xtce_parser))
         assert full_circle == expectation
 
 
 @pytest.mark.parametrize(
     ('xml_string', 'expectation'),
     [
-        ("""
-<xtce:IntegerParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_INT_Type">
+        (f"""
+<xtce:IntegerParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_INT_Type">
     <xtce:UnitSet>
         <xtce:Unit>m/s</xtce:Unit>
     </xtce:UnitSet>
@@ -84,8 +83,8 @@ def test_string_parameter_type(elmaker, xml_string: str, expectation):
 """,
          parameter_types.IntegerParameterType(name='TEST_INT_Type', unit='m/s',
                                                                        encoding=encodings.IntegerDataEncoding(size_in_bits=16, encoding='unsigned'))),
-        ("""
-<xtce:IntegerParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_INT_Type">
+        (f"""
+<xtce:IntegerParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_INT_Type">
     <xtce:UnitSet>
         <xtce:Unit>m/s</xtce:Unit>
     </xtce:UnitSet>
@@ -109,8 +108,8 @@ def test_string_parameter_type(elmaker, xml_string: str, expectation):
                                                  calibrators.PolynomialCoefficient(-0.185486, 2)
                                              ])
                                          ))),
-        ("""
-<xtce:IntegerParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_INT_Type">
+        (f"""
+<xtce:IntegerParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_INT_Type">
     <xtce:UnitSet>
         <xtce:Unit>m/s</xtce:Unit>
     </xtce:UnitSet>
@@ -138,29 +137,28 @@ def test_string_parameter_type(elmaker, xml_string: str, expectation):
                                              )))),
     ]
 )
-def test_integer_parameter_type(elmaker, xml_string: str, expectation):
+def test_integer_parameter_type(elmaker, xtce_parser, xml_string: str, expectation):
     """Test parsing an IntegerParameterType from an XML string"""
-    element = ElementTree.fromstring(xml_string)
+    element = ElementTree.fromstring(xml_string, xtce_parser)
 
     if isinstance(expectation, Exception):
         with pytest.raises(type(expectation)):
-            parameter_types.IntegerParameterType.from_xml(element, ns=XTCE_NSMAP)
+            parameter_types.IntegerParameterType.from_xml(element)
     else:
-        result = parameter_types.IntegerParameterType.from_xml(element, ns=XTCE_NSMAP)
+        result = parameter_types.IntegerParameterType.from_xml(element)
         assert result == expectation
         # Recover XML and re-parse it to check it's recoverable
         result_string = ElementTree.tostring(result.to_xml(elmaker=elmaker), pretty_print=True).decode()
         full_circle = parameter_types.IntegerParameterType.from_xml(
-            ElementTree.fromstring(result_string),
-            ns=XTCE_NSMAP)
+            ElementTree.fromstring(result_string, parser=xtce_parser))
         assert full_circle == expectation
 
 
 @pytest.mark.parametrize(
     ('xml_string', 'expectation'),
     [
-        ("""
-<xtce:FloatParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_INT_Type">
+        (f"""
+<xtce:FloatParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_INT_Type">
     <xtce:UnitSet>
         <xtce:Unit>m/s</xtce:Unit>
     </xtce:UnitSet>
@@ -169,8 +167,8 @@ def test_integer_parameter_type(elmaker, xml_string: str, expectation):
 """,
          parameter_types.FloatParameterType(name='TEST_INT_Type', unit='m/s',
                                                                      encoding=encodings.FloatDataEncoding(size_in_bits=16, encoding='IEEE754'))),
-        ("""
-<xtce:FloatParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_INT_Type">
+        (f"""
+<xtce:FloatParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_INT_Type">
     <xtce:UnitSet>
         <xtce:Unit>m/s</xtce:Unit>
     </xtce:UnitSet>
@@ -179,8 +177,8 @@ def test_integer_parameter_type(elmaker, xml_string: str, expectation):
 """,
          parameter_types.FloatParameterType(name='TEST_INT_Type', unit='m/s',
                                                                      encoding=encodings.IntegerDataEncoding(size_in_bits=16, encoding='unsigned'))),
-        ("""
-<xtce:FloatParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_INT_Type">
+        (f"""
+<xtce:FloatParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_INT_Type">
     <xtce:UnitSet>
         <xtce:Unit>m/s</xtce:Unit>
     </xtce:UnitSet>
@@ -204,8 +202,8 @@ def test_integer_parameter_type(elmaker, xml_string: str, expectation):
                                                calibrators.PolynomialCoefficient(-0.185486, 2)
                                            ])
                                        ))),
-        ("""
-<xtce:FloatParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_INT_Type">
+        (f"""
+<xtce:FloatParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_INT_Type">
     <xtce:UnitSet>
         <xtce:Unit>m/s</xtce:Unit>
     </xtce:UnitSet>
@@ -233,29 +231,28 @@ def test_integer_parameter_type(elmaker, xml_string: str, expectation):
                                            )))),
     ]
 )
-def test_float_parameter_type(elmaker, xml_string: str, expectation):
+def test_float_parameter_type(elmaker, xtce_parser, xml_string: str, expectation):
     """Test parsing an FloatParameterType from an XML string"""
-    element = ElementTree.fromstring(xml_string)
+    element = ElementTree.fromstring(xml_string, xtce_parser)
 
     if isinstance(expectation, Exception):
         with pytest.raises(type(expectation)):
-            parameter_types.FloatParameterType.from_xml(element, ns=XTCE_NSMAP)
+            parameter_types.FloatParameterType.from_xml(element)
     else:
-        result = parameter_types.FloatParameterType.from_xml(element, ns=XTCE_NSMAP)
+        result = parameter_types.FloatParameterType.from_xml(element)
         assert result == expectation
         # Recover XML and re-parse it to check it's recoverable
         result_string = ElementTree.tostring(result.to_xml(elmaker=elmaker), pretty_print=True).decode()
         full_circle = parameter_types.FloatParameterType.from_xml(
-            ElementTree.fromstring(result_string),
-            ns=XTCE_NSMAP)
+            ElementTree.fromstring(result_string, parser=xtce_parser))
         assert full_circle == expectation
 
 
 @pytest.mark.parametrize(
     ('xml_string', 'expectation'),
     [
-        ("""
-<xtce:EnumeratedParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_ENUM_Type">
+        (f"""
+<xtce:EnumeratedParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_ENUM_Type">
     <xtce:UnitSet/>
     <xtce:IntegerDataEncoding sizeInBits="2" encoding="unsigned"/>
     <xtce:EnumerationList>
@@ -272,8 +269,8 @@ def test_float_parameter_type(elmaker, xml_string: str, expectation):
                                                                           # NOTE: Duplicate final value is on purpose to make sure we handle that case
                                                                           enumeration={0: 'BOOT_POR', 1: 'BOOT_RETURN', 2: 'OP_LOW', 3: 'OP_HIGH',
                                                          4: 'OP_HIGH'})),
-        ("""
-<xtce:EnumeratedParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_ENUM_Type">
+        (f"""
+<xtce:EnumeratedParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_ENUM_Type">
     <xtce:UnitSet/>
     <xtce:FloatDataEncoding sizeInBits="32" encoding="IEEE754"/>
     <xtce:EnumerationList>
@@ -290,8 +287,8 @@ def test_float_parameter_type(elmaker, xml_string: str, expectation):
                                                                           # NOTE: Duplicate final value is on purpose to make sure we handle that case
                                                                           enumeration={0.0: 'BOOT_POR', 1.1: 'BOOT_RETURN', 2.2: 'OP_LOW', 3.3: 'OP_HIGH',
                                                          4.4: 'OP_HIGH'})),
-        ("""
-<xtce:EnumeratedParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_ENUM_Type">
+        (f"""
+<xtce:EnumeratedParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_ENUM_Type">
     <xtce:UnitSet/>
     <xtce:StringDataEncoding>
         <xtce:SizeInBits>
@@ -317,8 +314,8 @@ def test_float_parameter_type(elmaker, xml_string: str, expectation):
                                                          b"CC": 'OP_LOW',
                                                          b"DD": 'OP_HIGH',
                                                          b"EE": 'OP_HIGH'})),
-        ("""
-<xtce:EnumeratedParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_ENUM_Type">
+        (f"""
+<xtce:EnumeratedParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_ENUM_Type">
     <xtce:UnitSet/>
     <xtce:StringDataEncoding encoding="UTF-16BE">
         <xtce:SizeInBits>
@@ -346,29 +343,28 @@ def test_float_parameter_type(elmaker, xml_string: str, expectation):
                                                          b"\x00E\x00E": 'OP_HIGH'})),
     ]
 )
-def test_enumerated_parameter_type(elmaker, xml_string: str, expectation):
+def test_enumerated_parameter_type(elmaker, xtce_parser, xml_string: str, expectation):
     """Test parsing an EnumeratedParameterType from an XML string"""
-    element = ElementTree.fromstring(xml_string)
+    element = ElementTree.fromstring(xml_string, xtce_parser)
 
     if isinstance(expectation, Exception):
         with pytest.raises(type(expectation)):
-            parameter_types.EnumeratedParameterType.from_xml(element, ns=XTCE_NSMAP)
+            parameter_types.EnumeratedParameterType.from_xml(element)
     else:
-        result = parameter_types.EnumeratedParameterType.from_xml(element, ns=XTCE_NSMAP)
+        result = parameter_types.EnumeratedParameterType.from_xml(element)
         assert result == expectation
         # Recover XML and re-parse it to check it's recoverable
         result_string = ElementTree.tostring(result.to_xml(elmaker=elmaker), pretty_print=True).decode()
         full_circle = parameter_types.EnumeratedParameterType.from_xml(
-            ElementTree.fromstring(result_string),
-            ns=XTCE_NSMAP)
+            ElementTree.fromstring(result_string, parser=xtce_parser))
         assert full_circle == expectation
 
 
 @pytest.mark.parametrize(
     ('xml_string', 'expectation'),
     [
-        ("""
-<xtce:BinaryParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_PARAM_Type">
+        (f"""
+<xtce:BinaryParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_PARAM_Type">
     <xtce:UnitSet>
         <xtce:Unit>m/s</xtce:Unit>
     </xtce:UnitSet>
@@ -381,8 +377,8 @@ def test_enumerated_parameter_type(elmaker, xml_string: str, expectation):
 """,
          parameter_types.BinaryParameterType(name='TEST_PARAM_Type', unit='m/s',
                                                                       encoding=encodings.BinaryDataEncoding(fixed_size_in_bits=256))),
-        ("""
-<xtce:BinaryParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_PARAM_Type">
+        (f"""
+<xtce:BinaryParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_PARAM_Type">
     <xtce:UnitSet/>
     <xtce:BinaryDataEncoding>
         <xtce:SizeInBits>
@@ -393,8 +389,8 @@ def test_enumerated_parameter_type(elmaker, xml_string: str, expectation):
 """,
          parameter_types.BinaryParameterType(name='TEST_PARAM_Type', unit=None,
                                                                       encoding=encodings.BinaryDataEncoding(fixed_size_in_bits=128))),
-        ("""
-<xtce:BinaryParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_PARAM_Type">
+        (f"""
+<xtce:BinaryParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_PARAM_Type">
     <xtce:UnitSet/>
     <xtce:BinaryDataEncoding>
         <xtce:SizeInBits>
@@ -411,8 +407,8 @@ def test_enumerated_parameter_type(elmaker, xml_string: str, expectation):
                                             size_reference_parameter='SizeFromThisParameter',
                                             use_calibrated_value=False,
                                             linear_adjuster=lambda x: x))),
-        ("""
-<xtce:BinaryParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_PARAM_Type">
+        (f"""
+<xtce:BinaryParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_PARAM_Type">
     <xtce:UnitSet/>
     <xtce:BinaryDataEncoding>
         <xtce:SizeInBits>
@@ -428,29 +424,28 @@ def test_enumerated_parameter_type(elmaker, xml_string: str, expectation):
                                             size_reference_parameter='SizeFromThisParameter'))),
     ]
 )
-def test_binary_parameter_type(elmaker, xml_string: str, expectation):
+def test_binary_parameter_type(elmaker, xtce_parser, xml_string: str, expectation):
     """Test parsing an BinaryParameterType from an XML string"""
-    element = ElementTree.fromstring(xml_string)
+    element = ElementTree.fromstring(xml_string, xtce_parser)
 
     if isinstance(expectation, Exception):
         with pytest.raises(type(expectation)):
-            parameter_types.BinaryParameterType.from_xml(element, ns=XTCE_NSMAP)
+            parameter_types.BinaryParameterType.from_xml(element)
     else:
-        result = parameter_types.BinaryParameterType.from_xml(element, ns=XTCE_NSMAP)
+        result = parameter_types.BinaryParameterType.from_xml(element)
         assert result == expectation
         # Recover XML and re-parse it to check it's recoverable
         result_string = ElementTree.tostring(result.to_xml(elmaker=elmaker), pretty_print=True).decode()
         full_circle = parameter_types.BinaryParameterType.from_xml(
-            ElementTree.fromstring(result_string),
-            ns=XTCE_NSMAP)
+            ElementTree.fromstring(result_string, parser=xtce_parser))
         assert full_circle == expectation
 
 
 @pytest.mark.parametrize(
     ('xml_string', 'expectation'),
     [
-        ("""
-<xtce:BooleanParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_PARAM_Type">
+        (f"""
+<xtce:BooleanParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_PARAM_Type">
     <xtce:UnitSet>
         <xtce:Unit>m/s</xtce:Unit>
     </xtce:UnitSet>
@@ -463,8 +458,8 @@ def test_binary_parameter_type(elmaker, xml_string: str, expectation):
 """,
          parameter_types.BooleanParameterType(name='TEST_PARAM_Type', unit='m/s',
                                                                        encoding=encodings.BinaryDataEncoding(fixed_size_in_bits=1))),
-        ("""
-<xtce:BooleanParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_PARAM_Type">
+        (f"""
+<xtce:BooleanParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_PARAM_Type">
     <xtce:UnitSet>
         <xtce:Unit>m/s</xtce:Unit>
     </xtce:UnitSet>
@@ -473,8 +468,8 @@ def test_binary_parameter_type(elmaker, xml_string: str, expectation):
 """,
          parameter_types.BooleanParameterType(name='TEST_PARAM_Type', unit='m/s',
                                                                        encoding=encodings.IntegerDataEncoding(size_in_bits=1, encoding="unsigned"))),
-        ("""
-<xtce:BooleanParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_PARAM_Type">
+        (f"""
+<xtce:BooleanParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_PARAM_Type">
     <xtce:UnitSet>
         <xtce:Unit>m/s</xtce:Unit>
     </xtce:UnitSet>
@@ -493,29 +488,28 @@ def test_binary_parameter_type(elmaker, xml_string: str, expectation):
                                                                                termination_character='00'))),
     ]
 )
-def test_boolean_parameter_type(elmaker, xml_string, expectation):
+def test_boolean_parameter_type(elmaker, xtce_parser, xml_string, expectation):
     """Test parsing a BooleanParameterType from an XML string"""
-    element = ElementTree.fromstring(xml_string)
+    element = ElementTree.fromstring(xml_string, xtce_parser)
 
     if isinstance(expectation, Exception):
         with pytest.raises(type(expectation)):
-            parameter_types.BooleanParameterType.from_xml(element, ns=XTCE_NSMAP)
+            parameter_types.BooleanParameterType.from_xml(element)
     else:
-        result = parameter_types.BooleanParameterType.from_xml(element, ns=XTCE_NSMAP)
+        result = parameter_types.BooleanParameterType.from_xml(element)
         assert result == expectation
         # Recover XML and re-parse it to check it's recoverable
         result_string = ElementTree.tostring(result.to_xml(elmaker=elmaker), pretty_print=True).decode()
         full_circle = parameter_types.BooleanParameterType.from_xml(
-            ElementTree.fromstring(result_string),
-            ns=XTCE_NSMAP)
+            ElementTree.fromstring(result_string, parser=xtce_parser))
         assert full_circle == expectation
 
 
 @pytest.mark.parametrize(
     ('xml_string', 'expectation'),
     [
-        ("""
-<xtce:AbsoluteTimeParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_PARAM_Type">
+        (f"""
+<xtce:AbsoluteTimeParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_PARAM_Type">
     <xtce:Encoding units="seconds">
         <xtce:IntegerDataEncoding sizeInBits="32"/>
     </xtce:Encoding>
@@ -529,8 +523,8 @@ def test_boolean_parameter_type(elmaker, xml_string, expectation):
                                                                             encoding=encodings.IntegerDataEncoding(size_in_bits=32,
                                                                                      encoding="unsigned"),
                                                                             epoch="TAI", offset_from="MilliSeconds")),
-        ("""
-<xtce:AbsoluteTimeParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_PARAM_Type">
+        (f"""
+<xtce:AbsoluteTimeParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_PARAM_Type">
     <xtce:Encoding scale="1E-6" offset="0" units="s">
         <xtce:IntegerDataEncoding sizeInBits="32"/>
     </xtce:Encoding>
@@ -550,8 +544,8 @@ def test_boolean_parameter_type(elmaker, xml_string, expectation):
                          calibrators.PolynomialCoefficient(1E-6, 1)
                      ])),
              epoch="2009-10-10T12:00:00-05:00", offset_from="MilliSeconds")),
-        ("""
-<xtce:AbsoluteTimeParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_PARAM_Type">
+        (f"""
+<xtce:AbsoluteTimeParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_PARAM_Type">
     <xtce:Encoding scale="1.31E-6" units="s">
         <xtce:IntegerDataEncoding sizeInBits="32"/>
     </xtce:Encoding>
@@ -566,8 +560,8 @@ def test_boolean_parameter_type(elmaker, xml_string, expectation):
                          calibrators.PolynomialCoefficient(1.31E-6, 1)
                      ]))
          )),
-        ("""
-<xtce:AbsoluteTimeParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_PARAM_Type">
+        (f"""
+<xtce:AbsoluteTimeParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_PARAM_Type">
     <xtce:Encoding offset="147.884" units="s">
         <xtce:IntegerDataEncoding sizeInBits="32"/>
     </xtce:Encoding>
@@ -583,8 +577,8 @@ def test_boolean_parameter_type(elmaker, xml_string, expectation):
                          calibrators.PolynomialCoefficient(1, 1)
                      ]))
          )),
-        ("""
-<xtce:AbsoluteTimeParameterType xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_PARAM_Type">
+        (f"""
+<xtce:AbsoluteTimeParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_PARAM_Type">
     <xtce:Encoding offset="147.884" units="s">
         <xtce:FloatDataEncoding sizeInBits="32"/>
     </xtce:Encoding>
@@ -602,21 +596,20 @@ def test_boolean_parameter_type(elmaker, xml_string, expectation):
          )),
     ]
 )
-def test_absolute_time_parameter_type(elmaker, xml_string, expectation):
+def test_absolute_time_parameter_type(elmaker, xtce_parser, xml_string, expectation):
     """Test parsing an AbsoluteTimeParameterType from an XML string."""
-    element = ElementTree.fromstring(xml_string)
+    element = ElementTree.fromstring(xml_string, xtce_parser)
 
     if isinstance(expectation, Exception):
         with pytest.raises(type(expectation)):
-            parameter_types.AbsoluteTimeParameterType.from_xml(element, ns=XTCE_NSMAP)
+            parameter_types.AbsoluteTimeParameterType.from_xml(element)
     else:
-        result = parameter_types.AbsoluteTimeParameterType.from_xml(element, ns=XTCE_NSMAP)
+        result = parameter_types.AbsoluteTimeParameterType.from_xml(element)
         assert result == expectation
         # Recover XML and re-parse it to check it's recoverable
         result_string = ElementTree.tostring(result.to_xml(elmaker=elmaker), pretty_print=True).decode()
         full_circle = parameter_types.AbsoluteTimeParameterType.from_xml(
-            ElementTree.fromstring(result_string),
-            ns=XTCE_NSMAP)
+            ElementTree.fromstring(result_string, parser=xtce_parser))
         assert full_circle == expectation
 
 

--- a/tests/unit/test_xtce/test_parameters.py
+++ b/tests/unit/test_xtce/test_parameters.py
@@ -6,14 +6,14 @@ import lxml.etree as ElementTree
 
 import space_packet_parser.xtce.parameter_types
 from space_packet_parser import common, packets
-from space_packet_parser.xtce import parameters, encodings, comparisons, calibrators, definitions, XTCE_NSMAP
+from space_packet_parser.xtce import XTCE_1_2_XMLNS, parameters, encodings, comparisons, calibrators, definitions
 
 
 def test_invalid_parameter_type_error(test_data_dir):
     """Test proper reporting of an invalid parameter type element"""
     # Test document contains an invalid "InvalidParameterType" element
-    test_xtce_document = """<?xml version='1.0' encoding='UTF-8'?>
-<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="Space Packet Parser"
+    test_xtce_document = f"""<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="{XTCE_1_2_XMLNS}" name="Space Packet Parser"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd">
     <xtce:Header date="2024-03-05T13:36:00MST" version="1.0" author="Gavin Medley"/>
@@ -45,8 +45,8 @@ def test_invalid_parameter_type_error(test_data_dir):
 def test_unsupported_parameter_type_error(test_data_dir):
     """Test proper reporting of an unsupported parameter type element"""
     # Test document contains an unsupported array parameter type that is not yet implemented
-    test_xtce_document = """<?xml version='1.0' encoding='UTF-8'?>
-<xtce:SpaceSystem xmlns:xtce="http://www.omg.org/space/xtce" name="Space Packet Parser"
+    test_xtce_document = f"""<?xml version='1.0' encoding='UTF-8'?>
+<xtce:SpaceSystem xmlns:xtce="{XTCE_1_2_XMLNS}" name="Space Packet Parser"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd">
     <xtce:Header date="2024-03-05T13:36:00MST" version="1.0" author="Gavin Medley"/>
@@ -647,8 +647,8 @@ def test_absolute_time_parameter_parsing(parameter_type, raw_data, current_pos, 
 @pytest.mark.parametrize(
     ("param_xml", "param_object"),
     [
-        ("""
-<xtce:Parameter xmlns:xtce="http://www.omg.org/space/xtce" name="TEST_INT" parameterTypeRef="TEST_INT_Type" shortDescription="Param short desc">
+        (f"""
+<xtce:Parameter xmlns:xtce="{XTCE_1_2_XMLNS}" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="TEST_INT" parameterTypeRef="TEST_INT_Type" shortDescription="Param short desc">
   <xtce:LongDescription>This is a long description of the parameter</xtce:LongDescription>
 </xtce:Parameter>
 """,
@@ -662,6 +662,6 @@ def test_absolute_time_parameter_parsing(parameter_type, raw_data, current_pos, 
          )
     ]
 )
-def test_parameter(elmaker, param_xml, param_object):
+def test_parameter(elmaker, xtce_parser, param_xml, param_object):
     """Test Parameter"""
-    assert ElementTree.tostring(param_object.to_xml(elmaker=elmaker), pretty_print=True) == ElementTree.tostring(ElementTree.fromstring(param_xml), pretty_print=True)
+    assert ElementTree.tostring(param_object.to_xml(elmaker=elmaker), pretty_print=True) == ElementTree.tostring(ElementTree.fromstring(param_xml, parser=xtce_parser), pretty_print=True)


### PR DESCRIPTION
- Avoid passing namespace dicts down through all from_xml methods in favor of predefining a custom Element class that contains the namespace
- Convert internal parameter types, parameters, and containers to set objects with read only dict accessor properties.
- Increase performance by minimizing broad XML find and findall calls.

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
