### PR TITLE
CI: Remove explicit linting job and use precommit.ci instead

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,19 +9,6 @@ on:
     - cron: '50 23 * * *'  # 11:50pm daily (to get ahead of all those midnight jobs)
 
 jobs:
-
-  linting:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-      - name: Install pre-commit
-        run: pip install pre-commit
-      - name: Run pre-commit
-        run: |
-          pre-commit install
-          pre-commit run --all
-
   ci-tests:
     runs-on: ${{ matrix.os }}
     permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ci:
   autofix_prs: false
   autoupdate_schedule: 'quarterly'
+  skip: [no-commit-to-branch]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 ci:
   autofix_prs: false
   autoupdate_schedule: 'quarterly'
-  skip: [poetry-lock]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ build:
   jobs:
     post_create_environment:
       # Install poetry
-      - pip install poetry
+      - pip install poetry==2.0.1
       # Tell poetry to not create a new virtual environment but use the current one
       - poetry config virtualenvs.create false
     post_install:


### PR DESCRIPTION
The current merge to main failed because it ran "no commit to a branch named main". I enabled pre-commit.ci service so that will do the linting checks for us now as a separate action. (we could remove that check to fix this too)