### PR TITLE
Bring your own bytes generator

### DIFF
--- a/.devcontainer/CLAUDE.md
+++ b/.devcontainer/CLAUDE.md
@@ -31,11 +31,14 @@ Space Packet Parser is a Python library for decoding CCSDS telemetry packets acc
 - Use Ruff for linting (configured in pyproject.toml)
 - Maintain high test coverage
 - Write clear docstrings for public APIs
+- Avoid inline imports unless absolutely necessary
 
 ### Testing
 - Run tests with: `pytest`
 - Include benchmarks for performance-critical code
 - Test with real mission data when possible
+- Place lengthy or complex tests in the `tests/integration` directory
+- Tests in `tests/unit` should use fake data and isolate functionality
 - Cover edge cases and error conditions
 
 ### Key Commands
@@ -44,6 +47,7 @@ Space Packet Parser is a Python library for decoding CCSDS telemetry packets acc
 - `ruff check` - Lint code
 - `ruff format` - Format code
 - `spp` - CLI entry point
+- `pre-commit run --all` - Run all pre-commit checks
 
 ### Mission Support
 This library actively supports multiple space missions including IMAP, CLARREO Pathfinder, Libera, CTIM-FD, and MMS-FEEPS. Changes should maintain backward compatibility and consider real-world usage patterns.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
     "dockerfile": "Dockerfile",
     "args": {
       "USERNAME": "sppdev"
-    }
+    },
+    "platform": "linux/aarch64"
   },
   "runArgs": [
     "--cap-add=NET_ADMIN",
@@ -14,26 +15,29 @@
     "vscode": {
       "extensions": [
         "ms-python.python",
-        "ms-python.pylint",
-        "charliermarsh.ruff",
+        "ms-python.vscode-pylance",
+        "ms-python.debugpy",
+        "ms-python.vscode-python-envs",
         "ms-python.mypy-type-checker",
-        "tamasfe.even-better-toml",
-        "redhat.vscode-xml",
         "ms-vscode.test-adapter-converter",
         "ms-python.pytest",
+        "charliermarsh.ruff",
+        "tamasfe.even-better-toml",
+        "redhat.vscode-xml",
         "github.copilot",
         "github.copilot-chat",
-        "anthropic.claude-code"
+        "anthropic.claude-code",
+        "GitHub.vscode-pull-request-github"
       ],
       "settings": {
         "dev.containers.copyGitConfig": true,
-        "python.terminal.activateEnvironment": true,
-        "python.linting.enabled": true,
-        "python.linting.ruffEnabled": true,
-        "python.formatting.provider": "ruff",
+        "python.terminal.activateEnvironment": false,
+        "python-envs.terminal.autoActivationType": "off",
+        "python.defaultInterpreterPath": "python",
         "python.testing.pytestEnabled": true,
         "python.testing.unittestEnabled": false,
         "python.testing.pytestArgs": [
+          "-s",
           "."
         ],
         "files.associations": {
@@ -41,10 +45,11 @@
         },
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
-          "source.organizeImports": "explicit"
+          "source.organizeImports.ruff": "explicit"
         },
-        "ruff.organizeImports": true,
-        "ruff.fixAll": true
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff"
+        }
       }
     }
   },

--- a/.devcontainer/setup-dev-environment.sh
+++ b/.devcontainer/setup-dev-environment.sh
@@ -3,7 +3,7 @@
 # Set up the development environment
 
 # Install poetry dependencies
-poetry install
+poetry lock && poetry sync
 
 # Install pre-commit and pre-commit hooks
 pre-commit install

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ venv
 ##################
 .python-version
 pytest.ini
+.claude

--- a/docs/source/_static/pyodide_parse_packets.js
+++ b/docs/source/_static/pyodide_parse_packets.js
@@ -31,6 +31,7 @@ async function processPackets() {
     // Execute Python code to simulate opening a binary file
     await pyodide.runPythonAsync(`
         import io
+        from space_packet_parser import ccsds
         from space_packet_parser.definitions import XtcePacketDefinition
 
         # Create an in-memory binary file using io.BytesIO
@@ -39,11 +40,12 @@ async function processPackets() {
         packet_def = XtcePacketDefinition(xtce_file_obj)
 
         count = 0
-        packet_generator = packet_def.packet_generator(packet_file_obj)
-        packets = list(packet_generator)
+        ccsds_generator = ccsds.ccsds_generator(packet_file_obj)
+        packets = [packet_def.parse_bytes(binary_data) for binary_data in ccsds_generator]
         npackets = len(packets)
         print(f"Total packets: {npackets}")
     `);
+
 
    // Import the Python list back to JavaScript as an array of dictionaries
    const objectList = pyodide.globals.get('packets');

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -11,6 +11,9 @@ Release notes for the `space_packet_parser` library
 - *BREAKING*: Reorganization of the project into different submodules for more explicit handling
   of imports. There is now an `space_packet_parser.xtce` module with xtce representations separated
   into modules underneath that.
+- *BREAKING*: Removed mid-level abstraction methods `packet_generator()` and `ccsds_packet_generator()`
+  from `XtcePacketDefinition`. Use low-level `parse_bytes()` with bytes generators directly, or high-level
+  `space_packet_parser.xarr.create_dataset()` for xarray integration.
 - Add support for creating a packet definition from Python objects and serializing it as XML.
 - BUGFIX: Fix kbps calculation in packet generator for showing progress.
 - Add support for string and float encoded enumerated lookup parameters.

--- a/examples/csv_to_xtce_conversion.py
+++ b/examples/csv_to_xtce_conversion.py
@@ -16,6 +16,7 @@ import re
 import warnings
 from pathlib import Path
 
+from space_packet_parser import ccsds
 from space_packet_parser.xtce import containers, definitions, encodings, parameter_types, parameters
 
 # This regex is for detecting a dynamically sized field where its bit_length is
@@ -217,7 +218,8 @@ if __name__ == "__main__":
 
     packet_file = jpss_test_data_dir / "J01_G011_LZ_2021-04-09T00-00-00Z_V01.DAT1"
     with packet_file.open("rb") as packet_fh:
-        packets = list(xtce_definition.packet_generator(packet_fh))
+        ccsds_generator = ccsds.ccsds_generator(packet_fh)
+        packets = [xtce_definition.parse_bytes(binary_data) for binary_data in ccsds_generator]
 
     assert len(packets) == 7200  # noqa S101
     print(packets[3])

--- a/space_packet_parser/__init__.py
+++ b/space_packet_parser/__init__.py
@@ -10,7 +10,7 @@ __all__ = [
     "ccsds_generator",
     "SpacePacket",
     "XtcePacketDefinition",
-    "load_xml",
+    "load_xtce",
 ]
 
 def load_xtce(filename: Union[str, Path]) -> XtcePacketDefinition:

--- a/space_packet_parser/ccsds.py
+++ b/space_packet_parser/ccsds.py
@@ -112,6 +112,21 @@ class CCSDSPacketBytes(bytes):
                 self.sequence_count,
                 self.data_length)
 
