### PR TITLE
6.1.0 Release PR

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -7,16 +7,13 @@ list and release milestones.
 
 Release notes for the `space_packet_parser` library
 
-### v6.2.0
-
-- Migrated from Poetry to uv/hatchling for Python project management
-
 ### v6.1.0
 
-- Add support for filtering packets in `create_dataset`
+- DEVOPS: Migrated from Poetry to uv/hatchling for Python project management
+- PERF: Add support for filtering packets in `create_dataset`
 - BUGFIX: Handle optional secondary headers with CCSDS continuation packets
 - Add warnings if there are leftover bytes from a CCSDS generator
-- Add support for Python 3.14
+- DEVOPS: Add support for Python 3.14
 
 ### v6.0.1
 


### PR DESCRIPTION
Preparing for release of 6.1.0

Updated changelog, which listed 6.2.0 and 6.1.0 (both unreleased) into single 6.1.0 release.
