### PR TITLE
Improve unit test coverage

### DIFF
--- a/space_packet_parser/xarr.py
+++ b/space_packet_parser/xarr.py
@@ -17,7 +17,7 @@ from space_packet_parser.xtce import definitions, encodings, parameter_types
 
 
 def _min_dtype_for_encoding(data_encoding: encodings.DataEncoding):
-    """Find the minimum data type capaable of representing an XTCE data encoding.
+    """Find the minimum data type capable of representing an XTCE data encoding.
 
     This only works for raw values and does not apply to calibrated or otherwise derived values.
 
@@ -91,6 +91,10 @@ def _get_minimum_numpy_datatype(
         # If we are using raw values, we can determine the minimal dtype from the parameter data encoding
         return _min_dtype_for_encoding(data_encoding)
 
+    if isinstance(parameter_type, parameter_types.EnumeratedParameterType):
+        # Enums are always strings in their derived state
+        return "str"
+
     if isinstance(data_encoding, encodings.NumericDataEncoding):
         if not (data_encoding.context_calibrators is not None or data_encoding.default_calibrator is not None):
             # If there are no calibrators attached to the encoding, then we can proceed as if we're using
@@ -102,10 +106,6 @@ def _get_minimum_numpy_datatype(
 
     if isinstance(data_encoding, encodings.BinaryDataEncoding):
         return "bytes"
-
-    if isinstance(parameter_type, parameter_types.EnumeratedParameterType):
-        # Enums are always strings in their derived state
-        return "str"
 
     if isinstance(data_encoding, encodings.StringDataEncoding):
         return "str"

--- a/space_packet_parser/xtce/definitions.py
+++ b/space_packet_parser/xtce/definitions.py
@@ -423,7 +423,7 @@ class XtcePacketDefinition(common.AttrComparable):
 
     def packet_generator(
             self,
-            binary_data: Union[BinaryIO, socket.socket],
+            binary_data: Union[BinaryIO, socket.socket, bytes],
             *,
             parse_bad_pkts: bool = True,
             root_container_name: Optional[str] = None,

--- a/tests/unit/test_xarr.py
+++ b/tests/unit/test_xarr.py
@@ -1,0 +1,99 @@
+"""Tests for the xarr.py extras module"""
+import pytest
+
+from space_packet_parser import xarr
+from space_packet_parser.xtce import calibrators, containers, definitions, encodings, parameter_types, parameters
+
+np = pytest.importorskip("numpy", reason="numpy is not available")
+
+
+@pytest.fixture
+def test_xtce():
+    """Test definition for testing surmising data types"""
+    container_set = [
+        containers.SequenceContainer(
+            "CONTAINER",
+            entry_list=[
+                parameters.Parameter(
+                    "INT32_PARAM",
+                    parameter_type=parameter_types.IntegerParameterType(
+                        "I32_TYPE",
+                        encoding=encodings.IntegerDataEncoding(size_in_bits=32, encoding="twosComplement")
+                    )
+                ),
+                parameters.Parameter(
+                    "F32_PARAM",
+                    parameter_type=parameter_types.FloatParameterType(
+                        "F32_TYPE",
+                        encoding=encodings.FloatDataEncoding(size_in_bits=32, encoding="IEEE754")
+                    )
+                ),
+                parameters.Parameter(
+                    "CAL_INT_PARAM",
+                    parameter_type=parameter_types.IntegerParameterType(
+                        "I32_TYPE",
+                        encoding=encodings.IntegerDataEncoding(
+                            size_in_bits=32,
+                            encoding="twosComplement",
+                            default_calibrator=calibrators.PolynomialCalibrator(
+                                coefficients=[
+                                    calibrators.PolynomialCoefficient(1, 1)
+                                ]
+                            )
+                        )
+                    )
+                ),
+                parameters.Parameter(
+                    "BIN_PARAM",
+                    parameter_type=parameter_types.BinaryParameterType(
+                        "BIN_TYPE",
+                        encoding=encodings.BinaryDataEncoding(
+                            fixed_size_in_bits=32
+                        )
+                    )
+                ),
+                parameters.Parameter(
+                    "INT_ENUM_PARAM",
+                    parameter_type=parameter_types.EnumeratedParameterType(
+                        "INT_ENUM_TYPE",
+                        encoding=encodings.IntegerDataEncoding(size_in_bits=8, encoding="unsigned"),
+                        enumeration={
+                            "ONE": 1,
+                            "TWO": 2
+                        }
+                    )
+                ),
+                parameters.Parameter(
+                    "STR_PARAM",
+                    parameter_type=parameter_types.StringParameterType(
+                        "STR_TYPE",
+                        encoding=encodings.StringDataEncoding(
+                            fixed_raw_length=32
+                        )
+                    )
+                ),
+            ]
+        )
+    ]
+    return definitions.XtcePacketDefinition(container_set=container_set)
+
+@pytest.mark.parametrize(
+    ("pname", "use_raw_value", "expected_dtype"),
+    [
+        ("INT32_PARAM", True, "int32"),
+        ("INT32_PARAM", False, "int32"),
+        ("F32_PARAM", False, "float32"),
+        ("F32_PARAM", True, "float32"),
+        ("CAL_INT_PARAM", True, "int32"),
+        ("CAL_INT_PARAM", False, None),
+        ("BIN_PARAM", True, "bytes"),
+        ("BIN_PARAM", False, "bytes"),
+        ("INT_ENUM_PARAM", True, "uint8"),
+        ("INT_ENUM_PARAM", False, "str"),
+        ("STR_PARAM", True, "str"),
+        ("STR_PARAM", False, "str"),
+    ]
+)
+def test_minimum_numpy_dtype(test_xtce, pname, use_raw_value, expected_dtype):
+    """Test finding the minimum numpy data type for a parameter"""
+    assert xarr._get_minimum_numpy_datatype(pname, test_xtce, use_raw_value) == expected_dtype

--- a/tests/unit/test_xtce/test_comparisons.py
+++ b/tests/unit/test_xtce/test_comparisons.py
@@ -4,6 +4,7 @@ import pytest
 
 from space_packet_parser import common
 from space_packet_parser.exceptions import ComparisonError
+from space_packet_parser.packets import CCSDSPacket
 from space_packet_parser.xtce import XTCE_1_2_XMLNS, comparisons
 
 
@@ -14,82 +15,82 @@ from space_packet_parser.xtce import XTCE_1_2_XMLNS, comparisons
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="==" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': common.FloatParameter(678, 3)}, None, True),
+         CCSDSPacket(**{'MSN__PARAM': common.FloatParameter(678, 3)}), None, True),
         (f"""
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="eq" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': common.FloatParameter(668, 3)}, None, False),
+         CCSDSPacket(**{'MSN__PARAM': common.FloatParameter(668, 3)}), None, False),
         (f"""
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="!=" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': common.FloatParameter(678, 3)}, None, False),
+         CCSDSPacket(**{'MSN__PARAM': common.FloatParameter(678, 3)}), None, False),
         (f"""
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="neq" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': common.FloatParameter(658, 3)}, None, True),
+         CCSDSPacket(**{'MSN__PARAM': common.FloatParameter(658, 3)}), None, True),
         (f"""
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="&lt;" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': common.FloatParameter(679, 3)}, None, False),
+         CCSDSPacket(**{'MSN__PARAM': common.FloatParameter(679, 3)}), None, False),
         (f"""
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="lt" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': common.FloatParameter(670, 3)}, None, True),
+         CCSDSPacket(**{'MSN__PARAM': common.FloatParameter(670, 3)}), None, True),
         (f"""
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="&gt;" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': common.FloatParameter(678, 3)}, None, False),
+         CCSDSPacket(**{'MSN__PARAM': common.FloatParameter(678, 3)}), None, False),
         (f"""
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="gt" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': common.FloatParameter(679, 3)}, None, True),
+         CCSDSPacket(**{'MSN__PARAM': common.FloatParameter(679, 3)}), None, True),
         (f"""
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="&lt;=" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': common.FloatParameter(660, 3)}, None, True),
+         CCSDSPacket(**{'MSN__PARAM': common.FloatParameter(660, 3)}), None, True),
         (f"""
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="leq" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': common.FloatParameter(690, 3)}, None, False),
+         CCSDSPacket(**{'MSN__PARAM': common.FloatParameter(690, 3)}), None, False),
         (f"""
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="&gt;=" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': common.FloatParameter(660, 3)}, None, False),
+         CCSDSPacket(**{'MSN__PARAM': common.FloatParameter(660, 3)}), None, False),
         (f"""
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="geq" value="678" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': common.FloatParameter(690, 3)}, None, True),
+         CCSDSPacket(**{'MSN__PARAM': common.FloatParameter(690, 3)}), None, True),
         (f"""
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="==" value="678" parameterRef="MSN__PARAM" useCalibratedValue="false"/>
 """,
-         {'MSN__PARAM': common.FloatParameter(690, 678)}, None, True),
+         CCSDSPacket(**{'MSN__PARAM': common.FloatParameter(690, 678)}), None, True),
         (f"""
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="==" value="678" parameterRef="MSN__PARAM" useCalibratedValue="true"/>
 """,
-         {'MSN__PARAM': common.FloatParameter(678, 3)}, None, True),
+         CCSDSPacket(**{'MSN__PARAM': common.FloatParameter(678, 3)}), None, True),
         (f"""
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="==" value="foostring" parameterRef="MSN__PARAM" useCalibratedValue="false"/>
 """,
-         {'MSN__PARAM': common.StrParameter('calibratedfoostring', 'foostring')}, None, True),
+         CCSDSPacket(**{'MSN__PARAM': common.StrParameter('calibratedfoostring', 'foostring')}), None, True),
         (f"""
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="==" value="3.14" parameterRef="MSN__PARAM"/>
 """,
-         {'MSN__PARAM': common.FloatParameter(3.14, 1)}, None, True),
+         CCSDSPacket(**{'MSN__PARAM': common.FloatParameter(3.14, 1)}), None, True),
         (f"""
 <xtce:Comparison xmlns:xtce="{XTCE_1_2_XMLNS}"
     comparisonOperator="==" value="3.0" parameterRef="REFERENCE_TO_OWN_RAW_VAL"/>
@@ -130,6 +131,16 @@ def test_comparison(elmaker, xtce_parser,
 
 
 @pytest.mark.parametrize(
+    ("args", "kwargs", "expected_error", "expected_error_msg"),
+    [(("3", "REFERENCE_TO_OWN_RAW_VAL", "~="), {}, ValueError, "Unrecognized operator syntax ~=")]
+)
+def test_comparison_validity_check(args, kwargs, expected_error, expected_error_msg):
+    """Test validation checks when creating a Comparison"""
+    with pytest.raises(expected_error, match=expected_error_msg):
+        comparisons.Comparison(*args, **kwargs)
+
+
+@pytest.mark.parametrize(
     ('xml_string', 'test_parsed_data', 'expected_condition_result'),
     [
         (f"""
@@ -139,8 +150,8 @@ def test_comparison(elmaker, xtce_parser,
     <xtce:ParameterInstanceRef parameterRef="P2"/>
 </xtce:Condition>
 """,
-         {'P1': common.IntParameter(700, 4),
-          'P2': common.IntParameter(678, 3)}, True),
+         CCSDSPacket(**{'P1': common.IntParameter(700, 4),
+          'P2': common.IntParameter(678, 3)}), True),
         (f"""
 <xtce:Condition xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:ParameterInstanceRef parameterRef="P1"/>
@@ -148,7 +159,7 @@ def test_comparison(elmaker, xtce_parser,
     <xtce:Value>4</xtce:Value>
 </xtce:Condition>
 """,
-         {'P1': common.IntParameter(700, 4)}, True),
+         CCSDSPacket(**{'P1': common.IntParameter(700, 4)}), True),
         (f"""
 <xtce:Condition xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:ParameterInstanceRef parameterRef="P1"/>
@@ -156,8 +167,8 @@ def test_comparison(elmaker, xtce_parser,
     <xtce:ParameterInstanceRef parameterRef="P2"/>
 </xtce:Condition>
 """,
-         {'P1': common.IntParameter(700, 4),
-          'P2': common.IntParameter(678, 3)}, False),
+         CCSDSPacket(**{'P1': common.IntParameter(700, 4),
+          'P2': common.IntParameter(678, 3)}), False),
         (f"""
 <xtce:Condition xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:ParameterInstanceRef parameterRef="P1" useCalibratedValue="false"/>
@@ -165,8 +176,8 @@ def test_comparison(elmaker, xtce_parser,
     <xtce:ParameterInstanceRef parameterRef="P2" useCalibratedValue="false"/>
 </xtce:Condition>
 """,
-         {'P1': common.StrParameter('abcd'),
-          'P2': common.StrParameter('abcd')}, True),
+         CCSDSPacket(**{'P1': common.StrParameter('abcd'),
+          'P2': common.StrParameter('abcd')}), True),
         (f"""
 <xtce:Condition xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:ParameterInstanceRef parameterRef="P1"/>
@@ -174,8 +185,8 @@ def test_comparison(elmaker, xtce_parser,
     <xtce:ParameterInstanceRef parameterRef="P2"/>
 </xtce:Condition>
 """,
-         {'P1': common.FloatParameter(3.14, 1),
-          'P2': common.FloatParameter(3.14, 180)}, True),
+         CCSDSPacket(**{'P1': common.FloatParameter(3.14, 1),
+          'P2': common.FloatParameter(3.14, 180)}), True),
     ]
 )
 def test_condition(elmaker, xtce_parser, xml_string, test_parsed_data, expected_condition_result):