+    @property
+    def header(self) -> bytes:
+        """Convenience property returns the CCSDS header bytes"""
+        return self[:6]
+
+    @property
+    def user_data(self) -> bytes:
+        """Convenience property returns only the user data bytes (no header)
+
+        Notes:
+        ------
+        This includes the secondary header, if present
+        """
+        return self[6:]
+
 
 def create_ccsds_packet(data=b"\x00",
                         *,

--- a/space_packet_parser/cli.py
+++ b/space_packet_parser/cli.py
@@ -22,6 +22,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.tree import Tree
 
+from space_packet_parser import ccsds
 from space_packet_parser.ccsds import ccsds_generator
 from space_packet_parser.xtce.definitions import DEFAULT_ROOT_CONTAINER, XtcePacketDefinition
 
@@ -178,16 +179,10 @@ def parse(
     """Parse a packet file using the provided XTCE definition."""
     logging.debug(f"Parsing packet file: {packet_file}")
     logging.debug(f"Using packet definition file: {definition_file}")
-
+    packet_definition = XtcePacketDefinition.from_xtce(definition_file)
     with open(packet_file, "rb") as f:
-        packets = list(
-            XtcePacketDefinition.from_xtce(
-                definition_file
-            ).packet_generator(
-                f,
-                skip_header_bytes=skip_header_bytes
-            )
-        )
+        ccsds_generator = ccsds.ccsds_generator(f, skip_header_bytes=skip_header_bytes)
+        packets = [packet_definition.parse_bytes(binary_data) for binary_data in ccsds_generator]
 
     if packet is not None:
         if packet > len(packets):

--- a/space_packet_parser/xtce/containers.py
+++ b/space_packet_parser/xtce/containers.py
@@ -1,6 +1,6 @@
 """Module with XTCE models related to SequenceContainers"""
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from lxml import etree as ElementTree
 from lxml.builder import ElementMaker
@@ -63,7 +63,7 @@ class SequenceContainer(common.Parseable, common.XmlObject):
             *,
             tree: ElementTree.ElementTree,
             parameter_lookup: dict[str, parameters.Parameter],
-            container_lookup: Optional[dict[str, any]],
+            container_lookup: Optional[dict[str, Any]],
             parameter_type_lookup: Optional[dict[str, parameter_types.ParameterType]] = None
     ) -> 'SequenceContainer':
         """Parses the list of parameters in a SequenceContainer element, recursively parsing nested SequenceContainers

--- a/space_packet_parser/xtce/definitions.py
+++ b/space_packet_parser/xtce/definitions.py
@@ -1,11 +1,11 @@
 """Module for parsing XTCE xml files to specify packet format"""
+
 import logging
-import socket
 import warnings
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO, Optional, TextIO, Union
+from typing import Optional, TextIO, Union
 
 import lxml.etree as ElementTree
 from lxml.builder import ElementMaker
@@ -26,15 +26,15 @@ logger = logging.getLogger(__name__)
 DEFAULT_ROOT_CONTAINER = "CCSDSPacket"
 
 TAG_NAME_TO_PARAMETER_TYPE_OBJECT = {
-        'StringParameterType': parameter_types.StringParameterType,
-        'IntegerParameterType': parameter_types.IntegerParameterType,
-        'FloatParameterType': parameter_types.FloatParameterType,
-        'EnumeratedParameterType': parameter_types.EnumeratedParameterType,
-        'BinaryParameterType': parameter_types.BinaryParameterType,
-        'BooleanParameterType': parameter_types.BooleanParameterType,
-        'AbsoluteTimeParameterType': parameter_types.AbsoluteTimeParameterType,
-        'RelativeTimeParameterType': parameter_types.RelativeTimeParameterType,
-    }
+    "StringParameterType": parameter_types.StringParameterType,
+    "IntegerParameterType": parameter_types.IntegerParameterType,
+    "FloatParameterType": parameter_types.FloatParameterType,
+    "EnumeratedParameterType": parameter_types.EnumeratedParameterType,
+    "BinaryParameterType": parameter_types.BinaryParameterType,
+    "BooleanParameterType": parameter_types.BooleanParameterType,
+    "AbsoluteTimeParameterType": parameter_types.AbsoluteTimeParameterType,
+    "RelativeTimeParameterType": parameter_types.RelativeTimeParameterType,
+}
 
 
 class XtcePacketDefinition(common.AttrComparable):
@@ -46,16 +46,16 @@ class XtcePacketDefinition(common.AttrComparable):
     #                   xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd"
     #  This will require an additional namespace dict entry for xsi (in this example)
     def __init__(
-            self,
-            container_set: Optional[Iterable[containers.SequenceContainer]] = None,
-            *,
-            ns: dict = DEFAULT_XTCE_NSMAP,
-            xtce_ns_prefix: Optional[str] = DEFAULT_XTCE_NS_PREFIX,
-            root_container_name: Optional[str] = DEFAULT_ROOT_CONTAINER,
-            space_system_name: Optional[str] = None,
-            validation_status: str = "Unknown",
-            xtce_version: str = "1.0",
-            date: str = None
+        self,
+        container_set: Optional[Iterable[containers.SequenceContainer]] = None,
+        *,
+        ns: dict = DEFAULT_XTCE_NSMAP,
+        xtce_ns_prefix: Optional[str] = DEFAULT_XTCE_NS_PREFIX,
+        root_container_name: Optional[str] = DEFAULT_ROOT_CONTAINER,
+        space_system_name: Optional[str] = None,
+        validation_status: str = "Unknown",
+        xtce_version: str = "1.0",
+        date: Optional[str] = None,
     ):
         f"""
 
@@ -90,12 +90,14 @@ class XtcePacketDefinition(common.AttrComparable):
                             "To instantiate an XtcePacketDefinition from an XTCE XML file, use "
                             "XtcePacketDefinition.from_xtce() instead.")
         if xtce_ns_prefix is not None and xtce_ns_prefix not in ns:
