### PR TITLE
Add support for filelike objects in create_dataset

### DIFF
--- a/examples/csv_to_xtce_conversion.py
+++ b/examples/csv_to_xtce_conversion.py
@@ -17,7 +17,7 @@ import re
 import warnings
 from pathlib import Path
 
-from space_packet_parser import ccsds
+from space_packet_parser import generators
 from space_packet_parser.xtce import containers, definitions, encodings, parameter_types, parameters
 
 # This regex is for detecting a dynamically sized field where its bit_length is
@@ -170,7 +170,7 @@ if __name__ == "__main__":
 
     packet_file = jpss_test_data_dir / "J01_G011_LZ_2021-04-09T00-00-00Z_V01.DAT1"
     with packet_file.open("rb") as packet_fh:
-        ccsds_generator = ccsds.ccsds_generator(packet_fh)
+        ccsds_generator = generators.ccsds_generator(packet_fh)
         packets = [xtce_definition.parse_bytes(binary_data) for binary_data in ccsds_generator]
 
     assert len(packets) == 7200  # noqa S101

--- a/examples/parsing_and_plotting_idex_waveforms_from_socket.py
+++ b/examples/parsing_and_plotting_idex_waveforms_from_socket.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 
-from space_packet_parser import ccsds
+from space_packet_parser import generators
 from space_packet_parser.xtce import definitions
 
 
@@ -116,7 +116,7 @@ if __name__ == "__main__":
     p.start()
 
     # Create a packet generator that listens to a socket
-    idex_ccsds_generator = ccsds.ccsds_generator(receiver)
+    idex_ccsds_generator = generators.ccsds_generator(receiver)
     # No data yet. We start recording data from an event when we encounter a packet with IDX__SCI0TYPE==1
     data: dict[int, bytes] = {}
     try:

--- a/space_packet_parser/__init__.py
+++ b/space_packet_parser/__init__.py
@@ -3,8 +3,8 @@
 from pathlib import Path
 from typing import Union
 
-from space_packet_parser.ccsds import ccsds_generator
 from space_packet_parser.common import SpacePacket
+from space_packet_parser.generators import ccsds_generator
 from space_packet_parser.xtce.definitions import XtcePacketDefinition
 from space_packet_parser.xtce.validation import validate_xtce
 