@@ -187,6 +198,23 @@ def test_condition(elmaker, xtce_parser, xml_string, test_parsed_data, expected_
     result_string = ElementTree.tostring(condition.to_xml(elmaker=elmaker), pretty_print=True).decode()
     full_circle = comparisons.Condition.from_xml(ElementTree.fromstring(result_string, parser=xtce_parser))
     assert full_circle.evaluate(test_parsed_data) == expected_condition_result
+
+
+@pytest.mark.parametrize(
+    ("args", "kwargs", "expected_error", "expected_error_msg"),
+    [
+        (("X", "~="), {"right_value": "4"},
+         ValueError, "Unrecognized operator syntax ~="),
+        (("X", "=="), {"right_param": "R", "right_value": "1"},
+         comparisons.ComparisonError, "Received both a right_value and a right_param reference to Condition"),
+        (("X", "=="), {"right_value": "4", "right_use_calibrated_value": True},
+         comparisons.ComparisonError, "Unable to use calibrated form of a fixed value in Condition")
+    ]
+)
+def test_condition_validity_check(args, kwargs, expected_error, expected_error_msg):
+    """Test validation checks when creating a Condition"""
+    with pytest.raises(expected_error, match=expected_error_msg):
+        comparisons.Condition(*args, **kwargs)
 
 
 @pytest.mark.parametrize(
@@ -215,10 +243,10 @@ def test_condition(elmaker, xtce_parser, xml_string, test_parsed_data, expected_
     </xtce:ORedConditions>
 </xtce:BooleanExpression>
 """,
-         {'P': common.IntParameter(0, 4),
-          'P2': common.IntParameter(700, 4),
-          'P3': common.IntParameter(701, 4),
-          'P4': common.IntParameter(98, 4)}, True),
+         CCSDSPacket(**{'P': common.IntParameter(0, 4),
+                        'P2': common.IntParameter(700, 4),
+                        'P3': common.IntParameter(701, 4),
+                        'P4': common.IntParameter(98, 4)}), True),
         (f"""
 <xtce:BooleanExpression xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:ANDedConditions>
@@ -247,12 +275,12 @@ def test_condition(elmaker, xtce_parser, xml_string, test_parsed_data, expected_
     </xtce:ANDedConditions>
 </xtce:BooleanExpression>
 """,
-         {'P': common.IntParameter(100, 4),
-          'P0': common.IntParameter(678, 4),
-          'P1': common.IntParameter(500, 4),
-          'P2': common.IntParameter(700, 4),
-          'P3': common.IntParameter(701, 4),
-          'P4': common.IntParameter(99, 4)}, True),
+         CCSDSPacket(**{'P': common.IntParameter(100, 4),
+                        'P0': common.IntParameter(678, 4),
+                        'P1': common.IntParameter(500, 4),
+                        'P2': common.IntParameter(700, 4),
+                        'P3': common.IntParameter(701, 4),
+                        'P4': common.IntParameter(99, 4)}), True),
     ]
 )
 def test_boolean_expression(elmaker, xtce_parser, xml_string, test_parsed_data, expected_result):
@@ -278,13 +306,13 @@ def test_boolean_expression(elmaker, xtce_parser, xml_string, test_parsed_data, 
     <xtce:Comparison useCalibratedValue="false" parameterRef="P1" value="1"/>
 </xtce:DiscreteLookup>
 """,
-         {'P1': common.IntParameter(678, 1)}, 10),
+         CCSDSPacket(**{'P1': common.IntParameter(678, 1)}), 10),
         (f"""
 <xtce:DiscreteLookup value="10" xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:Comparison useCalibratedValue="false" parameterRef="P1" value="1"/>
 </xtce:DiscreteLookup>
 """,
-         {'P1': common.IntParameter(678, 0)}, None),
+         CCSDSPacket(**{'P1': common.IntParameter(678, 0)}), None),
         (f"""
 <xtce:DiscreteLookup value="11" xmlns:xtce="{XTCE_1_2_XMLNS}">
     <xtce:ComparisonList>
@@ -293,10 +321,10 @@ def test_boolean_expression(elmaker, xtce_parser, xml_string, test_parsed_data, 
     </xtce:ComparisonList>
 </xtce:DiscreteLookup>
 """,
-         {
+         CCSDSPacket(**{
              'MSN__PARAM1': common.IntParameter(680, 3),
              'MSN__PARAM2': common.IntParameter(3000, 3),
-         }, 11),
+         }), 11),
     ]
 )
 def test_discrete_lookup(elmaker, xtce_parser, xml_string, test_parsed_data, expected_lookup_result):


### PR DESCRIPTION
I noticed that we had low-ish coverage on a couple modules, mostly on the error-handling since most of the tests are run correctly. I found some locations where we were checking for exception cases in `evaluate` methods when we should have been pre-checking in either init or `from_xml`. 

I added some additional coverage to the packets.py module but I'm thinking that will probably need rework after @greglucas 's refactoring in #140 

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [NA] The changelog.md has been updated