-            raise ValueError(f"XTCE namespace prefix {xtce_ns_prefix=} not in namespace mapping {ns=}. If the "
-                             f"namespace prefix is not 'None', it must appear as a key in the namespace mapping dict.")
+            raise ValueError(
+                f"XTCE namespace prefix {xtce_ns_prefix=} not in namespace mapping {ns=}. If the "
+                f"namespace prefix is not 'None', it must appear as a key in the namespace mapping dict."
+            )
 
-        self.parameter_types = {}
-        self.parameters = {}
-        self.containers = {}
+        self.parameter_types: dict[str, parameter_types.ParameterType] = {}
+        self.parameters: dict[str, parameters.Parameter] = {}
+        self.containers: dict[str, containers.SequenceContainer] = {}
 
         def _update_caches(sc: containers.SequenceContainer) -> None:
             """Iterate through a SequenceContainer, updating internal caches with all Parameter, ParameterType,
@@ -141,7 +143,7 @@ class XtcePacketDefinition(common.AttrComparable):
         filepath : Union[str, Path]
             Location to write this packet definition
         """
-        self.to_xml_tree().write(filepath.absolute(), pretty_print=True, xml_declaration=True, encoding="utf-8")
+        self.to_xml_tree().write(Path(filepath).absolute(), pretty_print=True, xml_declaration=True, encoding="utf-8")
 
     def to_xml_tree(self) -> ElementTree.ElementTree:
         """Initializes and returns an ElementTree object based on parameter type, parameter, and container information
@@ -163,7 +165,7 @@ class XtcePacketDefinition(common.AttrComparable):
         header_attrib = {
             "date": self.date or datetime.now().isoformat(),
             "version": self.xtce_version,
-            "validationStatus": self.validation_status
+            "validationStatus": self.validation_status,
         }
 
         # TODO: Ensure XSI namespace and XSD reference are written to the root element
@@ -179,9 +181,9 @@ class XtcePacketDefinition(common.AttrComparable):
                     ),
                     elmaker.ContainerSet(
                         *(sc.to_xml(elmaker=elmaker) for sc in self.containers.values()),
-                    )
+                    ),
                 ),
-                **space_system_attrib
+                **space_system_attrib,
             )
         )
 
@@ -189,12 +191,12 @@ class XtcePacketDefinition(common.AttrComparable):
 
     @classmethod
     def from_xtce(
-            cls,
-            xtce_document: Union[str, Path, TextIO],
-            *,
-            xtce_ns_prefix: Optional[str] = DEFAULT_XTCE_NS_PREFIX,
-            root_container_name: Optional[str] = DEFAULT_ROOT_CONTAINER
-    ) -> 'XtcePacketDefinition':
+        cls,
+        xtce_document: Union[str, Path, TextIO],
+        *,
+        xtce_ns_prefix: Optional[str] = DEFAULT_XTCE_NS_PREFIX,
+        root_container_name: Optional[str] = DEFAULT_ROOT_CONTAINER,
+    ) -> "XtcePacketDefinition":
         f"""Instantiate an object representation of a CCSDS packet definition,
         according to a format specified in an XTCE XML document.
 
@@ -252,15 +254,14 @@ class XtcePacketDefinition(common.AttrComparable):
             xtce_ns_prefix=xtce_ns_prefix,
             root_container_name=root_container_name,
             date=date,
-            space_system_name=space_system.attrib.get("name", None)
+            space_system_name=space_system.attrib.get("name", None),
         )
 
         return xtce_definition
 
     @staticmethod
     def _parse_container_set(
-            tree: ElementTree.Element,
-            parameter_lookup: dict[str, parameters.Parameter]
+        tree: ElementTree.Element, parameter_lookup: dict[str, parameters.Parameter]
     ) -> dict[str, containers.SequenceContainer]:
         """Parse the <xtce:ContainerSet> element into a dictionary of SequenceContainer objects
 
@@ -275,14 +276,15 @@ class XtcePacketDefinition(common.AttrComparable):
         -------
         : dict[str, containers.SequenceContainer]
         """
-        container_lookup = {}  # This lookup dict is mutated as a side effect by SequenceContainer parsing methods
+        # This lookup dict is mutated as a side effect by SequenceContainer parsing methods
+        container_lookup: dict[str, containers.SequenceContainer] = {}
         container_set_element = tree.getroot().find("TelemetryMetaData/ContainerSet")
-        for sequence_container_element in container_set_element.iterfind('*'):
+        for sequence_container_element in container_set_element.iterfind("*"):
             sequence_container = containers.SequenceContainer.from_xml(
                 sequence_container_element,
                 tree=tree,
                 parameter_lookup=parameter_lookup,
-                container_lookup=container_lookup
+                container_lookup=container_lookup,
             )
 
             if sequence_container.name not in container_lookup:
@@ -290,9 +292,11 @@ class XtcePacketDefinition(common.AttrComparable):
             elif container_lookup[sequence_container.name] == sequence_container:
                 continue
             else:
-                raise ValueError(f"Found duplicate sequence container name "
-                                 f"{sequence_container.name} for two non-equal "
-                                 f"sequence containers. Sequence container names are expected to be unique.")
+                raise ValueError(
+                    f"Found duplicate sequence container name "
+                    f"{sequence_container.name} for two non-equal "
+                    f"sequence containers. Sequence container names are expected to be unique."
+                )
 
         # Back-populate the list of inheritors for each container
         for name, sc in container_lookup.items():
@@ -302,9 +306,7 @@ class XtcePacketDefinition(common.AttrComparable):
         return container_lookup
 
     @staticmethod
-    def _parse_parameter_type_set(
-            tree: ElementTree.ElementTree
-    ) -> dict[str, parameter_types.ParameterType]:
+    def _parse_parameter_type_set(tree: ElementTree.ElementTree) -> dict[str, parameter_types.ParameterType]:
         """Parse the <xtce:ParameterTypeSet> into a dictionary of ParameterType objects
 
         Parameters
@@ -318,36 +320,41 @@ class XtcePacketDefinition(common.AttrComparable):
         """
         parameter_type_dict = {}
         parameter_type_set_element = tree.getroot().find("TelemetryMetaData/ParameterTypeSet")
-        for parameter_type_element in parameter_type_set_element.iterfind('*'):
+        for parameter_type_element in parameter_type_set_element.iterfind("*"):
             try:
                 parameter_type_class = TAG_NAME_TO_PARAMETER_TYPE_OBJECT[
                     ElementTree.QName(parameter_type_element).localname
                 ]
             except KeyError as e:
                 if (
-                        "ArrayParameterType" in parameter_type_element.tag or
-                        "AggregateParameterType" in parameter_type_element.tag
+                    "ArrayParameterType" in parameter_type_element.tag
+                    or "AggregateParameterType" in parameter_type_element.tag
                 ):
