### PR TITLE
PERF: Use direct bitshift logic instead of _extract_bits function

### DIFF
--- a/space_packet_parser/packets.py
+++ b/space_packet_parser/packets.py
@@ -97,7 +97,7 @@ class RawPacketData(bytes):
         Section 4.1.3.5.3 The length count C shall be expressed as:
         C = (Total Number of Octets in the Packet Data Field) – 1
         """
-        return (self[4] << 8) | self[5] + 1
+        return (self[4] << 8) | self[5]
 
     @cached_property
     def header_values(self) -> tuple[int, ...]:


### PR DESCRIPTION
int.from_bytes() is about 2x slower than a direct bitshift of two values, and we avoid some other checks as well.

```
python -m timeit "b=b'\x01\x02\x03\x04\x05\x06'*100; int.from_bytes(b[-2:], 'big')" 
5000000 loops, best of 5: 80.2 nsec per loop

python -m timeit "b=b'\x01\x02\x03\x04\x05\x06'*100; (b[-2] << 8) | b[-1]"
5000000 loops, best of 5: 47.8 nsec per loop
```