### PR TITLE
Add test case and namespace handling for Issues/47 support xtce unitset 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,3 @@ repos:
           - pyyaml
           - tomli
         always_run: true
-  - repo: https://github.com/mashi/codecov-validator
-    rev: 1.0.1
-    hooks:
-      - id: ccv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,12 +33,6 @@ repos:
         files: ^.*\.(py|md|rst|yml)$
   - repo: local
     hooks:
-      - id: codecov-validate
-        name: validate codecov.yml
-        entry: sh -c 'curl --fail --silent --show-error --data-binary @codecov.yml https://codecov.io/validate'
-        language: system
-        files: ^codecov\.yml$
-        pass_filenames: false
       - id: check-space-packet-parser-metadata
         name: check space_packet_parser metadata
         entry: python scripts/check_metadata.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ci:
   autofix_prs: false
   autoupdate_schedule: "quarterly"
-  skip: [no-commit-to-branch, ccv]
+  skip: [no-commit-to-branch]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -33,6 +33,12 @@ repos:
         files: ^.*\.(py|md|rst|yml)$
   - repo: local
     hooks:
+      - id: codecov-validate
+        name: validate codecov.yml
+        entry: sh -c 'curl --fail --silent --show-error --data-binary @codecov.yml https://codecov.io/validate'
+        language: system
+        files: ^codecov\.yml$
+        pass_filenames: false
       - id: check-space-packet-parser-metadata
         name: check space_packet_parser metadata
         entry: python scripts/check_metadata.py

--- a/space_packet_parser/xtce/parameter_types.py
+++ b/space_packet_parser/xtce/parameter_types.py
@@ -126,8 +126,7 @@ class ParameterType(common.AttrComparable, common.XmlObject, metaclass=ABCMeta):
         """
         # Assume we are not parsing a Time Parameter Type, which stores units differently
 
-        units = parameter_type_element.findall("UnitSet/Unit")
-        units = [u.text for u in units if u.text]
+        units = parameter_type_element.xpath('.//*[local-name()="UnitSet"]/*[local-name()="Unit"]/text()')
 
         if not units:
             # Units are optional so return None if they aren't specified
@@ -293,12 +292,15 @@ class EnumeratedParameterType(ParameterType):
         """
 
         param_type_element = getattr(elmaker, self.__class__.__name__)(name=self.name)
-
+        print("HIT PARAMETER TYPE UNIT BLOCK")
         if self.unit:
+            print("Entered PARAMETER TYPE UNIT BLOCK")
             if isinstance(self.unit, tuple):
+                print("Entered IF PARAMETER TYPE UNIT BLOCK")
                 unit_elements = [elmaker.Unit(u) for u in self.unit]
                 param_type_element.append(elmaker.UnitSet(*unit_elements))
             else:
+                print("Entered ELSE PARAMETER TYPE UNIT BLOCK")
                 param_type_element.append(elmaker.UnitSet(elmaker.Unit(self.unit)))
 
         param_type_element.append(self.encoding.to_xml(elmaker=elmaker))

--- a/space_packet_parser/xtce/parameter_types.py
+++ b/space_packet_parser/xtce/parameter_types.py
@@ -292,15 +292,11 @@ class EnumeratedParameterType(ParameterType):
         """
 
         param_type_element = getattr(elmaker, self.__class__.__name__)(name=self.name)
-        print("HIT PARAMETER TYPE UNIT BLOCK")
         if self.unit:
-            print("Entered PARAMETER TYPE UNIT BLOCK")
             if isinstance(self.unit, tuple):
-                print("Entered IF PARAMETER TYPE UNIT BLOCK")
                 unit_elements = [elmaker.Unit(u) for u in self.unit]
                 param_type_element.append(elmaker.UnitSet(*unit_elements))
             else:
-                print("Entered ELSE PARAMETER TYPE UNIT BLOCK")
                 param_type_element.append(elmaker.UnitSet(elmaker.Unit(self.unit)))
 
         param_type_element.append(self.encoding.to_xml(elmaker=elmaker))

--- a/tests/unit/test_xtce/test_parameter_types.py
+++ b/tests/unit/test_xtce/test_parameter_types.py
@@ -211,14 +211,11 @@ def test_integer_parameter_type(elmaker, xtce_parser, xml_string: str, expectati
     else:
         result = parameter_types.IntegerParameterType.from_xml(element)
         assert result == expectation
-
         # Recover XML and re-parse it to check it's recoverable
         result_string = ElementTree.tostring(result.to_xml(elmaker=elmaker), pretty_print=True).decode()
-
         full_circle = parameter_types.IntegerParameterType.from_xml(
             ElementTree.fromstring(result_string, parser=xtce_parser)
         )
-
         assert full_circle == expectation
 
 

--- a/tests/unit/test_xtce/test_parameter_types.py
+++ b/tests/unit/test_xtce/test_parameter_types.py
@@ -172,6 +172,21 @@ def test_string_parameter_type(elmaker, xtce_parser, xml_string: str, expectatio
             f"""
 <xtce:IntegerParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_INT_Type">
     <xtce:UnitSet>