-                    raise NotImplementedError(f"Unsupported parameter type {parameter_type_element.tag}. "
-                                              "Supporting this parameter type is in the roadmap but has "
-                                              "not yet been implemented.") from e
-                raise InvalidParameterTypeError(f"Invalid parameter type {parameter_type_element.tag}. "
-                                                "If you believe this is a valid XTCE parameter type, "
-                                                "please open a feature request as a Github issue with a "
-                                                "reference to the XTCE element description for the "
-                                                "parameter type element.") from e
+                    raise NotImplementedError(
+                        f"Unsupported parameter type {parameter_type_element.tag}. "
+                        "Supporting this parameter type is in the roadmap but has "
+                        "not yet been implemented."
+                    ) from e
+                raise InvalidParameterTypeError(
+                    f"Invalid parameter type {parameter_type_element.tag}. "
+                    "If you believe this is a valid XTCE parameter type, "
+                    "please open a feature request as a Github issue with a "
+                    "reference to the XTCE element description for the "
+                    "parameter type element."
+                ) from e
             parameter_type_object = parameter_type_class.from_xml(parameter_type_element)
             if parameter_type_object.name in parameter_type_dict:
-                raise ValueError(f"Found duplicate parameter type {parameter_type_object.name}. "
-                                 f"Parameter types names are expected to be unique")
+                raise ValueError(
+                    f"Found duplicate parameter type {parameter_type_object.name}. "
+                    f"Parameter types names are expected to be unique"
+                )
             parameter_type_dict[parameter_type_object.name] = parameter_type_object  # Add to cache
 
         return parameter_type_dict
 
     @staticmethod
     def _parse_parameter_set(
-            tree: ElementTree.ElementTree,
-            parameter_type_lookup: dict[str, parameter_types.ParameterType]
+        tree: ElementTree.ElementTree, parameter_type_lookup: dict[str, parameter_types.ParameterType]
     ) -> dict[str, parameters.Parameter]:
         """Parse an <xtce:ParameterSet> object into a dictionary of Parameter objects
 
@@ -364,22 +371,21 @@ class XtcePacketDefinition(common.AttrComparable):
         """
         parameter_lookup = {}
         parameter_set_element = tree.getroot().find("TelemetryMetaData/ParameterSet")
-        for parameter_element in parameter_set_element.iterfind('*'):
-            parameter_object = parameters.Parameter.from_xml(parameter_element,
-                                                             parameter_type_lookup=parameter_type_lookup)
+        for parameter_element in parameter_set_element.iterfind("*"):
+            parameter_object = parameters.Parameter.from_xml(
+                parameter_element, parameter_type_lookup=parameter_type_lookup
+            )
 
             if parameter_object.name in parameter_lookup:
-                raise ValueError(f"Found duplicate parameter name {parameter_object.name}. "
-                                 "Parameters are expected to be unique")
+                raise ValueError(
+                    f"Found duplicate parameter name {parameter_object.name}. Parameters are expected to be unique"
+                )
 
             parameter_lookup[parameter_object.name] = parameter_object  # Add to cache
 
         return parameter_lookup
 
-    def parse_bytes(self,
-                    binary_data: bytes,
-                    *,
-                    root_container_name: Optional[str] = None) -> spp.SpacePacket:
+    def parse_bytes(self, binary_data: bytes, *, root_container_name: Optional[str] = None) -> spp.SpacePacket:
         """Parse binary packet data according to the self.packet_definition object
 
         Parameters
@@ -397,28 +403,7 @@ class XtcePacketDefinition(common.AttrComparable):
             A SpacePacket object containing header and data attributes.
         """
         packet = spp.SpacePacket(binary_data=binary_data)
-        return self.parse_packet(packet, root_container_name=root_container_name)
 
-    def parse_packet(self,
-                     packet: spp.SpacePacket,
-                     *,
-                     root_container_name: Optional[str] = None) -> spp.SpacePacket:
-        """Parse binary packet data according to the self.packet_definition object
-
-        Parameters
-        ----------
-        packet: space_packet_parser.SpacePacket
-            Binary representation of the packet used to get the coming bits and any
-            previously parsed data items to infer field lengths.
-        root_container_name : Optional[str]
-            Default is taken from the XtcePacketDefinition object. Any root container may be specified, but it must
-            begin with the definition of a CCSDS header in order to parse correctly.
-
-        Returns
-        -------
-        SpacePacket
-            A SpacePacket object containing header and data attributes.
-        """
         root_container_name = root_container_name or self.root_container_name
         current_container: containers.SequenceContainer = self.containers[root_container_name]
         while True:
@@ -426,8 +411,7 @@ class XtcePacketDefinition(common.AttrComparable):
 
             valid_inheritors = []
             for inheritor_name in current_container.inheritors:
-                if all(rc.evaluate(packet)
-                       for rc in self.containers[inheritor_name].restriction_criteria):
+                if all(rc.evaluate(packet) for rc in self.containers[inheritor_name].restriction_criteria):
                     valid_inheritors.append(inheritor_name)
 
             if len(valid_inheritors) == 1:
@@ -441,7 +425,8 @@ class XtcePacketDefinition(common.AttrComparable):
                         f"Detected an abstract container with no valid inheritors by restriction criteria. "
                         f"This might mean this packet type is not accounted for in the provided packet definition. "
                         f"APID={packet['PKT_APID']}.",
