### PR TITLE
FIX: CCSDS packet generator bit logic needs concatentation before addition

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -5,6 +5,11 @@ list and release milestones.
 ## Version Release Notes
 Release notes for the `space_packet_parser` library
 
+### v6.0.1 (unreleased)
+
+- BUGFIX: Incorrect bitshift logic for ccsds generator packet length creation
+  in very specific circumstances (only if large data on power of 2 boundary)
+
 ### v6.0.0 (released)
 - *BREAKING*: `XtcePacketDefinition` no longer accepts a file object as input.
   Use `spp.xtce.definitions.XtcePacketDefinition.from_xtce()` or `spp.load_xtce()` instead.

--- a/space_packet_parser/generators/ccsds.py
+++ b/space_packet_parser/generators/ccsds.py
@@ -329,7 +329,7 @@ def ccsds_generator(
         # 4.1.3.5.3 The length count C shall be expressed as:
         #   C = (Total Number of Octets in the Packet Data Field) – 1
         # Use direct bitshift here rather than _extract_bits for speed
-        n_bytes_data = (read_buffer[current_pos + 4] << 8) | read_buffer[current_pos + 5] + 1
+        n_bytes_data = ((read_buffer[current_pos + 4] << 8) | read_buffer[current_pos + 5]) + 1
         n_bytes_packet = header_length_bytes + n_bytes_data
 
         # Fill the buffer enough to read a full packet, taking into account the user data length


### PR DESCRIPTION
There was an error in the bitshifting logic where there was a 1 added to the right-most byte before or'ing the two bytes together. This causes an error only on packets with data size greater than 2**8 and near a power of 2 boundary.

@medley56 I'd like to get this in a release ASAP because it is a pretty bad bug we are encountering when I am trying to update to the latest version (Doh! My oversight here forgetting parens). Do we want to backport this to a release bugfix branch to do a v6.0.1 release?

## Checklist

- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
