### PR TITLE
FIX: Handle optional secondary headers with CCSDS continuation packets

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -10,6 +10,7 @@ Release notes for the `space_packet_parser` library
 ### v6.1.0
 
 - Add support for filtering packets in `create_dataset`
+- BUGFIX: Handle optional secondary headers with CCSDS continuation packets
 
 ### v6.0.0 (released)
 

--- a/space_packet_parser/generators/ccsds.py
+++ b/space_packet_parser/generators/ccsds.py
@@ -381,7 +381,12 @@ def ccsds_generator(
             binary_data = packets[0]
             # Add the continuation packets to the first packet, skipping the headers
             for p in packets[1:]:
-                binary_data += p[header_length_bytes + secondary_header_bytes :]
+                # The continuation packets may or may not have a secondary header,
+                # so we need to account for both cases when trimming the initial header
+                tmp_header_length = (
+                    header_length_bytes + secondary_header_bytes if p.secondary_header_flag else header_length_bytes
+                )
+                binary_data += p[tmp_header_length:]
             yield CCSDSPacketBytes(binary_data)
 
     if show_progress:

--- a/tests/unit/test_generators/test_ccsds.py
+++ b/tests/unit/test_generators/test_ccsds.py
@@ -152,13 +152,25 @@ def test_continuation_packets(test_data_dir):
     # but skip the following
     # Add in 4 1s to the 2nd and 3rd packet that should be removed
     p0 = ccsds.create_ccsds_packet(
-        data=b"0" * 63, apid=11, sequence_flags=ccsds.SequenceFlags.FIRST, sequence_count=16382
+        data=b"0" * 63,
+        apid=11,
+        sequence_flags=ccsds.SequenceFlags.FIRST,
+        sequence_count=16382,
+        secondary_header_flag=False,
     )
     p1 = ccsds.create_ccsds_packet(
-        data=b"1" * 4 + b"0" * 1, apid=11, sequence_flags=ccsds.SequenceFlags.CONTINUATION, sequence_count=16383
+        data=b"1" * 4 + b"0" * 1,
+        apid=11,
+        sequence_flags=ccsds.SequenceFlags.CONTINUATION,
+        sequence_count=16383,
+        secondary_header_flag=True,
     )
     p2 = ccsds.create_ccsds_packet(
-        data=b"1" * 4 + b"0" * 1, apid=11, sequence_flags=ccsds.SequenceFlags.LAST, sequence_count=0
+        data=b"1" * 4 + b"0" * 1,
+        apid=11,
+        sequence_flags=ccsds.SequenceFlags.LAST,
+        sequence_count=0,
+        secondary_header_flag=True,
     )
     raw_bytes = p0 + p1 + p2
     result_packets = [
@@ -169,6 +181,42 @@ def test_continuation_packets(test_data_dir):
     ]
     remove_keys(result_packets[0])
     assert result_packets == orig_packets
+
+
+def test_continuation_packets_secondary_header(test_data_dir):
+    """Continuation packets may or may not contain secondary headers.
+
+    When combining the bytes from multiple packets, the secondary headers from all but the first packet
+    should be stripped out.
+    """
+    # 8 byte long data, with 4 byte secondary headers in each packet
+    data = b"0" * 8
+    p0 = ccsds.create_ccsds_packet(
+        data=data, apid=11, sequence_flags=ccsds.SequenceFlags.FIRST, sequence_count=0, secondary_header_flag=True
+    )
+    p1 = ccsds.create_ccsds_packet(
+        data=data,
+        apid=11,
+        sequence_flags=ccsds.SequenceFlags.CONTINUATION,
+        sequence_count=1,
+        secondary_header_flag=True,
+    )
+    p2 = ccsds.create_ccsds_packet(
+        data=data, apid=11, sequence_flags=ccsds.SequenceFlags.LAST, sequence_count=2, secondary_header_flag=False
+    )
+    raw_bytes = p0 + p1 + p2
+    result_packets = [
+        packet
+        for packet in space_packet_parser.generators.ccsds_generator(
+            raw_bytes, combine_segmented_packets=True, secondary_header_bytes=4
+        )
+    ]
+    assert len(result_packets) == 1
+    # The combined packet should strip the secondary header from packet 2, but packet 3 has no secondary header
+    combined_packet = result_packets[0]
+    assert combined_packet.secondary_header_flag == 1
+    # The data should be 8 + 4 + 8 = 20 bytes long
+    assert len(combined_packet.user_data) == 20
 
 
 def test_continuation_packet_warnings(test_data_dir):


### PR DESCRIPTION
There may or may not be a secondary header on the continuation packets for the CCSDS segmented packets. We can check whether the flag is set or not before stripping the secondary header bytes.

closes #206 

## Checklist

- [x] Changes are fully implemented without dangling issues or TODO items
- [n/a] Deprecated/superseded code is removed or marked with deprecation warning
- [n/a] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