-                        partial_data=packet)
+                        partial_data=packet,
+                    )
                 break
 
             raise UnrecognizedPacketTypeError(
@@ -456,10 +441,7 @@ class XtcePacketDefinition(common.AttrComparable):
             warnings.warn(message)
         return packet
 
-    def parse_ccsds_packet(self,
-                           packet: spp.SpacePacket,
-                           *,
-                           root_container_name: Optional[str] = None) -> spp.SpacePacket:
+    def parse_packet(self, packet: spp.SpacePacket, *, root_container_name: Optional[str] = None) -> spp.SpacePacket:
         """Parse binary packet data according to the self.packet_definition object
 
         Parameters
@@ -476,95 +458,37 @@ class XtcePacketDefinition(common.AttrComparable):
         SpacePacket
             A SpacePacket object containing header and data attributes.
         """
-        warnings.warn("parse_ccsds_packet is deprecated and will be removed in a future release. "
-                      "Use the parse_packet method instead, XTCE has no notion of the ccsds standard.",
-                      DeprecationWarning, stacklevel=2)
-        return self.parse_packet(packet, root_container_name=root_container_name)
+        warnings.warn(
+            "parse_packet is deprecated and will be removed in a future release. "
+            "Use the parse_bytes method instead, XTCE has no notion of the ccsds standard.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.parse_bytes(packet.binary_data, root_container_name=root_container_name)
 
-
-    def packet_generator(
-            self,
-            binary_data: Union[BinaryIO, socket.socket, bytes],
-            *,
-            parse_bad_pkts: bool = True,
-            root_container_name: Optional[str] = None,
-            ccsds_headers_only: bool = False,
-            yield_unrecognized_packet_errors: bool = False,
-            show_progress: bool = False,
-            buffer_read_size_bytes: Optional[int] = None,
-            skip_header_bytes: int = 0
-    ) -> Iterator[Union[spp.SpacePacket, UnrecognizedPacketTypeError]]:
-        """Create and return a SpacePacket generator that reads from a ConstBitStream or a filelike object or a socket.
-
-        Creating a generator object to return allows the user to create
-        many generators from a single Parser and reduces memory usage.
+    def parse_ccsds_packet(
+        self, packet: spp.SpacePacket, *, root_container_name: Optional[str] = None
+    ) -> spp.SpacePacket:
+        """Parse binary packet data according to the self.packet_definition object
 
         Parameters
         ----------
-        binary_data : Union[BinaryIO, socket.socket]
-            Binary data source to parse into SpacePackets.
-        parse_bad_pkts : bool
-            Default True.
-            If True, when the generator encounters a packet with an incorrect length it will still yield the packet
-            (the data will likely be invalid). If False, the generator will still write a debug log message but will
-            otherwise silently skip the bad packet.
-        root_container_name : str
-            The name of the root level (lowest level of container inheritance) SequenceContainer. This SequenceContainer
-            is assumed to be inherited by every possible packet structure in the XTCE document and is the starting
-            point for parsing. Default is taken from the parent XtcePacketDefinition object.
-        ccsds_headers_only : bool
-            Default False. If True, only parses the packet headers (does not use the provided packet definition).
-            ``space_packet_parser.ccsds.ccsds_packet_generator`` can be used directly to parse only the CCSDS headers
-            without needing a packet definition.
-        yield_unrecognized_packet_errors : bool
-            Default False.
-            If False, UnrecognizedPacketTypeErrors are caught silently and parsing continues to the next packet.
-            If True, the generator will yield an UnrecognizedPacketTypeError in the event of an unrecognized
-            packet. Note: These exceptions are not raised by default but are instead returned so that the generator
-            can continue. You can raise the exceptions if desired. Leave this as False unless you need to examine the
-            partial data from unrecognized packets.
-        show_progress : bool
-            Default False.
-            If True, prints a status bar. Note that for socket sources, the percentage will be zero until the generator
-            ends.
-        buffer_read_size_bytes : Optional[int]
-            Number of bytes to read from e.g. a BufferedReader or socket binary data source on each read attempt.
-            If None, defaults to 4096 bytes from a socket, -1 (full read) from a file.
-        skip_header_bytes : int
-            Default 0. The parser skips this many bytes at the beginning of every packet. This allows dynamic stripping
-            of additional header data that may be prepended to packets in "raw record" file formats.
+        packet: space_packet_parser.SpacePacket
+            Binary representation of the packet used to get the coming bits and any
+            previously parsed data items to infer field lengths.
+        root_container_name : Optional[str]
+            Default is taken from the XtcePacketDefinition object. Any root container may be specified, but it must
+            begin with the definition of a CCSDS header in order to parse correctly.
 
-        Yields
+        Returns
         -------
-        Union[Packet, UnrecognizedPacketTypeError]
-            Generator yields SpacePacket objects containing the parsed packet data for each subsequent packet.
-            If yield_unrecognized_packet_errors is True, it will yield an unraised exception object,
-            which can be raised or used for debugging purposes.
+        SpacePacket
+            A SpacePacket object containing header and data attributes.
         """
-        root_container_name = root_container_name or self.root_container_name
-
-        # Iterate over individual packets in the binary data
-        for raw_packet_data in ccsds.ccsds_generator(binary_data,
-                                                     buffer_read_size_bytes=buffer_read_size_bytes,
-                                                     show_progress=show_progress,
-                                                     skip_header_bytes=skip_header_bytes):
-            if ccsds_headers_only:
-                yield raw_packet_data
-                continue
-
-            # Now do the actual parsing of the packet data
-            try:
-                packet = self.parse_bytes(raw_packet_data, root_container_name=root_container_name)
-            except UnrecognizedPacketTypeError as e:
-                logger.debug(f"Unrecognized error on packet with APID {raw_packet_data.apid}")
-                if yield_unrecognized_packet_errors:
-                    # Yield the caught exception without raising it (raising ends generator)
-                    yield e
-                # Continue to next packet
-                continue
-
-            if not parse_bad_pkts and packet._parsing_pos != len(packet.binary_data) * 8:
-                logger.warning(f"Skipping (not yielding) bad packet with apid {raw_packet_data.apid}.")
-                continue
-
-            yield packet
+        warnings.warn(
+            "parse_ccsds_packet is deprecated and will be removed in a future release. "
+            "Use the parse_packet method instead, XTCE has no notion of the ccsds standard.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.parse_packet(packet, root_container_name=root_container_name)

--- a/tests/benchmark/test_slow_benchmarks.py
+++ b/tests/benchmark/test_slow_benchmarks.py
@@ -2,11 +2,10 @@
 
 Each test in this suite tests a specific metric over time
 """
-from collections.abc import Iterable
 
 import pytest
 
-import space_packet_parser as spp
+from space_packet_parser import ccsds
 from space_packet_parser.xtce import definitions
 
 
@@ -38,12 +37,12 @@ def test_benchmark_simple_packet_parsing(benchmark, jpss_test_data_dir):
         def _setup():
             """Function that sets up for each benchmark round"""
             packet_fh.seek(0)
-            packet_generator = packet_definition.packet_generator(packet_fh)
-            return (), {"generator": packet_generator}  # args, kwargs for benchmarked function
+            ccsds_generator = ccsds.ccsds_generator(packet_fh)
+            return (), {"generator": ccsds_generator}  # args, kwargs for benchmarked function
 
-        def _make_packet_list(generator: Iterable[spp.SpacePacket]):
+        def _make_packet_list(generator):
             """Function wrapper for list that takes the generator as a kwarg"""
-            return list(generator)
+            return [packet_definition.parse_bytes(binary_data) for binary_data in generator]
 
         # The setup function is run before each "round" so "iterations" is automatically set to 1 and cannot be changed
         packet_list: list = benchmark.pedantic(_make_packet_list, setup=_setup, rounds=20, warmup_rounds=1)
@@ -69,12 +68,12 @@ def test_benchmark_complex_packet_parsing(benchmark, idex_test_data_dir):
         def _setup():
             """Function that sets up for each benchmark round"""
             packet_fh.seek(0)
-            packet_generator = packet_definition.packet_generator(packet_fh, show_progress=True)
-            return (), {"generator": packet_generator}  # args, kwargs for benchmarked function
+            ccsds_generator = ccsds.ccsds_generator(packet_fh, show_progress=True)
+            return (), {"generator": ccsds_generator}  # args, kwargs for benchmarked function
 
-        def _make_packet_list(generator: Iterable[spp.SpacePacket]):
+        def _make_packet_list(generator):
             """Function wrapper for list that takes the generator as a kwarg"""
-            return list(generator)
+            return [packet_definition.parse_bytes(binary_data) for binary_data in generator]
 
         # The setup function is run before each "round" so "iterations" is automatically set to 1 and cannot be changed
         packet_list: list = benchmark.pedantic(_make_packet_list, setup=_setup, rounds=20, warmup_rounds=1)

--- a/tests/integration/test_bufferedreader_parsing.py
+++ b/tests/integration/test_bufferedreader_parsing.py
@@ -1,6 +1,7 @@
 """Integration test for parsing JPSS packets"""
 # Local
 import space_packet_parser as spp
+from space_packet_parser import ccsds
 from space_packet_parser.xtce import definitions
 
 
@@ -13,9 +14,10 @@ def test_jpss_xtce_packet_parsing(jpss_test_data_dir):
     jpss_packet_file = jpss_test_data_dir / 'J01_G011_LZ_2021-04-09T00-00-00Z_V01.DAT1'
 
     with jpss_packet_file.open('rb') as binary_data:
-        jpss_packet_generator = jpss_definition.packet_generator(binary_data, show_progress=True)
+        jpss_ccsds_generator = ccsds.ccsds_generator(binary_data, show_progress=True)
         n_packets = 0
-        for jpss_packet in jpss_packet_generator:
+        for packet_bytes in jpss_ccsds_generator:
+            jpss_packet = jpss_definition.parse_bytes(packet_bytes)
             assert isinstance(jpss_packet, spp.SpacePacket)
             assert jpss_packet['PKT_APID'] == 11
             assert jpss_packet['VERSION'] == 0

--- a/tests/integration/test_socket_parsing.py
+++ b/tests/integration/test_socket_parsing.py
@@ -7,6 +7,7 @@ from threading import Thread
 
 import pytest
 
+from space_packet_parser import ccsds
 from space_packet_parser.xtce.definitions import XtcePacketDefinition
 
 
@@ -50,10 +51,11 @@ def test_parsing_from_socket(jpss_test_data_dir):
         t = Thread(target=send_data, args=(sender, file,))
         t.start()
 
-        packet_generator = xdef.packet_generator(receiver, buffer_read_size_bytes=4096)
+        ccsds_generator = ccsds.ccsds_generator(receiver, buffer_read_size_bytes=4096)
         packets = []
         with pytest.raises(socket.timeout):  # noqa PT012
-            for p in packet_generator:
+            for packet_bytes in ccsds_generator:
+                p = xdef.parse_bytes(packet_bytes)
                 packets.append(p)
         t.join()
 

--- a/tests/integration/test_xarr.py
+++ b/tests/integration/test_xarr.py
@@ -44,7 +44,10 @@ def test_create_xarray_dataset_ctim(ctim_test_data_dir, caplog):
     """CTIM data contains many APIDs"""
     packet_file = ctim_test_data_dir / "ccsds_2021_155_14_39_51"
     definition_file = ctim_test_data_dir / "ctim_xtce_v1.xml"
-    ds = create_dataset(packet_file, definition_file, root_container_name="CCSDSTelemetryPacket", parse_bad_pkts=False)
+    ds = create_dataset(
+        packet_file, definition_file,
+        parse_bytes_kwargs={"root_container_name": "CCSDSTelemetryPacket"}
+        )
     print(ds)
 
 
@@ -54,4 +57,4 @@ def test_create_xarray_dataset_suda(suda_test_data_dir):
     definition_file = suda_test_data_dir / "suda_combined_science_definition.xml"
     # SUDA has a polymorphic packet structure
     with pytest.raises(ValueError, match="Packet fields do not match for APID 1425"):
-        create_dataset(packet_file, definition_file, skip_header_bytes=4)
+        create_dataset(packet_file, definition_file, generator_kwargs={"skip_header_bytes": 4})

--- a/tests/integration/test_xtce_based_parsing/test_ctim_parsing.py
+++ b/tests/integration/test_xtce_based_parsing/test_ctim_parsing.py
@@ -1,7 +1,7 @@
 """Test parsing of CTIM instrument data"""
 import pytest
 
-# Local
+from space_packet_parser import ccsds
 from space_packet_parser.xtce import definitions
 
 
@@ -16,10 +16,9 @@ def test_ctim_parsing(ctim_test_data_dir):
     print("Loading and parsing data")
     test_packet_file = ctim_test_data_dir / 'ccsds_2021_155_14_39_51'
     with open(test_packet_file, 'rb') as pkt_file:
-        pkt_gen = pkt_def.packet_generator(pkt_file,
-                                           root_container_name="CCSDSTelemetryPacket",
-                                           show_progress=True)
-        packets = list(pkt_gen)
+        ccsds_gen = ccsds.ccsds_generator(pkt_file, show_progress=True)
+        packets = [pkt_def.parse_bytes(binary_data, root_container_name="CCSDSTelemetryPacket")
+                   for binary_data in ccsds_gen]
 
     assert len(packets) == 1499
     assert packets[159]['PKT_APID'].raw_value == 34

--- a/tests/integration/test_xtce_based_parsing/test_inheritance_restrictions.py
+++ b/tests/integration/test_xtce_based_parsing/test_inheritance_restrictions.py
@@ -1,5 +1,6 @@
 """Test RestrictionCriteria being used creatively with JPSS data"""
 import space_packet_parser as spp
+from space_packet_parser import ccsds
 from space_packet_parser.xtce import definitions
 
 
@@ -11,10 +12,10 @@ def test_jpss_xtce_packet_parsing(jpss_test_data_dir):
 
     jpss_packet_file = jpss_test_data_dir / 'J01_G011_LZ_2021-04-09T00-00-00Z_V01.DAT1'
     with jpss_packet_file.open('rb') as binary_data:
-        jpss_packet_generator = jpss_definition.packet_generator(binary_data)
+        jpss_ccsds_generator = ccsds.ccsds_generator(binary_data)
         for _ in range(3):  # Iterate through 3 packets and check that the parsed APID remains the same
-            jpss_packet = next(jpss_packet_generator)
+            packet_bytes = next(jpss_ccsds_generator)
+            jpss_packet = jpss_definition.parse_bytes(packet_bytes)
             assert isinstance(jpss_packet, spp.SpacePacket)
             assert jpss_packet['PKT_APID'] == 11
             assert jpss_packet['VERSION'] == 0
-        jpss_packet_generator.close()

--- a/tests/integration/test_xtce_based_parsing/test_jpss_parsing.py
+++ b/tests/integration/test_xtce_based_parsing/test_jpss_parsing.py
@@ -1,5 +1,6 @@
 """Integration test for parsing JPSS packets"""
 import space_packet_parser as spp
+from space_packet_parser import ccsds
 from space_packet_parser.xtce import definitions
 
 
@@ -14,10 +15,11 @@ def test_jpss_xtce_packet_parsing(jpss_test_data_dir):
     jpss_packet_file = jpss_test_data_dir / 'J01_G011_LZ_2021-04-09T00-00-00Z_V01.DAT1'
 
     with jpss_packet_file.open('rb') as binary_data:
-        jpss_packet_generator = jpss_definition.packet_generator(binary_data, show_progress=True)
+        jpss_ccsds_generator = ccsds.ccsds_generator(binary_data, show_progress=True)
 
         n_packets = 0
-        for jpss_packet in jpss_packet_generator:
+        for packet_bytes in jpss_ccsds_generator:
+            jpss_packet = jpss_definition.parse_bytes(packet_bytes)
             assert isinstance(jpss_packet, spp.SpacePacket)
             assert jpss_packet['PKT_APID'] == 11
             assert jpss_packet['VERSION'] == 0

--- a/tests/unit/test_ccsds.py
+++ b/tests/unit/test_ccsds.py
@@ -92,7 +92,8 @@ def test_continuation_packets(test_data_dir):
     d = definitions.XtcePacketDefinition.from_xtce(test_data_dir / "test_xtce.xml")
     # We can put that all in one unsegmented packet, just to verify this is working as expected
     raw_bytes = ccsds.create_ccsds_packet(data=b"0"*65, apid=11, sequence_flags=ccsds.SequenceFlags.UNSEGMENTED)
-    orig_packets = list(d.packet_generator(raw_bytes))
+    ccsds_generator = ccsds.ccsds_generator(raw_bytes)
+    orig_packets = [d.parse_bytes(binary_data) for binary_data in ccsds_generator]
     assert len(orig_packets) == 1
     # Remove the sequence flags, counter, and packet length, as they are expected to vary across tests
     def remove_keys(d):

--- a/tests/unit/test_xarr.py
+++ b/tests/unit/test_xarr.py
@@ -1,7 +1,10 @@
 """Tests for the xarr.py extras module"""
+import struct
+
 import pytest
 
 from space_packet_parser import xarr
+from space_packet_parser.common import fixed_length_generator
 from space_packet_parser.xtce import calibrators, containers, definitions, encodings, parameter_types, parameters
 
 np = pytest.importorskip("numpy", reason="numpy is not available")
@@ -77,6 +80,7 @@ def test_xtce():
     ]
     return definitions.XtcePacketDefinition(container_set=container_set)
 
+
 @pytest.mark.parametrize(
     ("pname", "use_raw_value", "expected_dtype"),
     [
@@ -97,3 +101,75 @@ def test_xtce():
 def test_minimum_numpy_dtype(test_xtce, pname, use_raw_value, expected_dtype):
     """Test finding the minimum numpy data type for a parameter"""
     assert xarr._get_minimum_numpy_datatype(pname, test_xtce, use_raw_value) == expected_dtype
+
+
+def test_create_dataset_with_custom_generator(tmp_path):
+    """Test creating a dataset with a custom packet generator for non-CCSDS packets"""
+    # Create a simple fixed-length packet definition with 3 fields
+    container_set = [
+        containers.SequenceContainer(
+            "FIXED_LENGTH_CONTAINER",
+            entry_list=[
+                parameters.Parameter(
+                    "UINT8_FIELD",
+                    parameter_type=parameter_types.IntegerParameterType(
+                        "UINT8_TYPE",
+                        encoding=encodings.IntegerDataEncoding(size_in_bits=8, encoding="unsigned")
+                    )
+                ),
+                parameters.Parameter(
+                    "STRING_FIELD",
+                    parameter_type=parameter_types.StringParameterType(
+                        "STRING_TYPE",
+                        encoding=encodings.StringDataEncoding(
+                            fixed_raw_length=24  # 3 bytes = 24 bits
+                        )
+                    )
+                ),
+                parameters.Parameter(
+                    "INT32_FIELD",
+                    parameter_type=parameter_types.IntegerParameterType(
+                        "INT32_TYPE",
+                        encoding=encodings.IntegerDataEncoding(size_in_bits=32, encoding="twosComplement")
+                    )
+                ),
+            ]
+        )
+    ]
+
+    packet_definition = definitions.XtcePacketDefinition(container_set=container_set)
+
+    # Create 3 test packets with known data (8 bytes each)
+    packet1_data = struct.pack(">B3si", 0x42, b"ABC", 12345)
+    packet2_data = struct.pack(">B3si", 0x55, b"XYZ", 67890)
+    packet3_data = struct.pack(">B3si", 0xFF, b"123", -99999)
+
+    # Concatenate packets into binary data
+    binary_data = packet1_data + packet2_data + packet3_data
+
+    # Write to a temporary file
+    test_file = tmp_path / "test_packets.bin"
+    with open(test_file, "wb") as f:
+        f.write(binary_data)
+
+    # Create dataset using a custom fixed-length generator
+    datasets = xarr.create_dataset(
+        test_file,
+        packet_definition,
+        packet_bytes_generator=fixed_length_generator,
+        generator_kwargs={"packet_length_bytes": 8},
+        parse_bytes_kwargs={"root_container_name": "FIXED_LENGTH_CONTAINER"}
+    )
+
+    # Since these are not CCSDS packets, they won't have an APID
+    # The dataset should be keyed by 0 or similar default
+    assert len(datasets) == 1
+    dataset = list(datasets.values())[0]
+
+    # Check that we have 3 packets
+    assert len(dataset.packet) == 3
+
+    # Check the values
+    assert list(dataset["UINT8_FIELD"].values) == [0x42, 0x55, 0xFF]
+    assert list(dataset["STRING_FIELD"].values) == ["ABC", "XYZ", "123"]
+    assert list(dataset["INT32_FIELD"].values) == [12345, 67890, -99999]

--- a/tests/unit/test_xtce/test_containers.py
+++ b/tests/unit/test_xtce/test_containers.py
@@ -1,2 +1,127 @@
 """Tests for the containers module"""
+import struct
 
+import pytest
+
+from space_packet_parser import SpacePacket, ccsds
+from space_packet_parser.xtce import containers, encodings, parameter_types, parameters
+
+
+@pytest.fixture
+def mock_container_and_packet():
+    """Create a dummy packet and associated SequenceContainer to test parsing"""
+    # Create parameter types for CCSDS header fields
+    uint3_type = parameter_types.IntegerParameterType(
+        name="UINT3_Type",
+        encoding=encodings.IntegerDataEncoding(size_in_bits=3, encoding="unsigned")
+    )
+    uint1_type = parameter_types.IntegerParameterType(
+        name="UINT1_Type",
+        encoding=encodings.IntegerDataEncoding(size_in_bits=1, encoding="unsigned")
+    )
+    uint11_type = parameter_types.IntegerParameterType(
+        name="UINT11_Type",
+        encoding=encodings.IntegerDataEncoding(size_in_bits=11, encoding="unsigned")
+    )
+    uint2_type = parameter_types.IntegerParameterType(
+        name="UINT2_Type",
+        encoding=encodings.IntegerDataEncoding(size_in_bits=2, encoding="unsigned")
+    )
+    uint14_type = parameter_types.IntegerParameterType(
+        name="UINT14_Type",
+        encoding=encodings.IntegerDataEncoding(size_in_bits=14, encoding="unsigned")
+    )
+    uint16_type = parameter_types.IntegerParameterType(
+        name="UINT16_Type",
+        encoding=encodings.IntegerDataEncoding(size_in_bits=16, encoding="unsigned")
+    )
+
+    # Create parameter types for user data
+    uint8_type = parameter_types.IntegerParameterType(
+        name="UINT8_Type",
+        encoding=encodings.IntegerDataEncoding(size_in_bits=8, encoding="unsigned")
+    )
+    uint32_type = parameter_types.IntegerParameterType(
+        name="UINT32_Type",
+        encoding=encodings.IntegerDataEncoding(size_in_bits=32, encoding="unsigned")
+    )
+
+    # Create CCSDS header parameters
+    version_param = parameters.Parameter(name="VERSION", parameter_type=uint3_type)
+    type_param = parameters.Parameter(name="TYPE", parameter_type=uint1_type)
+    sec_hdr_flag_param = parameters.Parameter(name="SEC_HDR_FLG", parameter_type=uint1_type)
+    apid_param = parameters.Parameter(name="PKT_APID", parameter_type=uint11_type)
+    seq_flags_param = parameters.Parameter(name="SEQ_FLGS", parameter_type=uint2_type)
+    seq_count_param = parameters.Parameter(name="SRC_SEQ_CTR", parameter_type=uint14_type)
+    pkt_len_param = parameters.Parameter(name="PKT_LEN", parameter_type=uint16_type)
+
+    # Create user data parameters
+    param1 = parameters.Parameter(
+        name="PARAM1",
+        parameter_type=uint8_type,
+        short_description="First test parameter"
+    )
+    param2 = parameters.Parameter(
+        name="PARAM2",
+        parameter_type=uint16_type,
+        short_description="Second test parameter"
+    )
+    param3 = parameters.Parameter(
+        name="PARAM3",
+        parameter_type=uint32_type,
+        short_description="Third test parameter"
+    )
+
+    # Create a SequenceContainer with CCSDS header parameters followed by user data parameters
+    test_container = containers.SequenceContainer(
+        name="TestContainer",
+        entry_list=[
+            version_param, type_param, sec_hdr_flag_param, apid_param,
+            seq_flags_param, seq_count_param, pkt_len_param,
+            param1, param2, param3
+        ],
+        short_description="Test container for parsing"
+    )
+
+    # Create test data: uint8=42, uint16=1234, uint32=567890123
+    test_data = struct.pack(">BHI", 42, 1234, 567890123)
+
+    # Create CCSDS packet with the test data
+    packet_bytes = ccsds.create_ccsds_packet(
+        data=test_data,
+        apid=100,
+        sequence_count=42
+    )
+
+    # Debug: print packet structure
+    print(f"Test data: {test_data.hex()}")
+    print(f"Full packet: {packet_bytes.hex()}")
+    print(f"CCSDS header (6 bytes): {packet_bytes.header_values}")
+    print(f"User data portion: {packet_bytes.user_data.hex()}")
+
+    # Create SpacePacket from the raw bytes
+    test_packet = SpacePacket(binary_data=packet_bytes)
+
+    # Expected result after parsing
+    expected_values = {
+        "PARAM1": 42,
+        "PARAM2": 1234,
+        "PARAM3": 567890123
+    }
+
+    return test_container, test_packet, expected_values
+
+
+def test_sequence_container_parse_from_space_packet(mock_container_and_packet):
+    """Test successful parsing of a single SequenceContainer from a SpacePacket with raw bytes"""
+    (test_container, test_packet, expected_values) = mock_container_and_packet
+
+    # Parse the packet using the container definition
+    test_container.parse(test_packet)
+
+    # Validate the parsed results
+    for param_name, expected_value in expected_values.items():
+        assert param_name in test_packet, \
+            f"Parameter {param_name} not found in parsed packet"
+        assert test_packet[param_name] == expected_value, \
+            f"Parameter {param_name} value mismatch: expected {expected_value}, got {test_packet[param_name]}"


### PR DESCRIPTION
This PR removes the intermediate API on `XtcePacketDefinition.packet_generator` and cleans up the implementation of `xarr.create_dataset` to handle separate kwarg dicts for the `ccsds_generator` and the `parse_bytes` method. The `create_dataset` function will never be allowed to parse packets with incorrect length though because such behavior will not permit construction of the resulting `DataSet` object.

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
