### PR TITLE
Fix BinaryParameter truncation in xarray dataset creation

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -46,7 +46,7 @@ jobs:
 
       # Save ("upload") the distribution artifacts for use by downstream Actions jobs
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v6 # This allows us to persist the dist directory after the job has completed
+        uses: actions/upload-artifact@v7 # This allows us to persist the dist directory after the job has completed
         with:
           name: python-package-distributions
           path: dist/
@@ -98,7 +98,7 @@ jobs:
 
       # This makes the artifacts available for downstream jobs
       - name: Upload Conda build artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: conda-package
           path: ${{ env.CONDA_BLD_PATH }}/**/space_packet_parser-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           pytest --color=yes --cov --cov-report=xml
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           use_oidc: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,12 +146,21 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         # Uses the GitHub CLI to generate the Release and auto-generate the release notes. Also generates
         # the Release title based on the annotation on the git tag.
-        run: >-
+        run: |
           RELEASE_NAME=$(basename "${{ github.ref_name }}")
-          gh release create
-          '${{ github.ref_name }}'
-          --repo '${{ github.repository }}'
-          --title "$RELEASE_NAME"
-          ${{ env.PRE_RELEASE_OPTION }}
-          --generate-notes
-          --notes-start-tag '${{ env.LATEST_RELEASE_TAG }}'
+          ARGS=(
+            "${{ github.ref_name }}"
+            --repo "${{ github.repository }}"
+            --title "$RELEASE_NAME"
+          )
+
+          if [ "${{ env.PRE_RELEASE_OPTION }}" = "--prerelease" ]; then
+            ARGS+=(--prerelease)
+          fi
+
+          ARGS+=(
+            --generate-notes
+            --notes-start-tag "${{ env.LATEST_RELEASE_TAG }}"
+          )
+
+          gh release create "${ARGS[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # This downloads the build artifacts from the build job
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/
@@ -59,7 +59,7 @@ jobs:
     steps:
       # This downloads the build artifacts from the build job
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Download Conda artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: conda-package
           path: conda-package/

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ build
 dist
 space_packet_parser/_version.py
 uv.lock
+node_modules
 
 # Packages #
 ############

--- a/space_packet_parser/xarr.py
+++ b/space_packet_parser/xarr.py
@@ -16,6 +16,7 @@ from os import PathLike
 from pathlib import Path
 from typing import BinaryIO
 
+from space_packet_parser import common
 from space_packet_parser.exceptions import UnrecognizedPacketTypeError
 from space_packet_parser.generators import ccsds_generator
 from space_packet_parser.generators.utils import _read_packet_file
@@ -235,6 +236,10 @@ def create_dataset(
                     val = value.raw_value
                 else:
                     val = value
+
+                # Convert BinaryParameter to plain bytes to prevent numpy truncation
+                if isinstance(val, common.BinaryParameter):
+                    val = bytes(val)
 
                 data_dict[apid][key].append(val)
                 if key not in datatype_mapping[apid]:

--- a/tests/unit/test_xarr.py
+++ b/tests/unit/test_xarr.py
@@ -178,6 +178,41 @@ def test_create_dataset_with_custom_generator(tmp_path, fixed_length_packet_defi
     assert list(dataset["INT32_FIELD"].values) == [12345, 67890, -99999]
 
 
+def test_create_dataset_preserves_binary_parameter_width(tmp_path):
+    """Test that binary parameters keep their full byte width in the resulting dataset."""
+    packet_definition = definitions.XtcePacketDefinition(
+        container_set=[
+            containers.SequenceContainer(
+                "BINARY_CONTAINER",
+                entry_list=[
+                    parameters.Parameter(
+                        "BIN_FIELD",
+                        parameter_type=parameter_types.BinaryParameterType(
+                            "BIN_TYPE", encoding=encodings.BinaryDataEncoding(fixed_size_in_bits=64)
+                        ),
+                    )
+                ],
+            )
+        ]
+    )
+    packet_data = b"ABCDEFGH"
+    test_file = tmp_path / "binary_packets.bin"
+    test_file.write_bytes(packet_data)
+
+    datasets = xarr.create_dataset(
+        test_file,
+        packet_definition,
+        packet_bytes_generator=fixed_length_generator,
+        generator_kwargs={"packet_length_bytes": 8},
+        parse_bytes_kwargs={"root_container_name": "BINARY_CONTAINER"},
+    )
+
+    dataset = list(datasets.values())[0]
+
+    assert dataset["BIN_FIELD"].values.dtype.itemsize == 8
+    assert dataset["BIN_FIELD"].values.tolist() == [packet_data]
+
+
 def test_create_dataset_with_packet_filter(tmp_path, fixed_length_packet_definition, fixed_length_test_packets):
     """Test filtering packets with packet_filter parameter using raw byte inspection"""
     _, _, _, binary_data = fixed_length_test_packets


### PR DESCRIPTION
# _Checklist_

_Check these items and delete this block:_

- _The changelog.md has been updated if necessary_ (Is this needed for this PR?)

# Summary

This PR fixes a data-loss bug in xarray dataset creation where binary parameter values could be truncated to 4 bytes during NumPy array construction.

When a parsed value is a BinaryParameter subclass, NumPy can infer an incorrect fixed-width byte dtype when building arrays. The fix converts BinaryParameter values to plain bytes before they are appended for dataset construction, preserving the full payload width.

## Changes

Convert BinaryParameter values to plain bytes in [xarr.py:240](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Add a focused regression test in [test_xarr.py:181](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Details

In [xarr.py:233](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), values are now normalized so BinaryParameter instances are converted with bytes(...) before storing in data_dict.
New regression test [test_xarr.py:181](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) builds a minimal fixed-length binary container and verifies:
The resulting dtype itemsize matches the expected binary width (8 bytes)
The stored value content is unchanged
Why this is needed
Without this conversion, downstream arrays may be created with an undersized byte dtype, causing silent truncation and data loss for binary fields.

## Validation

Ran: pytest [test_xarr.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) -q
Result: 19 passed

## Risk / Compatibility

Change is scoped to BinaryParameter handling only
No behavior change for non-binary parameter types

