### PR TITLE
MNT: Add backcompat shim to ease transition to new packet file loading

### DIFF
--- a/space_packet_parser/__init__.py
+++ b/space_packet_parser/__init__.py
@@ -2,10 +2,10 @@
 from pathlib import Path
 from typing import Union
 
-from space_packet_parser.xtce import definitions
+from space_packet_parser.xtce.definitions import XtcePacketDefinition
 
 
-def load_xml(filename: Union[str, Path]) -> definitions.XtcePacketDefinition:
+def load_xml(filename: Union[str, Path]) -> XtcePacketDefinition:
     """Create an XtcePacketDefinition object from an XTCE XML file
 
     Parameters
@@ -17,4 +17,4 @@ def load_xml(filename: Union[str, Path]) -> definitions.XtcePacketDefinition:
     -------
     : definitions.XtcePacketDefinition
     """
-    return definitions.XtcePacketDefinition.from_xtce(filename)
+    return XtcePacketDefinition.from_xtce(filename)

--- a/space_packet_parser/definitions.py
+++ b/space_packet_parser/definitions.py
@@ -1,0 +1,17 @@
+# NOTE: This entire file is deprecated and here just to maintain backwards compatibility.
+# The functionality has been moved to space_packet_parser.xtce.definitions.XtcePacketDefinition
+import warnings
+
+from space_packet_parser.xtce import definitions
+
+warnings.warn("The space_packet_parser.definitions module is deprecated. "
+              "Use space_packet_parser.xtce.definitions instead (nested under xtce now).")
+
+
+class XtcePacketDefinition(definitions.XtcePacketDefinition):
+    def __init__(self, xtce_document, **kwargs):
+        warnings.warn("This class is deprecated. To load a packet definition from a file "
+                      "use space_packet_parser.load_xml() or "
+                      "space_packet_parser.xtce.definitions.XtcePacketDefinition.from_xtce() instead.")
+        other = definitions.XtcePacketDefinition.from_xtce(xtce_document)
+        self.__dict__.update(other.__dict__)

--- a/tests/benchmark/test_xtce_parsing_benchmarks.py
+++ b/tests/benchmark/test_xtce_parsing_benchmarks.py
@@ -1,7 +1,7 @@
 """Benchmark test for how fast we can parse a large XTCE definition file"""
 import pytest
 
-from space_packet_parser import definitions
+from space_packet_parser.xtce import definitions
 
 
 @pytest.mark.benchmark

--- a/tests/unit/test_xtce/test_definitions.py
+++ b/tests/unit/test_xtce/test_definitions.py
@@ -497,3 +497,14 @@ def test_uniqueness_of_reused_sequence_container(jpss_test_data_dir):
     assert unused_secondary_header_container_ref in jpss_definition.containers.values()
     assert jpss_att_ephem_header_container_ref in jpss_definition.containers.values()
     assert unused_secondary_header_container_ref is jpss_att_ephem_header_container_ref
+
+
+def test_deprecated_definition_class(test_data_dir):
+    """Test that the deprecated XtcePacketDefinition class still works"""
+    with pytest.warns(UserWarning, match="The space_packet_parser.definitions module is deprecated"):
+        from space_packet_parser.definitions import XtcePacketDefinition as DeprecatedXtcePacketDefinition
+
+    with pytest.warns(UserWarning, match="This class is deprecated"):
+        xtce = DeprecatedXtcePacketDefinition(test_data_dir / "test_xtce.xml")
+    assert xtce.containers == definitions.XtcePacketDefinition.from_xtce(test_data_dir / "test_xtce.xml").containers
+


### PR DESCRIPTION
When I was trying to profile things across versions, it got a little annoying to comment/uncomment lines of files for the different loading XTCE patterns. This adds a small shim layer for the old `XtcePacketDefinition` format that then warns and suggests how to transition to the new patterns, still working the same as previously.