@@ -19,6 +19,8 @@ __all__ = [
 
 def load_xtce(filename: Union[str, Path]) -> XtcePacketDefinition:
     """Create an XtcePacketDefinition object from an XTCE XML file
+
+    This is a shortcut for calling XtcePacketDefinition.from_xtce().
 
     Parameters
     ----------

--- a/space_packet_parser/cli.py
+++ b/space_packet_parser/cli.py
@@ -23,8 +23,8 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.tree import Tree
 
-from space_packet_parser import ccsds
-from space_packet_parser.ccsds import ccsds_generator
+from space_packet_parser import generators
+from space_packet_parser.generators import ccsds_generator
 from space_packet_parser.xtce.definitions import DEFAULT_ROOT_CONTAINER, XtcePacketDefinition
 from space_packet_parser.xtce.validation import validate_xtce
 
@@ -198,7 +198,7 @@ def parse(
     logging.debug(f"Using packet definition file: {definition_file}")
     packet_definition = XtcePacketDefinition.from_xtce(definition_file)
     with open(packet_file, "rb") as f:
-        ccsds_generator = ccsds.ccsds_generator(f, skip_header_bytes=skip_header_bytes)
+        ccsds_generator = generators.ccsds_generator(f, skip_header_bytes=skip_header_bytes)
         packets = [packet_definition.parse_bytes(binary_data) for binary_data in ccsds_generator]
 
     if packet is not None:

--- a/space_packet_parser/common.py
+++ b/space_packet_parser/common.py
@@ -1,15 +1,10 @@
 """Common mixins"""
 
-import datetime as dt
 import inspect
-import io
 import logging
-import socket
-import time
 import warnings
 from abc import ABCMeta, abstractmethod
-from collections.abc import Iterator
-from typing import BinaryIO, Optional, Protocol, Union
+from typing import Optional, Protocol, Union
 
 import lxml.etree as ElementTree
 from lxml.builder import ElementMaker
@@ -385,162 +380,6 @@ class SpacePacket(dict):
         int_data = _extract_bits(self.binary_data, self._parsing_pos, nbits)
         self._parsing_pos += nbits
         return int_data
-
-
-def fixed_length_generator(
-    binary_data: Union[BinaryIO, socket.socket, bytes],
-    *,
-    packet_length_bytes: int,
-    buffer_read_size_bytes: Optional[int] = None,
-    show_progress: bool = False,
-) -> Iterator[bytes]:
-    """A generator that yields fixed-length chunks from binary_data.
-
-    Parameters
-    ----------
-    binary_data : Union[BinaryIO, socket.socket, bytes]
-        Binary data source.
-    packet_length_bytes : int
-        Number of bytes per packet to yield.
-    buffer_read_size_bytes : int, optional
-        Number of bytes to read from the source per read.
-    show_progress : bool
-        If True, prints a status bar.
-
-    Yields
-    ------
-    bytes
-        Fixed-length packet bytes.
-    """
-    n_bytes_parsed = 0  # Keep track of how many bytes we have parsed
-    n_packets_parsed = 0  # Keep track of how many packets we have parsed
-    read_buffer, total_length_bytes, read_bytes_from_source, buffer_read_size_bytes = _setup_binary_reader(
-        binary_data, buffer_read_size_bytes
-    )
-    current_pos = 0  # Keep track of where we are in the buffer
-    start_time = time.time_ns()
-    while True:
-        if total_length_bytes and n_bytes_parsed == total_length_bytes:
-            break
-        if show_progress:
-            _print_progress(
-                current_bytes=n_bytes_parsed,
-                total_bytes=total_length_bytes,
-                start_time_ns=start_time,
-                current_packets=n_packets_parsed,
-            )
-        if current_pos > 20_000_000:
-            # Only trim the buffer after 20 MB read to prevent modifying
-            # the bitstream and trimming after every packet
-            read_buffer = read_buffer[current_pos:]
-            current_pos = 0
-        while len(read_buffer) - current_pos < packet_length_bytes:
-            result = read_bytes_from_source(buffer_read_size_bytes)
-            if not result:
-                break
-            read_buffer += result
-        packet_bytes = read_buffer[current_pos : current_pos + packet_length_bytes]
-        current_pos += packet_length_bytes
-        n_packets_parsed += 1
-        n_bytes_parsed += packet_length_bytes
-        yield packet_bytes
-    if show_progress:
-        _print_progress(
-            current_bytes=n_bytes_parsed,
-            total_bytes=total_length_bytes,
-            start_time_ns=start_time,
-            current_packets=n_packets_parsed,
-            end="\n",
-            log=True,
-        )
-
-
-def _setup_binary_reader(binary_data, buffer_read_size_bytes=None):
-    """Helper to set up reading from binary_data (file, socket, bytes). Returns:
-    read_buffer, total_length_bytes, read_bytes_from_source, buffer_read_size_bytes
-    """
-    read_buffer = b""
-    # ========
-    # Set up the reader based on the type of binary_data
-    # ========
-    if isinstance(binary_data, io.BufferedIOBase):
-        if buffer_read_size_bytes is None:
-            # Default to a full read of the file
-            buffer_read_size_bytes = -1
-        total_length_bytes = binary_data.seek(0, io.SEEK_END)  # This is probably preferable to len
-        binary_data.seek(0, 0)
-        logger.info(
-            f"Creating packet generator from a filelike object, {binary_data}. "
-            f"Total length is {total_length_bytes} bytes"
-        )
-        read_bytes_from_source = binary_data.read
-    elif isinstance(binary_data, socket.socket):  # It's a socket and we don't know how much data we will get
-        logger.info("Creating packet generator to read from a socket. Total length to parse is unknown.")
-        total_length_bytes = None  # We don't know how long it is
-        if buffer_read_size_bytes is None:
-            # Default to 4096 bytes from a socket
-            buffer_read_size_bytes = 4096
-        read_bytes_from_source = binary_data.recv
-    elif isinstance(binary_data, bytes):
-        read_buffer = binary_data
-        total_length_bytes = len(read_buffer)
-        read_bytes_from_source = None  # No data to read, we've filled the read_buffer already
-        logger.info(f"Creating packet generator from a bytes object. Total length is {total_length_bytes} bytes")
-    elif isinstance(binary_data, io.TextIOWrapper):
-        raise OSError("Packet data file opened in TextIO mode. You must open packet data in binary mode.")
-    else:
-        raise OSError(f"Unrecognized data source: {binary_data}")
-    return read_buffer, total_length_bytes, read_bytes_from_source, buffer_read_size_bytes
-
-
-def _print_progress(
-    *,
-    current_bytes: int,
-    total_bytes: Optional[int],
-    start_time_ns: int,
-    current_packets: int,
-    end: str = "\r",
-    log: bool = False,
-):
-    """Prints a progress bar, including statistics on parsing rate.
-
-    Parameters
-    ----------
-    current_bytes : int
-        Number of bytes parsed so far.
-    total_bytes : Optional[int]
-        Number of total bytes to parse, if known. None otherwise.
-    current_packets : int
-        Number of packets parsed so far.
-    start_time_ns : int
-        Start time on system clock, in nanoseconds.
-    end : str
-        Print function end string. Default is `\\r` to create a dynamically updating loading bar.
-    log : bool
-        If True, log the progress bar at INFO level.
-    """
-    progress_char = "="
-    bar_length = 20
-
-    if total_bytes is not None:  # If we actually have an endpoint (i.e. not using a socket)
-        percentage = int((current_bytes / total_bytes) * 100)  # Percent Completed Calculation
-        progress = int((bar_length * current_bytes) / total_bytes)  # Progress Done Calculation
-    else:
-        percentage = "???"
-        progress = 0
-
-    # Fast calls initially on Windows can result in a zero elapsed time
-    elapsed_ns = max(time.time_ns() - start_time_ns, 1)
-    delta = dt.timedelta(microseconds=elapsed_ns / 1e3)
-    kbps = int(current_bytes * 8e6 / elapsed_ns)  # 8 bits per byte, 1E9 s per ns, 1E3 bits per kb
-    pps = int(current_packets * 1e9 / elapsed_ns)
-    info_str = (
-        f"[Elapsed: {delta}, Parsed {current_bytes} bytes ({current_packets} packets) at {kbps}kb/s ({pps}pkts/s)]"
-    )
-    loadbar = f"Progress: [{progress * progress_char:{bar_length}}]{percentage}% {info_str}"
-    print(loadbar, end=end)
-    if log:
-        logger.info(loadbar)
 
 
 def _extract_bits(data: bytes, start_bit: int, nbits: int):

--- a/space_packet_parser/generators/__init__.py
+++ b/space_packet_parser/generators/__init__.py
@@ -1,0 +1,6 @@
+"""Generators subpackage, containing packet generators for different packet formats."""
+
+from space_packet_parser.generators.ccsds import ccsds_generator
+from space_packet_parser.generators.fixed_length import fixed_length_generator
+
+__all__ = ["ccsds_generator", "fixed_length_generator"]

--- a/space_packet_parser/generators/ccsds.py
+++ b/space_packet_parser/generators/ccsds.py
@@ -1,4 +1,4 @@
-"""Parsing utilities for CCSDS packets.
+"""Packet generator utilities for CCSDS packets.
 
 The parsing begins with binary data representing CCSDS Packets. A user can then create a generator
 from the binary data reading from a filelike object or a socket. The ``ccsds_generator`` function yields
@@ -16,7 +16,8 @@ from collections.abc import Iterator
 from enum import IntEnum
 from typing import BinaryIO, Optional, Union
 
-from space_packet_parser.common import SpacePacket, _print_progress, _setup_binary_reader
+from space_packet_parser.common import SpacePacket
+from space_packet_parser.generators.utils import _print_progress, _setup_binary_reader
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ class SequenceFlags(IntEnum):
 
 
 class CCSDSPacketBytes(bytes):
-    """Binary representation of a CCSDS packet.
+    """Binary (bytes) representation of a CCSDS packet.
 
     Methods to extract the header fields are added to the raw bytes object.
     """
@@ -170,6 +171,10 @@ def create_ccsds_packet(
     -------
     : CCSDSPacketBytes
         Resulting binary packet
+
+    Notes
+    -----
+    This function is extremely useful for generating test packets for debugging or mocking purposes.
     """
     if version_number < 0 or version_number > 7:  # 3 bits
         raise ValueError("version_number must be between 0 and 7")
@@ -223,7 +228,7 @@ class CCSDSPacket(SpacePacket):
     def __init__(self, *args, **kwargs):
         warnings.warn(
             "The CCSDSPacket class is deprecated and will be removed in a future release. "
-            "Use the Packet class instead (no CCSDS prefix).",
+            "Use the SpacePacket class instead (no CCSDS prefix).",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -294,7 +299,7 @@ def ccsds_generator(
     # ========
     start_time = time.time_ns()
     while True:
-        if total_length_bytes and n_bytes_parsed == total_length_bytes:
+        if n_bytes_parsed == total_length_bytes:
             break  # Exit if we know the length and we've reached it
 
         if show_progress:

--- a/space_packet_parser/generators/fixed_length.py
+++ b/space_packet_parser/generators/fixed_length.py
@@ -1,0 +1,76 @@
+"""Fixed length packet generator."""
+
+import socket
+import time
+from collections.abc import Iterator
+from typing import BinaryIO, Optional, Union
+
+from space_packet_parser.generators.utils import _print_progress, _setup_binary_reader
+
+
+def fixed_length_generator(
+    binary_data: Union[BinaryIO, socket.socket, bytes],
+    *,
+    packet_length_bytes: int,
+    buffer_read_size_bytes: Optional[int] = None,
+    show_progress: bool = False,
+) -> Iterator[bytes]:
+    """A generator that yields fixed-length chunks from binary_data.
+
+    Parameters
+    ----------
+    binary_data : Union[BinaryIO, socket.socket, bytes]
+        Binary data source.
+    packet_length_bytes : int
+        Number of bytes per packet to yield.
+    buffer_read_size_bytes : int, optional
+        Number of bytes to read from the source per read.
+    show_progress : bool
+        If True, prints a status bar.
+
+    Yields
+    ------
+    bytes
+        Fixed-length packet bytes.
+    """
+    n_bytes_parsed = 0  # Keep track of how many bytes we have parsed
+    n_packets_parsed = 0  # Keep track of how many packets we have parsed
+    read_buffer, total_length_bytes, read_bytes_from_source, buffer_read_size_bytes = _setup_binary_reader(
+        binary_data, buffer_read_size_bytes
+    )
+    current_pos = 0  # Keep track of where we are in the buffer
+    start_time = time.time_ns()
+    while True:
+        if n_bytes_parsed == total_length_bytes:
+            break
+        if show_progress:
+            _print_progress(
+                current_bytes=n_bytes_parsed,
+                total_bytes=total_length_bytes,
+                start_time_ns=start_time,
+                current_packets=n_packets_parsed,
+            )
+        if current_pos > 20_000_000:
+            # Only trim the buffer after 20 MB read to prevent modifying
+            # the bitstream and trimming after every packet
+            read_buffer = read_buffer[current_pos:]
+            current_pos = 0
+        while len(read_buffer) - current_pos < packet_length_bytes:
+            result = read_bytes_from_source(buffer_read_size_bytes)
+            if not result:
+                break
+            read_buffer += result
+        packet_bytes = read_buffer[current_pos : current_pos + packet_length_bytes]
+        current_pos += packet_length_bytes
+        n_packets_parsed += 1
+        n_bytes_parsed += packet_length_bytes
+        yield packet_bytes
+    if show_progress:
+        _print_progress(
+            current_bytes=n_bytes_parsed,
+            total_bytes=total_length_bytes,
+            start_time_ns=start_time,
+            current_packets=n_packets_parsed,
+            end="\n",
+            log=True,
+        )

--- a/space_packet_parser/generators/utils.py
+++ b/space_packet_parser/generators/utils.py
@@ -1,0 +1,195 @@
+"""Utility functions for building packet generators."""
+
+import datetime as dt
+import io
+import logging
+import socket
+import time
+from functools import singledispatch
+from os import PathLike
+from pathlib import Path
+from typing import Optional, Union
+
+logger = logging.getLogger(__name__)
+
+
+@singledispatch
+def _read_packet_file(packet_file) -> Union[bytes, io.BufferedIOBase, io.RawIOBase]:
+    """Read a packet file or file-like object and return an object suitable for passing to a generator.
+
+    Specifically this function prepares the input for use with _setup_binary_reader.
+
+    Parameters
+    ----------
+    packet_file : Union[str, Path, PathLike, BinaryIO, bytes]
+
+    Notes
+    -----
+    This function handles strings and pathlike objects but it reads the full file into memory for the generator.
+    This alleviates the need for generators to internally handle opening and closing files.
+    For a more memory efficient approach, pass an opened file object.
+    """
+    raise OSError(f"Unable to open and read packet_file type: {type(packet_file)}")
+
+
+@_read_packet_file.register(io.BufferedIOBase)
+@_read_packet_file.register(io.RawIOBase)
+def _(packet_file: Union[io.BufferedIOBase, io.RawIOBase]) -> Union[io.BufferedIOBase, io.RawIOBase]:
+    """File-like object, this can be passed directly to a generator."""
+    return packet_file
+
+
+@_read_packet_file.register
+def _(packet_file: bytes) -> bytes:
+    """bytes input, return as-is."""
+    return packet_file
+
+
+@_read_packet_file.register
+def _(packet_file: str) -> bytes:
+    """String file path, open and read bytes."""
+    with open(packet_file, "rb") as f:
+        return f.read()
+
+
+@_read_packet_file.register
+def _(packet_file: Path) -> bytes:
+    """Path file path, open and read bytes.
+
+    Notes
+    -----
+    This is a bit inefficient as we have to read the entire file into memory, but it does ensure we close the file after reading.
+    """
+    with packet_file.expanduser().open("rb") as f:
+        return f.read()
+
+
+@_read_packet_file.register
+def _(packet_file: PathLike) -> bytes:
+    """PathLike file path (e.g. anything supporting the Path interface), open and read bytes.
+
+    Notes
+    -----
+    This is a bit inefficient as we have to read the entire file into memory, but it does ensure we close the file after reading.
+    """
+    with open(packet_file, "rb") as f:
+        return f.read()
+
+
+@singledispatch
+def _setup_binary_reader(binary_data, buffer_read_size_bytes=None) -> tuple:
+    """Helper to set up reading from binary_data (file, socket, bytes) for a packet generator.
+
+    Parameters
+    ----------
+    binary_data : Union[io.BufferedIOBase, socket.socket, bytes]
+        The binary data source to read from.
+    buffer_read_size_bytes : Optional[int]
+        The number of bytes to read at a time from the source. If None, defaults to a sensible value based on the type of source.
+
+    Returns
+    -------
+    read_buffer, total_length_bytes, read_bytes_from_source, buffer_read_size_bytes
+
+    Notes
+    -----
+    This function does not handle pathlike objects. It expects objects to be opened and readable already.
+    """
+    raise OSError(f"Unrecognized data source: {binary_data}")
+
+
+@_setup_binary_reader.register(io.BufferedIOBase)
+@_setup_binary_reader.register(io.RawIOBase)
+def _(binary_data: Union[io.BufferedIOBase, io.RawIOBase], buffer_read_size_bytes=None) -> tuple:
+    """Set up a binary reader from a file-like object."""
+    read_buffer = b""
+    if buffer_read_size_bytes is None:
+        # Default to a full read of the file
+        buffer_read_size_bytes = -1
+    total_length_bytes = binary_data.seek(0, io.SEEK_END)
+    binary_data.seek(0, 0)
+    read_bytes_from_source = binary_data.read
+    logger.info(
+        f"Creating packet generator from a filelike object, {binary_data}. Total length is {total_length_bytes} bytes"
+    )
+    return read_buffer, total_length_bytes, read_bytes_from_source, buffer_read_size_bytes
+
+
+@_setup_binary_reader.register
+def _(binary_data: socket.socket, buffer_read_size_bytes=None) -> tuple:
+    """Set up a binary reader from a socket object."""
+    read_buffer = b""
+    total_length_bytes = None  # We don't know how long it is
+    if buffer_read_size_bytes is None:
+        # Default to 4096 bytes from a socket
+        buffer_read_size_bytes = 4096
+    read_bytes_from_source = binary_data.recv
+    logger.info("Creating packet generator to read from a socket. Total length to parse is unknown.")
+    return read_buffer, total_length_bytes, read_bytes_from_source, buffer_read_size_bytes
+
+
+@_setup_binary_reader.register
+def _(binary_data: bytes, buffer_read_size_bytes=None) -> tuple:
+    """Set up a binary reader from a bytes object."""
+    read_buffer = b""
+    read_buffer = binary_data
+    total_length_bytes = len(read_buffer)
+    read_bytes_from_source = None  # No data to read, we've filled the read_buffer already
+    logger.info(f"Creating packet generator from a bytes object. Total length is {total_length_bytes} bytes")
+    return read_buffer, total_length_bytes, read_bytes_from_source, buffer_read_size_bytes
+
+
+@_setup_binary_reader.register
+def _(binary_data: io.TextIOWrapper, buffer_read_size_bytes=None):
+    """Informative error if someone tries to pass a text file."""
+    raise OSError("Packet data file opened in TextIO mode. You must open packet data in binary mode.")
+
+
+def _print_progress(
+    *,
+    current_bytes: int,
+    total_bytes: Optional[int],
+    start_time_ns: int,
+    current_packets: int,
+    end: str = "\r",
+    log: bool = False,
+):
+    """Prints a progress bar for a packet generator, including statistics on parsing rate.
+
+    Parameters
+    ----------
+    current_bytes : int
+        Number of bytes parsed so far.
+    total_bytes : Optional[int]
+        Number of total bytes to parse, if known. None otherwise.
+    current_packets : int
+        Number of packets parsed so far.
+    start_time_ns : int
+        Start time on system clock, in nanoseconds.
+    end : str
+        Print function end string. Default is `\\r` to create a dynamically updating loading bar.
+    log : bool
+        If True, log the progress bar at INFO level.
+    """
+    progress_char = "="
+    bar_length = 20
+
+    if total_bytes is not None:  # If we actually have an endpoint (i.e. not using a socket)
+        percentage: Union[str, int] = int((current_bytes / total_bytes) * 100)  # Percent Completed Calculation
+        progress = int((bar_length * current_bytes) / total_bytes)  # Progress Done Calculation
+    else:
+        percentage = "???"
+        progress = 0
+
+    # Fast calls initially on Windows can result in a zero elapsed time
+    elapsed_ns = max(time.time_ns() - start_time_ns, 1)
+    delta = dt.timedelta(microseconds=elapsed_ns / 1e3)
+    kbps = int(current_bytes * 8e6 / elapsed_ns)  # 8 bits per byte, 1E9 s per ns, 1E3 bits per kb
+    pps = int(current_packets * 1e9 / elapsed_ns)
+    info_str = (
+        f"[Elapsed: {delta}, Parsed {current_bytes} bytes ({current_packets} packets) at {kbps}kb/s ({pps}pkts/s)]"
+    )
+    loadbar = f"Progress: [{progress * progress_char:{bar_length}}]{percentage}% {info_str}"
+    print(loadbar, end=end)
+    if log:
+        logger.info(loadbar)

--- a/space_packet_parser/packets.py
+++ b/space_packet_parser/packets.py
@@ -2,7 +2,7 @@ import warnings
 
 # Reimport the classes and functions from space_packet_parser.ccsds module
 # This is done to maintain backwards compatibility with the old imports
-from space_packet_parser.ccsds import *  # noqa: F403
+from space_packet_parser.generators.ccsds import *  # noqa: F403
 
 warnings.warn(
     "The space_packet_parser.packets module is deprecated. "

--- a/tests/benchmark/test_slow_benchmarks.py
+++ b/tests/benchmark/test_slow_benchmarks.py
@@ -5,7 +5,7 @@ Each test in this suite tests a specific metric over time
 
 import pytest
 
-from space_packet_parser import ccsds
+from space_packet_parser import generators
 from space_packet_parser.xtce import definitions
 
 
@@ -34,7 +34,7 @@ def test_benchmark_simple_packet_parsing(benchmark, jpss_test_data_dir):
         def _setup():
             """Function that sets up for each benchmark round"""
             packet_fh.seek(0)
-            ccsds_generator = ccsds.ccsds_generator(packet_fh)
+            ccsds_generator = generators.ccsds_generator(packet_fh)
             return (), {"generator": ccsds_generator}  # args, kwargs for benchmarked function
 
         def _make_packet_list(generator):
@@ -67,7 +67,7 @@ def test_benchmark_complex_packet_parsing(benchmark, idex_test_data_dir):
         def _setup():
             """Function that sets up for each benchmark round"""
             packet_fh.seek(0)
-            ccsds_generator = ccsds.ccsds_generator(packet_fh, show_progress=True)
+            ccsds_generator = generators.ccsds_generator(packet_fh, show_progress=True)
             return (), {"generator": ccsds_generator}  # args, kwargs for benchmarked function
 
         def _make_packet_list(generator):

--- a/tests/integration/test_bufferedreader_parsing.py
+++ b/tests/integration/test_bufferedreader_parsing.py
@@ -2,7 +2,7 @@
 
 # Local
 import space_packet_parser as spp
-from space_packet_parser import ccsds
+from space_packet_parser import generators
 from space_packet_parser.xtce import definitions
 
 
@@ -15,7 +15,7 @@ def test_jpss_xtce_packet_parsing(jpss_test_data_dir):
     jpss_packet_file = jpss_test_data_dir / "J01_G011_LZ_2021-04-09T00-00-00Z_V01.DAT1"
 
     with jpss_packet_file.open("rb") as binary_data:
-        jpss_ccsds_generator = ccsds.ccsds_generator(binary_data, show_progress=True)
+        jpss_ccsds_generator = generators.ccsds_generator(binary_data, show_progress=True)
         n_packets = 0
         for packet_bytes in jpss_ccsds_generator:
             jpss_packet = jpss_definition.parse_bytes(packet_bytes)

--- a/tests/integration/test_socket_parsing.py
+++ b/tests/integration/test_socket_parsing.py
@@ -8,7 +8,7 @@ from threading import Thread
 
 import pytest
 
-from space_packet_parser import ccsds
+from space_packet_parser import generators
 from space_packet_parser.xtce.definitions import XtcePacketDefinition
 
 
@@ -58,7 +58,7 @@ def test_parsing_from_socket(jpss_test_data_dir):
         )
         t.start()
 
-        ccsds_generator = ccsds.ccsds_generator(receiver, buffer_read_size_bytes=4096)
+        ccsds_generator = generators.ccsds_generator(receiver, buffer_read_size_bytes=4096)
         packets = []
         with pytest.raises(socket.timeout):  # noqa PT012
             for packet_bytes in ccsds_generator:

--- a/tests/integration/test_xtce_based_parsing/test_ctim_parsing.py
+++ b/tests/integration/test_xtce_based_parsing/test_ctim_parsing.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from space_packet_parser import ccsds
+from space_packet_parser import generators
 from space_packet_parser.xtce import definitions
 
 
@@ -17,7 +17,7 @@ def test_ctim_parsing(ctim_test_data_dir):
     print("Loading and parsing data")
     test_packet_file = ctim_test_data_dir / "ccsds_2021_155_14_39_51"
     with open(test_packet_file, "rb") as pkt_file:
-        ccsds_gen = ccsds.ccsds_generator(pkt_file, show_progress=True)
+        ccsds_gen = generators.ccsds_generator(pkt_file, show_progress=True)
         packets = [
             pkt_def.parse_bytes(binary_data, root_container_name="CCSDSTelemetryPacket") for binary_data in ccsds_gen
         ]

--- a/tests/integration/test_xtce_based_parsing/test_inheritance_restrictions.py
+++ b/tests/integration/test_xtce_based_parsing/test_inheritance_restrictions.py
@@ -1,7 +1,7 @@
 """Test RestrictionCriteria being used creatively with JPSS data"""
 
 import space_packet_parser as spp
-from space_packet_parser import ccsds
+from space_packet_parser import generators
 from space_packet_parser.xtce import definitions
 
 
@@ -13,7 +13,7 @@ def test_jpss_xtce_packet_parsing(jpss_test_data_dir):
 
     jpss_packet_file = jpss_test_data_dir / "J01_G011_LZ_2021-04-09T00-00-00Z_V01.DAT1"
     with jpss_packet_file.open("rb") as binary_data:
-        jpss_ccsds_generator = ccsds.ccsds_generator(binary_data)
+        jpss_ccsds_generator = generators.ccsds_generator(binary_data)
         for _ in range(3):  # Iterate through 3 packets and check that the parsed APID remains the same
             packet_bytes = next(jpss_ccsds_generator)
             jpss_packet = jpss_definition.parse_bytes(packet_bytes)

--- a/tests/integration/test_xtce_based_parsing/test_jpss_parsing.py
+++ b/tests/integration/test_xtce_based_parsing/test_jpss_parsing.py
@@ -1,7 +1,7 @@
 """Integration test for parsing JPSS packets"""
 
 import space_packet_parser as spp
-from space_packet_parser import ccsds
+from space_packet_parser import generators
 from space_packet_parser.xtce import definitions
 
 
@@ -16,7 +16,7 @@ def test_jpss_xtce_packet_parsing(jpss_test_data_dir):
     jpss_packet_file = jpss_test_data_dir / "J01_G011_LZ_2021-04-09T00-00-00Z_V01.DAT1"
 
     with jpss_packet_file.open("rb") as binary_data:
-        jpss_ccsds_generator = ccsds.ccsds_generator(binary_data, show_progress=True)
+        jpss_ccsds_generator = generators.ccsds_generator(binary_data, show_progress=True)
 
         n_packets = 0
         for packet_bytes in jpss_ccsds_generator:

--- a/tests/integration/test_xtce_based_parsing/test_suda_parsing.py
+++ b/tests/integration/test_xtce_based_parsing/test_suda_parsing.py
@@ -6,7 +6,7 @@ The data used here is SUDA data but the fields are parsed using IDEX naming conv
 
 # Local
 import space_packet_parser as spp
-from space_packet_parser import ccsds
+from space_packet_parser import generators
 from space_packet_parser.xtce import definitions
 
 
@@ -52,14 +52,14 @@ def test_suda_xtce_packet_parsing(suda_test_data_dir):
     suda_packet_file = suda_test_data_dir / "sciData_2022_130_17_41_53.spl"
 
     with suda_packet_file.open("rb") as suda_binary_data:
-        suda_ccsds_generator = ccsds.ccsds_generator(suda_binary_data, skip_header_bytes=4, show_progress=True)
+        suda_ccsds_generator = generators.ccsds_generator(suda_binary_data, skip_header_bytes=4, show_progress=True)
         for packet_bytes in suda_ccsds_generator:
             suda_packet = suda_definition.parse_bytes(packet_bytes)
             assert isinstance(suda_packet, spp.SpacePacket)
             assert suda_packet["PKT_APID"] == 1425, "APID is not as expected."
             assert suda_packet["VERSION"] == 0, "CCSDS header VERSION incorrect."
 
-        suda_ccsds_generator = ccsds.ccsds_generator(suda_binary_data, skip_header_bytes=4)
+        suda_ccsds_generator = generators.ccsds_generator(suda_binary_data, skip_header_bytes=4)
 
         try:
             packet_bytes = next(suda_ccsds_generator)

--- a/tests/unit/test_generators/test_fixed_length.py
+++ b/tests/unit/test_generators/test_fixed_length.py
@@ -1,5 +1,5 @@
 from space_packet_parser import load_xtce
-from space_packet_parser.common import fixed_length_generator
+from space_packet_parser.generators.fixed_length import fixed_length_generator
 
 
 def test_fixed_length_generator():

--- a/tests/unit/test_generators/test_utils.py
+++ b/tests/unit/test_generators/test_utils.py
@@ -1,0 +1,197 @@
+"""Tests for the generators.utils module"""
+
+import io
+import socket
+from unittest.mock import Mock
+
+import pytest
+
+from space_packet_parser.generators.utils import _read_packet_file, _setup_binary_reader
+
+
+@pytest.mark.parametrize(
+    ("input_data", "expected_data"),
+    [
+        pytest.param(b"test packet data", b"test packet data", id="bytes-direct"),
+        pytest.param(b"\x01\x02\x03\x04", b"\x01\x02\x03\x04", id="bytes-binary"),
+        pytest.param(b"", b"", id="bytes-empty"),
+    ],
+)
+def test_read_packet_file_bytes(input_data, expected_data):
+    """Test _read_packet_file with bytes input."""
+    result = _read_packet_file(input_data)
+    assert result == expected_data
+    assert isinstance(result, bytes)
+    _setup_binary_reader(result)
+
+
+@pytest.mark.parametrize(
+    "file_content",
+    [
+        b"test file content",
+        b"\x00\x01\x02\x03\x04\x05",
+        b"",
+        b"\xff" * 1000,  # Larger file
+    ],
+)
+def test_read_packet_file_string_path(tmp_path, file_content):
+    """Test _read_packet_file with string file path."""
+    test_file = tmp_path / "test_packet.bin"
+    test_file.write_bytes(file_content)
+
+    result = _read_packet_file(str(test_file))
+    assert result == file_content
+    assert isinstance(result, bytes)
+    _setup_binary_reader(result)
+
+
+@pytest.mark.parametrize(
+    "file_content",
+    [
+        b"path object test",
+        b"\x10\x20\x30",
+        b"",
+    ],
+)
+def test_read_packet_file_path_object(tmp_path, file_content):
+    """Test _read_packet_file with Path object."""
+    test_file = tmp_path / "test_packet.bin"
+    test_file.write_bytes(file_content)
+
+    result = _read_packet_file(test_file)
+    assert result == file_content
+    assert isinstance(result, bytes)
+    _setup_binary_reader(result)
+
+
+@pytest.mark.parametrize(
+    "file_content",
+    [
+        b"buffered io test",
+        b"\x01\x02\x03",
+        b"",
+    ],
+)
+def test_read_packet_file_buffered_io(file_content):
+    """Test _read_packet_file with BufferedIOBase (BytesIO)."""
+    bio = io.BytesIO(file_content)
+    result = _read_packet_file(bio)
+    assert result.read() == file_content
+    _setup_binary_reader(result)
+
+
+def test_read_packet_file_raw_io(tmp_path):
+    """Test _read_packet_file with RawIOBase (opened file)."""
+    test_content = b"raw io test"
+    test_file = tmp_path / "test_packet.bin"
+    test_file.write_bytes(test_content)
+
+    with open(test_file, "rb") as f:
+        result = _read_packet_file(f)
+        assert result.read() == test_content
+        _setup_binary_reader(result)
+
+
+@pytest.mark.parametrize(
+    ("input_data", "expected_error", "error_pattern"),
+    [
+        pytest.param(42, OSError, r"Unable to open and read packet_file type: <class 'int'>", id="unsupported-int"),
+        pytest.param([], OSError, r"Unable to open and read packet_file type: <class 'list'>", id="unsupported-list"),
+        pytest.param({}, OSError, r"Unable to open and read packet_file type: <class 'dict'>", id="unsupported-dict"),
+        pytest.param(
+            None, OSError, r"Unable to open and read packet_file type: <class 'NoneType'>", id="unsupported-none"
+        ),
+    ],
+)
+def test_read_packet_file_unsupported_types(input_data, expected_error, error_pattern):
+    """Test _read_packet_file with unsupported input types."""
+    with pytest.raises(expected_error, match=error_pattern):
+        _read_packet_file(input_data)
+
+
+@pytest.mark.parametrize(
+    ("file_content", "buffer_size", "expected_buffer_size"),
+    [
+        pytest.param(b"test file io", None, -1, id="filelike-default-buffer"),
+        pytest.param(b"test file io", 1024, 1024, id="filelike-custom-buffer"),
+        pytest.param(b"\x01\x02\x03", 512, 512, id="filelike-small-custom-buffer"),
+        pytest.param(b"", None, -1, id="filelike-empty-file"),
+    ],
+)
+def test_setup_binary_reader_file_like(tmp_path, file_content, buffer_size, expected_buffer_size):
+    """Test _setup_binary_reader with file-like objects."""
+    test_file = tmp_path / "test_packet.bin"
+    test_file.write_bytes(file_content)
+
+    with open(test_file, "rb") as f:
+        read_buffer, total_length, read_func, actual_buffer_size = _setup_binary_reader(f, buffer_size)
+
+        assert read_buffer == b""
+        assert total_length == len(file_content)
+        assert callable(read_func)
+        assert actual_buffer_size == expected_buffer_size
+        assert read_func == f.read
+
+
+def test_setup_binary_reader_bytesio():
+    """Test _setup_binary_reader with BytesIO object."""
+    test_data = b"bytesio test data"
+    bio = io.BytesIO(test_data)
+
+    read_buffer, total_length, read_func, buffer_size = _setup_binary_reader(bio)
+
+    assert read_buffer == b""
+    assert total_length == len(test_data)
+    assert callable(read_func)
+    assert buffer_size == -1
+    assert read_func == bio.read
+
+
+@pytest.mark.parametrize(
+    ("buffer_size", "expected_buffer_size"),
+    [
+        pytest.param(None, 4096, id="socket-default-buffer"),
+        pytest.param(8192, 8192, id="socket-custom-buffer"),
+        pytest.param(1024, 1024, id="socket-small-buffer"),
+    ],
+)
+def test_setup_binary_reader_socket(buffer_size, expected_buffer_size):
+    """Test _setup_binary_reader with socket objects."""
+    mock_socket = Mock(spec=socket.socket)
+
+    read_buffer, total_length, read_func, actual_buffer_size = _setup_binary_reader(mock_socket, buffer_size)
+
+    assert read_buffer == b""
+    assert total_length is None
+    assert callable(read_func)
+    assert actual_buffer_size == expected_buffer_size
+    assert read_func == mock_socket.recv
+
+
+@pytest.mark.parametrize(
+    "test_bytes",
+    [
+        b"test bytes data",
+        b"\x00\x01\x02\x03",
+        b"",
+        b"\xff" * 1000,
+    ],
+)
+def test_setup_binary_reader_bytes(test_bytes):
+    """Test _setup_binary_reader with bytes objects."""
+    read_buffer, total_length, read_func, buffer_size = _setup_binary_reader(test_bytes)
+
+    assert read_buffer == test_bytes
+    assert total_length == len(test_bytes)
+    assert read_func is None
+    assert buffer_size is None
+
+
+def test_setup_binary_reader_text_file(tmp_path):
+    """Test _setup_binary_reader with actual text file (should raise error)."""
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("text content")
+
+    with open(test_file) as text_file:
+        with pytest.raises(OSError, match=r"Packet data file opened in TextIO mode"):
+            _setup_binary_reader(text_file)

--- a/tests/unit/test_xtce/test_containers.py
+++ b/tests/unit/test_xtce/test_containers.py
@@ -4,7 +4,8 @@ import struct
 
 import pytest
 
-from space_packet_parser import SpacePacket, ccsds
+from space_packet_parser import SpacePacket
+from space_packet_parser.generators import ccsds
 from space_packet_parser.xtce import containers, encodings, parameter_types, parameters
 
 

--- a/tests/unit/test_xtce/test_definitions.py
+++ b/tests/unit/test_xtce/test_definitions.py
@@ -6,7 +6,7 @@ import pytest
 from lxml import etree as ElementTree
 
 import space_packet_parser as spp
-import space_packet_parser.ccsds
+import space_packet_parser.generators.ccsds
 import space_packet_parser.xtce.parameter_types
 from space_packet_parser.xtce import comparisons, containers, definitions, encodings, parameters
 
@@ -589,8 +589,8 @@ def test_parse_methods(test_data_dir):
     xdef = definitions.XtcePacketDefinition.from_xtce(test_data_dir / "test_xtce.xml")
 
     # Test parsing a packet
-    empty_packet_data = space_packet_parser.ccsds.create_ccsds_packet(
-        data=bytes(65), apid=11, sequence_flags=space_packet_parser.ccsds.SequenceFlags.UNSEGMENTED
+    empty_packet_data = space_packet_parser.generators.ccsds.create_ccsds_packet(
+        data=bytes(65), apid=11, sequence_flags=space_packet_parser.generators.ccsds.SequenceFlags.UNSEGMENTED
     )
 
     # Parse in the simplest way and compare result to other parse methods
@@ -621,8 +621,8 @@ def test_parse_packet_extra_bytes(test_data_dir):
     xdef = definitions.XtcePacketDefinition.from_xtce(test_data_dir / "test_xtce.xml")
 
     # Test parsing a packet that is longer than the definition
-    too_long_packet_data = space_packet_parser.ccsds.create_ccsds_packet(
-        data=bytes(70), apid=11, sequence_flags=space_packet_parser.ccsds.SequenceFlags.UNSEGMENTED
+    too_long_packet_data = space_packet_parser.generators.ccsds.create_ccsds_packet(
+        data=bytes(70), apid=11, sequence_flags=space_packet_parser.generators.ccsds.SequenceFlags.UNSEGMENTED
     )
 
     with pytest.warns(
@@ -639,8 +639,8 @@ def test_parse_packet_too_few_bytes(test_data_dir):
     xdef = definitions.XtcePacketDefinition.from_xtce(test_data_dir / "test_xtce.xml")
 
     # Test parsing a packet that is longer than the definition
-    too_short_packet_data = space_packet_parser.ccsds.create_ccsds_packet(
-        data=bytes(60), apid=11, sequence_flags=space_packet_parser.ccsds.SequenceFlags.UNSEGMENTED
+    too_short_packet_data = space_packet_parser.generators.ccsds.create_ccsds_packet(
+        data=bytes(60), apid=11, sequence_flags=space_packet_parser.generators.ccsds.SequenceFlags.UNSEGMENTED
     )
 
     with pytest.raises(


### PR DESCRIPTION
# Add File-like Object Support to `create_dataset`

  ## Summary
  Enhanced the `create_dataset` function to accept file-like objects (such as those created with `open(filepath, "rb")` or `io.BytesIO`)
  in addition to file paths for both packet files and XTCE definitions.

  ## Changes Made

  ### Core Implementation (`space_packet_parser/xarr.py`)
  - **Enhanced type annotations**: Updated `packet_files` parameter to accept `BinaryIO` and `bytes` types alongside existing `str` and
  `Path` types
  - **Added file-like object detection**: Implemented logic to differentiate between file paths and file-like objects using type checking
  - **Restructured packet processing**: Refactored the main loop to handle both file paths (opened with context manager) and file-like
  objects (used directly)
  - **Improved code organization**: Extracted packet processing logic into a helper function `_process_generator()` to avoid code
  duplication

  ### Comprehensive Test Coverage (`tests/unit/test_xarr.py`)
  - **File-like objects test**: Tests passing file handles opened with `open(filepath, "rb")` and `io.BytesIO` objects
  - **Mixed file types test**: Tests combining file paths and file-like objects in the same call
  - **XTCE file-like support**: Tests using `io.StringIO` for XTCE definitions alongside binary file-like objects for packet data

## Checklist
- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [NA] The changelog.md has been updated