+        <xtce:Unit>km</xtce:Unit>
+    </xtce:UnitSet>
+    <xtce:IntegerDataEncoding sizeInBits="16" encoding="unsigned"/>
+</xtce:IntegerParameterType>
+""",
+            parameter_types.IntegerParameterType(
+                name="TEST_INT_Type",
+                unit="km",
+                encoding=encodings.IntegerDataEncoding(size_in_bits=16, encoding="unsigned"),
+            ),
+        ),
+        (
+            f"""
+<xtce:IntegerParameterType xmlns:xtce="{XTCE_1_2_XMLNS}" name="TEST_INT_Type">
+    <xtce:UnitSet>
         <xtce:Unit>m</xtce:Unit>
         <xtce:Unit>s</xtce:Unit>
     </xtce:UnitSet>
@@ -196,11 +211,14 @@ def test_integer_parameter_type(elmaker, xtce_parser, xml_string: str, expectati
     else:
         result = parameter_types.IntegerParameterType.from_xml(element)
         assert result == expectation
+
         # Recover XML and re-parse it to check it's recoverable
         result_string = ElementTree.tostring(result.to_xml(elmaker=elmaker), pretty_print=True).decode()
+
         full_circle = parameter_types.IntegerParameterType.from_xml(
             ElementTree.fromstring(result_string, parser=xtce_parser)
         )
+
         assert full_circle == expectation
 
 
@@ -843,3 +861,34 @@ def test_absolute_time_parameter_type(elmaker, xtce_parser, xml_string, expectat
             ElementTree.fromstring(result_string, parser=xtce_parser)
         )
         assert full_circle == expectation
+
+
+def test_parameter_type_to_xml_unit_serialization(elmaker):
+    """Test serialization of UnitSet in ParameterType.to_xml"""
+
+    encoding = encodings.IntegerDataEncoding(size_in_bits=16, encoding="unsigned")
+    ns = {"xtce": XTCE_1_2_XMLNS}
+
+    # Single unit
+    param = parameter_types.IntegerParameterType(
+        name="TEST_PARAM_Type",
+        unit="km",
+        encoding=encoding,
+    )
+    element = param.to_xml(elmaker=elmaker)
+
+    units = element.findall(".//xtce:Unit", namespaces=ns)
+    assert len(units) == 1
+    assert units[0].text == "km"
+
+    # Multiple units
+    param = parameter_types.IntegerParameterType(
+        name="TEST_PARAM_Type",
+        unit=("m", "s"),
+        encoding=encoding,
+    )
+    element = param.to_xml(elmaker=elmaker)
+
+    units = element.findall(".//xtce:Unit", namespaces=ns)
+    assert len(units) == 2
+    assert [u.text for u in units] == ["m", "s"]


### PR DESCRIPTION
# Summary

Adds support and test coverage for parsing multiple <xtce:Unit> elements in UnitSet. Fixes namespace handling in ParameterType.get_units to correctly extract units from namespaced XML and ensures enumerated parameter types support multi-unit round-trip serialization. Removes missing codecov-validator pre-commit hook.