### PR TITLE
Allow numpy>=1.26

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - click>=8.0
     - rich>=13.0
     - xarray>2024.0.0
-    - numpy>=2.0.0
+    - numpy>=1.26.0
 
 test:
   imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ spp = "space_packet_parser.cli:spp"
 [project.optional-dependencies]
 xarray = [
     "xarray>2024.0.0",
-    "numpy>=2.0.0"
+    "numpy>=1.26.0"
 ]
 examples = [
     "matplotlib>=3.4"


### PR DESCRIPTION
There are a lot of libraries that have pinned numpy<2.0.0. Just allowing the last v1 of numpy improves our compatibility greatly. Unfortunately going back beyond 1.26, we run into build system incompatibilities, I think because numpy<=1.25 relies on setuptools and setuptools has seen significant changes in the last few years but there's no documentation on what version is required because when 1.25 was developed, setuptools had not yet become incompatible and setuptools releases major versions every week it seems.