### PR TITLE
FIX: Only yield complete packets from ccsds_generator

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -11,6 +11,7 @@ Release notes for the `space_packet_parser` library
 
 - Add support for filtering packets in `create_dataset`
 - BUGFIX: Handle optional secondary headers with CCSDS continuation packets
+- Add warnings if there are leftover bytes from a CCSDS generator
 
 ### v6.0.0 (released)
 

--- a/space_packet_parser/generators/ccsds.py
+++ b/space_packet_parser/generators/ccsds.py
@@ -324,6 +324,12 @@ def ccsds_generator(
             read_buffer += result
         # Skip the header bytes
         current_pos += skip_header_bytes
+        if len(read_buffer) - current_pos < header_length_bytes:
+            warnings.warn(
+                f"{len(read_buffer) - current_pos} bytes left to read is not enough to read "
+                f"a CCSDS header ({header_length_bytes} bytes), ending generator with leftover bytes."
+            )
+            break
 
         # per the CCSDS spec
         # 4.1.3.5.3 The length count C shall be expressed as:
@@ -338,6 +344,13 @@ def ccsds_generator(
             if not result:  # If there is verifiably no more data to add, break
                 break
             read_buffer += result
+        if len(read_buffer) - current_pos < n_bytes_packet:
+            warnings.warn(
+                f"{len(read_buffer) - current_pos} bytes left to read is not enough to read "
+                f"a full packet ({n_bytes_packet}) based on the data length field, "
+                "ending generator with leftover bytes."
+            )
+            break
 
         # Consider it a counted packet once we've verified that we have read the full packet and parsed the header
         # Update the number of packets and bytes parsed

--- a/space_packet_parser/generators/utils.py
+++ b/space_packet_parser/generators/utils.py
@@ -134,7 +134,11 @@ def _(binary_data: bytes, buffer_read_size_bytes=None) -> tuple:
     read_buffer = b""
     read_buffer = binary_data
     total_length_bytes = len(read_buffer)
-    read_bytes_from_source = None  # No data to read, we've filled the read_buffer already
+
+    def read_bytes_from_source(size: int) -> bytes:
+        """No data to read, we've filled the read_buffer already."""
+        return b""
+
     logger.info(f"Creating packet generator from a bytes object. Total length is {total_length_bytes} bytes")
     return read_buffer, total_length_bytes, read_bytes_from_source, buffer_read_size_bytes
 

--- a/tests/unit/test_generators/test_utils.py
+++ b/tests/unit/test_generators/test_utils.py
@@ -183,7 +183,8 @@ def test_setup_binary_reader_bytes(test_bytes):
 
     assert read_buffer == test_bytes
     assert total_length == len(test_bytes)
-    assert read_func is None
+    assert callable(read_func)
+    assert read_func(10) == b""
     assert buffer_size is None
 
 


### PR DESCRIPTION
Previously, if we had enough bytes for a partial packet, we could end up creating a packet that was not as long as the number of bytes requested. This can happen if the file delivered has a partial packet at the end of it. Addtionally, if we only have a few bytes left at the end, we would try to read from the bytes source and end up reading from None, so implement a pass-through function to make sure that doesn't fail if it is called.

## Checklist

- [x] Changes are fully implemented without dangling issues or TODO items
- [x] Deprecated/superseded code is removed or marked with deprecation warning
- [x] Current dependencies have been properly specified and old dependencies removed
- [x] New code/functionality has accompanying tests and any old tests have been updated to match any new assumptions
- [x] The changelog.md has been updated
