### PR TITLE
Harden XTCE schema validation against local file read (CWE-73) and SSRF (CWE-918)

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Fix a local file read vulnerability (CWE-73) and a Server-Side Request Forgery vulnerability
+  (CWE-918) in `validate_xtce`. A document-supplied `xsi:schemaLocation` is now treated as
+  untrusted: absolute and relative local filesystem paths are rejected (use `local_xsd` for a
+  local schema), and schema URLs are fetched only over `https` from an allowlisted host (default
+  `www.omg.org`), with requests to internal/link-local addresses (e.g. `169.254.169.254`,
+  `127.0.0.1`) always blocked. Downloaded content is size-capped and is written to the cache only
+  after it validates as an XSD, so a non-schema response can no longer be persisted to disk.
+  [#266](https://github.com/lasp/space_packet_parser/issues/266)
+
+### Added
+
+- Bundle the standard OMG XTCE 1.2 schema with the package so documents referencing it validate
+  offline with no network request.
+- Add `allowed_schema_hosts`, `allow_insecure_http`, and `allow_schema_download` options to
+  `validate_xtce` (and the corresponding `--allowed-schema-host`, `--allow-insecure-http`, and
+  `--no-schema-download` flags to `spp validate`). The allowlist may also be set via the
+  `SPP_ALLOWED_SCHEMA_HOSTS` environment variable, and insecure http via `SPP_ALLOW_INSECURE_HTTP`.
+  The default allowlist is exported as `DEFAULT_ALLOWED_SCHEMA_HOSTS`.
+
+### Fixed
+
+- `validate_xtce(local_xsd=...)` and `spp validate --local-xsd` again accept absolute paths from
+  any working directory (a regression that silently rewrote them to a bare filename in the current
+  directory). Schema-fetch failures are now reported with accurate error codes
+  (`DISALLOWED_SCHEMA_LOCATION` rather than a misleading `MISSING_SCHEMA_LOCATION`).
+
 ## [6.1.2] - 2026-04-02
 
 ### Fixed

--- a/docs/source/users.md
+++ b/docs/source/users.md
@@ -542,10 +542,58 @@ e.g.
                                       https://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd">
 ```
 
+### Schema resolution and network security
+
+Because an XTCE document's `xsi:schemaLocation` is attacker-controllable when you validate a
+document from an untrusted source, schema resolution is deliberately locked down (see the
+security advisories addressed in the changelog: local file read / CWE-73 and SSRF / CWE-918).
+Schema validation resolves a schema in this order:
+
+1. **Bundled schema (offline).** The standard OMG XTCE schema ships with the package. A document
+   referencing `https://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd` (or the `http` variant)
+   validates against the bundled copy with **no network request** — this is the common case and
+   requires no configuration.
+2. **`local_xsd` (trusted).** A schema path you pass explicitly is trusted and opened directly,
+   from anywhere on the filesystem (absolute or relative).
+3. **Allowlisted download.** Any other `xsi:schemaLocation` URL is fetched **only** if it is an
+   `https` URL whose host is on the allowlist (default: `www.omg.org`). URLs pointing at internal
+   or link-local addresses (e.g. `169.254.169.254`, `127.0.0.1`) are always rejected.
+
+A **local filesystem path** appearing in a document's `xsi:schemaLocation` is never opened — pass
+`local_xsd` instead to validate against a local schema.
+
+Controls (all available on `validate_xtce(...)` and the `spp validate` CLI):
+
+| Option                  | Env var                                      | Default           | Purpose                                                                                                     |
+| ----------------------- | -------------------------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------- |
+| `allowed_schema_hosts`  | `SPP_ALLOWED_SCHEMA_HOSTS` (comma-separated) | `{"www.omg.org"}` | Hosts and/or exact URLs a schema download may target.                                                       |
+| `allow_insecure_http`   | `SPP_ALLOW_INSECURE_HTTP`                    | `False`           | **Dangerous.** Permit `http` (not just `https`). The host allowlist and internal-address guard still apply. |
+| `allow_schema_download` | —                                            | `True`            | When `False`, make no network request (bundled schemas and `local_xsd` only).                               |
+
+To allow an additional mirror while keeping the default, extend the exported constant:
+
+```python
+from space_packet_parser import DEFAULT_ALLOWED_SCHEMA_HOSTS, validate_xtce
+
+result = validate_xtce(
+    "my_xtce.xml",
+    level="schema",
+    allowed_schema_hosts=[*DEFAULT_ALLOWED_SCHEMA_HOSTS, "schemas.example.org"],
+)
+```
+
 ### CLI Validation
 
 ```shell
-spp --log-level=DEBUG validate my_xtce.xml --local-schema my_xsd.xml --level all
+# Validate against the schema referenced in the document (bundled/allowlisted)
+spp --log-level=DEBUG validate my_xtce.xml --level all
+
+# Validate against a trusted local schema
+spp validate my_xtce.xml --local-xsd my_xsd.xsd --level all
+
+# Allow an additional schema host, or disable network access entirely
+spp validate my_xtce.xml --allowed-schema-host schemas.example.org
+spp validate my_xtce.xml --no-schema-download --local-xsd my_xsd.xsd
 ```
 
 ### Programmatic Validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,8 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["space_packet_parser"]
+# Bundled XSD schemas are data files that must ship inside the wheel.
+artifacts = ["*.xsd"]
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/space_packet_parser/__init__.py
+++ b/space_packet_parser/__init__.py
@@ -5,10 +5,11 @@ from pathlib import Path
 from space_packet_parser.common import SpacePacket
 from space_packet_parser.generators import ccsds_generator
 from space_packet_parser.xtce.definitions import XtcePacketDefinition
-from space_packet_parser.xtce.validation import validate_xtce
+from space_packet_parser.xtce.validation import DEFAULT_ALLOWED_SCHEMA_HOSTS, validate_xtce
 
 __all__ = [
     "ccsds_generator",
+    "DEFAULT_ALLOWED_SCHEMA_HOSTS",
     "SpacePacket",
     "XtcePacketDefinition",
     "load_xtce",

--- a/space_packet_parser/cli.py
+++ b/space_packet_parser/cli.py
@@ -220,7 +220,35 @@ def parse(
 )
 @click.option("--timeout", type=int, default=30, help="Timeout in seconds for schema downloads")
 @click.option("--local-xsd", type=click.Path(exists=True, path_type=Path), help="Local XSD file for schema validation")
-def validate(file_path: Path, level: str, timeout: int, local_xsd: Path) -> None:
+@click.option(
+    "--allowed-schema-host",
+    "allowed_schema_hosts",
+    multiple=True,
+    help="Host or exact URL that a document-derived schema download may target. May be given "
+    "multiple times. Defaults to www.omg.org (or the SPP_ALLOWED_SCHEMA_HOSTS environment variable).",
+)
+@click.option(
+    "--allow-insecure-http",
+    is_flag=True,
+    default=False,
+    help="DANGEROUS: permit http (not just https) schema URLs. The host allowlist and internal-address "
+    "guard still apply. Only use for trusted internal mirrors.",
+)
+@click.option(
+    "--no-schema-download",
+    is_flag=True,
+    default=False,
+    help="Never download schemas over the network; use only bundled schemas and --local-xsd.",
+)
+def validate(
+    file_path: Path,
+    level: str,
+    timeout: int,
+    local_xsd: Path,
+    allowed_schema_hosts: tuple[str, ...],
+    allow_insecure_http: bool,
+    no_schema_download: bool,
+) -> None:
     """Validate an XTCE document."""
     logging.info(f"Validating XTCE file: {file_path}")
     logging.info(f"Validation level: {level}")
@@ -234,6 +262,9 @@ def validate(file_path: Path, level: str, timeout: int, local_xsd: Path) -> None
         print_results=False,
         raise_on_error=False,
         local_xsd=local_xsd,
+        allowed_schema_hosts=list(allowed_schema_hosts) or None,
+        allow_insecure_http=allow_insecure_http,
+        allow_schema_download=not no_schema_download,
     )
 
     # Display results in rich format (complementing the print_results from validate_xtce)

--- a/space_packet_parser/xtce/schemas/README.md
+++ b/space_packet_parser/xtce/schemas/README.md
@@ -1,0 +1,19 @@
+# Bundled XTCE schemas
+
+These XSD files are bundled with `space_packet_parser` so that schema validation of XTCE
+documents that reference the standard OMG schema works **offline**, with no network request.
+Resolving the schema locally (instead of downloading the URL named in a document's
+`xsi:schemaLocation`) is both faster and removes the SSRF/LFI attack surface for the common case.
+
+| File              | XTCE version | `targetNamespace`                       | Upstream source                                          |
+| ----------------- | ------------ | --------------------------------------- | -------------------------------------------------------- |
+| `SpaceSystem.xsd` | 1.2          | `http://www.omg.org/spec/XTCE/20180204` | <https://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd> |
+
+These schemas are published by the Object Management Group (OMG) and remain under OMG's
+copyright and license terms. They are redistributed here unmodified; the small set of
+lxml-compatibility fixups (see `_fix_known_schema_issues` in `../validation.py`) are applied
+at load time and are **not** baked into these files.
+
+The mapping from schema URL to bundled file lives in `_BUNDLED_SCHEMAS` in `../validation.py`.
+To add another version, drop the `.xsd` here and add an entry keyed on its scheme-insensitive
+`host/path`.

--- a/space_packet_parser/xtce/schemas/SpaceSystem.xsd
+++ b/space_packet_parser/xtce/schemas/SpaceSystem.xsd
@@ -1,0 +1,5918 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Style Notes, used throughout the schema:
+
+	- Element and Type names begin with a capital letter.
+	- Type names end with the word "Type".
+	- Attribute names begin with a lowercase letter.
+	- Usually, when the UML class diagram references classes, W3C Elements are used, and whenever
+	  the UML references simple types (strings, ints), W3C Attributes are used.  In general,
+	  attributes are preferred over elements because they're easier to deal with
+	  in SAX and DOM, but whenever the Element/Attribute may one day carry metadata,
+	  elements should be used.  One exception, is enumerated classes, because enumerations
+	  may be defined for attributes but not for elements.
+	- Bias toward self-describing names over short, bandwidth conserving ones.
+	- Use mixed case in names rather than underscores to combine multiple words (camelCase).
+	- A documentation annotation is included in every element and type definition.  Annotations for a type are
+        included with the type definition, use of the type is annotated in the element definition.
+	- Hints on units (for values with units) are provided in the names of attributes and
+	  elements (e.g. "dataRateInBPS" is preferred over "dataRate" OR "frameLengthInBits" is
+	  preferred over "frameLength").
+	- Major elements or any elements used multiple times are first defined with a complexType definition
+	- All collections are put inside either a "List" element or a "Set" Element depending on whether the collection
+	  is ordered or unordered.
+	- Simplicity in the XML files is favored over simplicity in the Schema
+	- Whenever an additional validity check must be performed that is not describable in the schema language,
+	  an appinfo annotation describes that validity check.
+-->
+<schema xmlns:xtce="http://www.omg.org/spec/XTCE/20180204" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.omg.org/spec/XTCE/20180204" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2">
+	<import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
+	<annotation>
+		<documentation xml:lang="en">This XML Schema Definition (XSD) defines syntax with concrete semantics for describing space or remote device telemetry and commanding in a platform and program independent manner.</documentation>
+	</annotation>
+	<!--******** SpaceSystem *********************-->
+	<element name="SpaceSystem" type="xtce:SpaceSystemType" nillable="true">
+		<annotation>
+			<documentation xml:lang="en">The top-level SpaceSystem is the root element for the set of metadata necessary to monitor and command a space device, such as a satellite.  A SpaceSystem defines a namespace.  Metadata areas include:  packets/minor frames layout, telemetry, calibration, alarm, algorithms, streams and commands.  A SpaceSystem may have child SpaceSystems, forming a SpaceSystem tree. See SpaceSystemType.</documentation>
+		</annotation>
+		<key name="parameterNameKey">
+			<annotation>
+				<documentation xml:lang="en">This key ensures a unique parameter name at the system level.</documentation>
+			</annotation>
+			<selector xpath="xtce:TelemetryMetaData/xtce:ParameterSet/xtce:Parameter|xtce:CommandMetaData/xtce:ParameterSet/xtce:Parameter"/>
+			<field xpath="@name"/>
+		</key>
+		<key name="parameterTypeNameKey">
+			<annotation>
+				<documentation xml:lang="en">This key ensures a unique parameter type name at the system level.</documentation>
+			</annotation>
+			<selector xpath="xtce:TelemetryMetaData/xtce:ParameterTypeSet/*|xtce:CommandMetaData/xtce:ParameterTypeSet/*"/>
+			<field xpath="@name"/>
+		</key>
+		<key name="metaCommandNameKey">
+			<annotation>
+				<documentation xml:lang="en">This key ensures a unique metaCommand name at the system level.</documentation>
+			</annotation>
+			<selector xpath="xtce:CommandMetaData/xtce:MetaCommandSet/xtce:MetaCommand"/>
+			<field xpath="@name"/>
+		</key>
+		<key name="algorithmNameKey">
+			<annotation>
+				<documentation xml:lang="en">This key ensures a unique algorithm name at the system level.</documentation>
+			</annotation>
+			<selector xpath="xtce:TelemetryMetaData/xtce:AlgorithmSet/*|xtce:CommandMetaData/xtce:AlgorithmSet/*"/>
+			<field xpath="@name"/>
+		</key>
+		<key name="streamNameKey">
+			<annotation>
+				<documentation xml:lang="en">This key ensures a unique stream name at the system level.</documentation>
+			</annotation>
+			<selector xpath="xtce:TelemetryMetaData/xtce:StreamSet/*|xtce:CommandMetaData/xtce:StreamSet/*"/>
+			<field xpath="@name"/>
+		</key>
+		<key name="serviceNameKey">
+			<annotation>
+				<documentation xml:lang="en">This key ensures a unique service name at the system level.</documentation>
+			</annotation>
+			<selector xpath="xtce:ServiceSet/*"/>
+			<field xpath="@name"/>
+		</key>
+		<key name="containerNameKey">
+			<annotation>
+				<documentation xml:lang="en">This key ensures a container stream name at the system level.</documentation>
+			</annotation>
+			<selector xpath="xtce:TelemetryMetaData/xtce:ContainerSet/*|xtce:CommandMetaData/xtce:CommandContainerSet/*"/>
+			<field xpath="@name"/>
+		</key>
+		<key name="messageNameKey">
+			<selector xpath="xtce:TelemetryMetaData/xtce:MessageSet/*"/>
+			<field xpath="@name"/>
+		</key>
+		<key name="argumentTypeNameKey">
+			<annotation>
+				<documentation xml:lang="en">This key ensures a unique argument type name at the system level.</documentation>
+			</annotation>
+			<selector xpath="xtce:CommandMetaData/xtce:ArgumentTypeSet/*|xtce:CommandMetaData/xtce:ParameterTypeSet/*"/>
+			<field xpath="@name"/>
+		</key>
+		<key name="blockMetaCommandNameKey">
+			<annotation>
+				<documentation xml:lang="en">This key ensures a unique BlockMetaCommand name at the system level.</documentation>
+			</annotation>
+			<selector xpath="xtce:CommandMetaData/xtce:MetaCommandSet/xtce:BlockMetaCommand"/>
+			<field xpath="@name"/>
+		</key>
+	</element>
+	<complexType name="SpaceSystemType" mixed="false">
+		<annotation>
+			<documentation xml:lang="en">SpaceSystem is a collection of SpaceSystem(s) including space assets, ground assets, multi-satellite systems and sub-systems.  A SpaceSystem is the root element for the set of data necessary to monitor and command an arbitrary space device - this includes the binary decomposition the data streams going into and out of a device.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<sequence>
+					<element name="Header" type="xtce:HeaderType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">The Header element contains optional descriptive information about this SpaceSystem or the document as a whole when specified at the root SpaceSystem.</documentation>
+						</annotation>
+					</element>
+					<element name="TelemetryMetaData" type="xtce:TelemetryMetaDataType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">This element contains descriptions of the telemetry created on the space asset/device and sent to other data consumers.</documentation>
+						</annotation>
+					</element>
+					<element name="CommandMetaData" type="xtce:CommandMetaDataType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">This element contains descriptions of the commands and their associated constraints and verifications that can be sent to the space asset/device.</documentation>
+						</annotation>
+					</element>
+					<element name="ServiceSet" type="xtce:ServiceSetType" minOccurs="0"/>
+					<element ref="xtce:SpaceSystem" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation xml:lang="en">Additional SpaceSystem elements may be used like namespaces to segregate portions of the space asset/device into convenient groupings or may be used to specialize a product line generic SpaceSystem to a specific asset instance.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="operationalStatus" type="token" use="optional">
+					<annotation>
+						<documentation xml:lang="en">Optional descriptive attribute for document owner convenience.</documentation>
+					</annotation>
+				</attribute>
+				<attribute ref="xml:base"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="CommandMetaDataType" mixed="false">
+		<annotation>
+			<documentation xml:lang="en">Describe command related metadata. Items defined in this area may refer to items defined in TelemetryMetaData.  See TelemetryMetaDataType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="ParameterTypeSet" type="xtce:ParameterTypeSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">A list of parameter types.</documentation>
+				</annotation>
+			</element>
+			<element name="ParameterSet" type="xtce:ParameterSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Parameters referenced by MetaCommands.  This Parameter Set is located here so that MetaCommand data can be built independently of TelemetryMetaData.</documentation>
+				</annotation>
+			</element>
+			<element name="ArgumentTypeSet" type="xtce:ArgumentTypeSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">A list of argument types.  MetaCommand definitions can contain arguments and parameters.  Arguments are user provided to the specific command definition.  Parameters are provided/calculated/determined by the software creating the command instance.  As a result, arguments contain separate type information.  In some cases, arguments have different descriptive characteristics.</documentation>
+				</annotation>
+			</element>
+			<element name="MetaCommandSet" type="xtce:MetaCommandSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">A list of command definitions with their arguments, parameters, and container encoding descriptions.</documentation>
+				</annotation>
+			</element>
+			<element name="CommandContainerSet" type="xtce:CommandContainerSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Similar to the ContainerSet for telemetry, the CommandContainerSet contains containers that can be referenced/shared by MetaCommand definitions.</documentation>
+				</annotation>
+			</element>
+			<element name="StreamSet" type="xtce:StreamSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Contains an unordered set of Streams.</documentation>
+				</annotation>
+			</element>
+			<element name="AlgorithmSet" type="xtce:AlgorithmSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Contains an unordered set of Algorithms.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="TelemetryMetaDataType" mixed="false">
+		<annotation>
+			<documentation xml:lang="en">All the data about telemetry is contained in TelemetryMetaData</documentation>
+		</annotation>
+		<sequence>
+			<element name="ParameterTypeSet" type="xtce:ParameterTypeSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">A list of parameter types</documentation>
+				</annotation>
+			</element>
+			<element name="ParameterSet" type="xtce:ParameterSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">A list of Parameters for this Space System.  </documentation>
+				</annotation>
+			</element>
+			<element name="ContainerSet" type="xtce:ContainerSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Holds the list of all potential container definitions for telemetry. Containers may parts of packets or TDM, and then groups of the containers, and then an entire entity -- such as a packet.  In order to maximize re-used for duplication, the pieces may defined once here, and then assembled as needed into larger structures, also here.</documentation>
+				</annotation>
+			</element>
+			<element name="MessageSet" type="xtce:MessageSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Messages are an alternative method of uniquely identifying containers within a Service.  A message provides a test in the form of MatchCriteria to match to a container.  A simple example might be: [When minorframeID=21, the message is the 21st minorframe container.  The collection of messages to search thru will be bound by a Service.</documentation>
+				</annotation>
+			</element>
+			<element name="StreamSet" type="xtce:StreamSetType" minOccurs="0"/>
+			<element name="AlgorithmSet" type="xtce:AlgorithmSetType" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<!--****** End of Top Level SpaceSystem Schema *****-->
+	<!--*************************************************************-->
+	<!--****** Packaging Schema *******************************-->
+	<annotation>
+		<documentation xml:lang="en">This schema defines the dictionary for containers, which in turn describe the physical composition of data in a communication system</documentation>
+	</annotation>
+	<complexType name="ArgumentArgumentRefEntryType">
+		<annotation>
+			<documentation xml:lang="en">Identical to ArgumentRefEntryType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentSequenceEntryType">
+				<attribute name="argumentRef" type="xtce:NameReferenceType" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentArrayArgumentRefEntryType">
+		<annotation>
+			<documentation xml:lang="en">Identical to ArrayParameterRefEntryType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentSequenceEntryType">
+				<sequence minOccurs="0">
+					<annotation>
+						<documentation xml:lang="en">Only used for subsetting an array.  The array's true dimension sizes are set in the Type.</documentation>
+					</annotation>
+					<element name="DimensionList" type="xtce:ArgumentDimensionListType">
+						<annotation>
+							<documentation xml:lang="en">The dimension here if used for subsetting must be less than the ones in the type.  It's not a subset if its the same size.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="argumentRef" type="xtce:NameReferenceType" use="required"/>
+				<attribute name="lastEntryForThisArrayInstance" type="boolean" default="false"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentArrayParameterRefEntryType">
+		<annotation>
+			<documentation xml:lang="en">Identical to ArrayParameterRefEntryType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentSequenceEntryType">
+				<sequence minOccurs="0">
+					<annotation>
+						<documentation xml:lang="en">Only used for subsetting an array.  The array's true dimension sizes are set in the Type.</documentation>
+					</annotation>
+					<element name="DimensionList" type="xtce:DimensionListType">
+						<annotation>
+							<documentation xml:lang="en">The dimension here if used for subsetting must be less than the ones in the type.  It's not a subset if its the same size.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="parameterRef" type="xtce:NameReferenceType" use="required"/>
+				<attribute name="lastEntryForThisArrayInstance" type="boolean" default="false"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentContainerRefEntryType">
+		<annotation>
+			<documentation xml:lang="en">Identical to ContainerRefEntryType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentSequenceEntryType">
+				<attribute name="containerRef" type="xtce:NameReferenceType" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentContainerSegmentRefEntryType">
+		<annotation>
+			<documentation xml:lang="en">Identical to ContainerSegmentRefEntryType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentSequenceEntryType">
+				<attribute name="containerRef" type="xtce:NameReferenceType" use="required"/>
+				<attribute name="order" type="xtce:PositiveLongType"/>
+				<attribute name="sizeInBits" type="xtce:PositiveLongType" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentFixedValueEntryType">
+		<annotation>
+			<documentation xml:lang="en">Identical to FixedValueEntryType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentSequenceEntryType">
+				<attribute name="name" type="string" use="optional">
+					<annotation>
+						<documentation xml:lang="en">An optional name for the fixed/constant field in the sequence.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="binaryValue" type="hexBinary" use="required">
+					<annotation>
+						<documentation xml:lang="en">The fixed/constant value that should be encoded into the sequence.  This value provided should have sufficient bit length to accomodate the size in bits.  If the value is larger, the most significant unnecessary bits are dropped.  The value provided should be in network byte order for encoding.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="sizeInBits" type="xtce:PositiveLongType" use="required">
+					<annotation>
+						<documentation xml:lang="en">The number of bits that this fixed/constant value should occupy in the sequence.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentIndirectParameterRefEntryType">
+		<annotation>
+			<documentation xml:lang="en">Identical to IndirectParameterRefEntryType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentSequenceEntryType">
+				<sequence>
+					<element name="ParameterInstance" type="xtce:ParameterInstanceRefType"/>
+				</sequence>
+				<attribute name="aliasNameSpace" type="string"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentParameterRefEntryType">
+		<annotation>
+			<documentation xml:lang="en">Identical to ParameterRefEntryType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentSequenceEntryType">
+				<attribute name="parameterRef" type="xtce:NameReferenceType" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentParameterSegmentRefEntryType">
+		<annotation>
+			<documentation xml:lang="en">Identical to ParameterSegmentRefEntryType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentSequenceEntryType">
+				<attribute name="parameterRef" type="xtce:NameReferenceType" use="required"/>
+				<attribute name="order" type="xtce:PositiveLongType"/>
+				<attribute name="sizeInBits" type="xtce:PositiveLongType" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentStreamSegmentEntryType">
+		<annotation>
+			<documentation xml:lang="en">Identical to StreamRefEntryType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentSequenceEntryType">
+				<attribute name="streamRef" type="xtce:NameReferenceType" use="required"/>
+				<attribute name="order" type="xtce:PositiveLongType"/>
+				<attribute name="sizeInBits" type="xtce:PositiveLongType" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArrayParameterRefEntryType">
+		<annotation>
+			<documentation>Describe an entry that is an array parameter. Specify the dimension sizes if you subsetting the array (the number of dimensions shall match the number defined in the parameter’s type definition), otherwise the ones in the ParameterType are assumed.  See SequenceEntryType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:SequenceEntryType">
+				<sequence minOccurs="0">
+					<annotation>
+						<documentation>Only used for subsetting an array.  The array's maximum dimension sizes are set in the type.  When a DimensionList is not used, the array is the full size provided in the type.</documentation>
+					</annotation>
+					<element name="DimensionList" type="xtce:DimensionListType">
+						<annotation>
+							<documentation>The dimension here if used for subsetting must be less than the ones in the type.  It's not a subset if its the same size.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="parameterRef" type="xtce:NameReferenceType" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="BaseAlarmType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Supplies an optional non-reference-able name and short description for alarms. Also includes an optional ancillary data for any special local flags, note that these may not necessarily transfer to another recipient of an instance document.</documentation>
+		</annotation>
+		<sequence>
+			<element name="AncillaryDataSet" type="xtce:AncillaryDataSetType" minOccurs="0"/>
+		</sequence>
+		<attribute name="name" type="string" use="optional">
+			<annotation>
+				<documentation xml:lang="en">The alarm definition may be named.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="shortDescription" type="xtce:ShortDescriptionType">
+			<annotation>
+				<documentation xml:lang="en">An optional brief description of this alarm definition.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="BaseContainerType">
+		<annotation>
+			<documentation xml:lang="en">Describe a child/parent container inheritance relationship.  Describe constraints with RestrictionCriteria, conditions that must be true for this container to be an extension of the parent container.  A constraint can be used to convey the identifying features of the telemetry format such as the CCSDS application id or minor-frame id.  See RestrictionCriteriaType and SequenceContainerType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="RestrictionCriteria" type="xtce:RestrictionCriteriaType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Contains the conditions that must evaluate to true in order for this container to be an extension of the parent container.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="containerRef" type="xtce:NameReferenceType" use="required">
+			<annotation>
+				<documentation xml:lang="en">Reference to the container that this container extends.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="ContainerType" abstract="true" mixed="false">
+		<annotation>
+			<documentation xml:lang="en">An abstract block of data; used as the base type for more specific container types</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<sequence>
+					<annotation>
+						<documentation xml:lang="en">RateInStream is used to:  a) generate alarms when the Container is updated too frequently or too infrequently, b) provide some 'guidelines' for generating forward link containers, c) provide some guidelines for spacecraft simulators to generate telemetry containers.  If necessary, these rates may be defined on a per stream basis.</documentation>
+						<appinfo>The software should check that any Stream names referenced in the RateInStreamSet actually exist.</appinfo>
+					</annotation>
+					<element name="DefaultRateInStream" type="xtce:RateInStreamType" minOccurs="0"/>
+					<element name="RateInStreamSet" type="xtce:RateInStreamSetType" minOccurs="0"/>
+					<element name="BinaryEncoding" type="xtce:BinaryDataEncodingType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">May be used to indicate error detection and correction, change byte order,  provide the size (when it can't be derived), or perform some custom processing.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ContainerRefSetType">
+		<sequence>
+			<element name="ContainerRef" type="xtce:ContainerRefType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="ContainerRefType">
+		<annotation>
+			<documentation xml:lang="en">Holds a reference to a container</documentation>
+		</annotation>
+		<attribute name="containerRef" type="xtce:NameReferenceType" use="required">
+			<annotation>
+				<documentation xml:lang="en">name of container</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="ContainerRefEntryType">
+		<annotation>
+			<documentation xml:lang="en">An entry that is simply a reference to another container.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:SequenceEntryType">
+				<attribute name="containerRef" type="xtce:NameReferenceType" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ContainerSegmentRefEntryType">
+		<annotation>
+			<documentation xml:lang="en">An entry that is only a portion of a container indicating that the entire container must be assembled from other container segments.   It is assumed that container segments happen sequentially in time, that is the first part of a container is first, however (and there's always a however), if this is not the case the order of this container segment may be supplied with the order attribute where the first segment order="0".  Each instance of a container cannot overlap in the overall sequence with another instance</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:SequenceEntryType">
+				<attribute name="containerRef" type="xtce:NameReferenceType" use="required"/>
+				<attribute name="order" type="xtce:PositiveLongType"/>
+				<attribute name="sizeInBits" type="xtce:PositiveLongType" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ContainerSetType">
+		<annotation>
+			<documentation xml:lang="en">Unordered Set of Containers</documentation>
+		</annotation>
+		<choice maxOccurs="unbounded">
+			<element name="SequenceContainer" type="xtce:SequenceContainerType">
+				<annotation>
+					<documentation xml:lang="en">SequenceContainers define sequences of parameters or other containers.  </documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<complexType name="EntryListType" mixed="false">
+		<annotation>
+			<documentation xml:lang="en">Contains an ordered list of Entries.  Used in Sequence Container</documentation>
+		</annotation>
+		<choice minOccurs="0" maxOccurs="unbounded">
+			<element name="ParameterRefEntry" type="xtce:ParameterRefEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify a Parameter to be a part of this container layout definition.</documentation>
+				</annotation>
+			</element>
+			<element name="ParameterSegmentRefEntry" type="xtce:ParameterSegmentRefEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify a portion of a Parameter to be a part of this container layout definition.  This is used when the Parameter is reported in fractional parts in the container before being fully updated.</documentation>
+				</annotation>
+			</element>
+			<element name="ContainerRefEntry" type="xtce:ContainerRefEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify the content of another Container to be a part of this container layout definition.</documentation>
+				</annotation>
+			</element>
+			<element name="ContainerSegmentRefEntry" type="xtce:ContainerSegmentRefEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify a portion of another Container to be a part of this container layout definition.</documentation>
+				</annotation>
+			</element>
+			<element name="StreamSegmentEntry" type="xtce:StreamSegmentEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify a portion of a Stream to be a part of this container layout definition.</documentation>
+				</annotation>
+			</element>
+			<element name="IndirectParameterRefEntry" type="xtce:IndirectParameterRefEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify a previous (not last reported) value of a Parmeter to be a part of this container layout definition.</documentation>
+				</annotation>
+			</element>
+			<element name="ArrayParameterRefEntry" type="xtce:ArrayParameterRefEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify an Array Type Parameter to be a part of this container layout definition when the Container does not populate the entire space of the Array contents.  If the entire space of the Array is populated, a tolerant implementation will accept ParameterRefEntry also.</documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<complexType name="IndirectParameterRefEntryType">
+		<annotation>
+			<documentation xml:lang="en">An entry whose name is given by the value of a ParamameterInstance.  This entry may be used to implement dwell telemetry streams.  The value of the parameter in ParameterInstance must use either the name of the Parameter or its alias.  If it's an alias name, the alias namespace is supplied as an attribute.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:SequenceEntryType">
+				<sequence>
+					<element name="ParameterInstance" type="xtce:ParameterInstanceRefType"/>
+				</sequence>
+				<attribute name="aliasNameSpace" type="string"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="LocationInContainerInBitsType">
+		<annotation>
+			<documentation xml:lang="en">Describe the absolute or relative bit location of an entry in a container.  The "referenceLocation" attribute specifies the starting bit anchor.  If no referenceLocation value is given, the entry is assumed to begin at the first bit position after the previous entry.  Each container starts at bit 0, thus "containerStart" is an offset from 0.  Negative container start bits are before the container and are implementation dependent – these should be flagged as likely errors.  "containerEnd" is given as a positive offset from the end of the container, thus a container end of 0 is exactly at the end of the container.  Negative container end addresses are after the container and are implementation dependent – these should be flagged as likely errors.  Positive "previouEntry" values are offsets from the previous entry – zero (0) is the default which means it follows contiguously from the last occupied bit of the previous entry.  A value of one means it is offset 1-bit from the previous entry, and a value of negative 1 (-1) means it overlaps the previous entry by one bit, and so forth. The "nextEntry" attribute value is proposed for deprecation and should be avoided.  See SequenceEntryType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:IntegerValueType">
+				<attribute name="referenceLocation" type="xtce:ReferenceLocationType" default="previousEntry">
+					<annotation>
+						<documentation xml:lang="en">Defines the relative reference used to interpret the start bit position.  The default is 0 bits from the end of the previousEntry, which makes the entry contiguous.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentLocationInContainerInBitsType">
+		<annotation>
+			<documentation xml:lang="en">Identical to LocationInContainerInBitsType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentIntegerValueType">
+				<attribute name="referenceLocation" type="xtce:ReferenceLocationType" default="previousEntry"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="MessageRefType">
+		<annotation>
+			<documentation xml:lang="en">Holds a reference to a message</documentation>
+		</annotation>
+		<attribute name="messageRef" type="xtce:NameReferenceType" use="required">
+			<annotation>
+				<documentation xml:lang="en">name of message</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="ParameterRefEntryType">
+		<annotation>
+			<documentation xml:lang="en">An entry that is a single Parameter</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:SequenceEntryType">
+				<attribute name="parameterRef" type="xtce:NameReferenceType" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ParameterSegmentRefEntryType">
+		<annotation>
+			<documentation xml:lang="en">An entry that is only a portion of a parameter value indicating that the entire parameter value must be assembled from other parameter segments.   It is assumed that parameter segments happen sequentially in time, that is the first part if a telemetry parameter first, however (and there's always a however), if this is not the case the order of this parameter segment may be supplied with the order attribute where the first segment order="0".</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:SequenceEntryType">
+				<attribute name="parameterRef" type="xtce:NameReferenceType" use="required"/>
+				<attribute name="order" type="xtce:PositiveLongType"/>
+				<attribute name="sizeInBits" type="xtce:PositiveLongType" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="SequenceContainerType">
+		<annotation>
+			<documentation xml:lang="en">Describes the binary layout/packing of data and also related properties, including an entry list of parameters, parameter segments, array parameters, stream segments, containers, and container segments.  Sequence containers may extend other sequence containers (see BaseContainerType).   The parent container’s entries are placed before the entries in the child container forming one entry list.  An inheritance chain may be formed using this mechanism, but only one entry list is being created.  Sequence containers may be marked as "abstract", when this occurs an instance of it cannot itself be created.  The idle pattern is part of any unallocated space in the container.  See EntryListType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ContainerType">
+				<sequence>
+					<element name="EntryList" type="xtce:EntryListType">
+						<annotation>
+							<documentation xml:lang="en">List of item entries to pack/encode into this container definition.</documentation>
+						</annotation>
+					</element>
+					<element name="BaseContainer" type="xtce:BaseContainerType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Optional inheritance for this container from another named container.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="abstract" type="boolean" default="false">
+					<annotation>
+						<documentation xml:lang="en">Abstract container definitions that are not instantiated, rather only used as bases to inherit from to create specialized container definitions.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="idlePattern" type="xtce:FixedIntegerValueType" default="0x0">
+					<annotation>
+						<documentation xml:lang="en">The idle pattern is part of any unallocated space in the container.  This is uncommon.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="SequenceEntryType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Defines an abstract schema type used to create other entry types. Describe an entry’s location in the container (See LocationInContainerInBitsType). The location may be fixed or dynamic, absolute or relative. Entries may be included depending on the value of a condition (See IncludeConditionType), and entries may also repeat (see RepeatEntryType). The entry’s IncludeCondition resolves to true, it is fully-resolved when its size is computable after RepeatEntry has been accounted for and then offset by LocationInContainer. See EntryListType, IncludeConditionType, RepeatEntryType and LocationInContainerInBitsType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="LocationInContainerInBits" type="xtce:LocationInContainerInBitsType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">The start bit 0 position for each container is local to the container, but does include space occupied by inherited containers.  When a container is "included", as opposed to inherited, then the interpreting implementation takes into account the start bit position of the referring container when finally assembling the start bits for the post-processed entry content.  The default start bit for any entry is 0 bits from the previous entry, making the content contiguous when this element is not used.</documentation>
+				</annotation>
+			</element>
+			<element name="RepeatEntry" type="xtce:RepeatType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">May be used when this entry repeats itself in the sequence container.  When an entry repeats, it effectively specifies that the same entry is reported more than once in the container and has the same physical meaning.  This should not be construed to be equivalent to arrays.</documentation>
+				</annotation>
+			</element>
+			<element name="IncludeCondition" type="xtce:MatchCriteriaType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">This entry will only be included in the sequence when this condition is true, otherwise it is always included.  When the include condition evaluates to false, it is as if the entry does not exist such that any start bit interpretations cannot take into account the space that would have been occupied if this included condition were true.</documentation>
+				</annotation>
+			</element>
+			<element name="TimeAssociation" type="xtce:TimeAssociationType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Optional timing information associated with this entry.</documentation>
+				</annotation>
+			</element>
+			<element name="AncillaryDataSet" type="xtce:AncillaryDataSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Optional ancillary data associated with this element.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="shortDescription" type="xtce:ShortDescriptionType" use="optional">
+			<annotation>
+				<documentation xml:lang="en">Optional short description for this entry element.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="ArgumentSequenceEntryType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Identical to a SequenceEntryType but supports argument instance references.</documentation>
+		</annotation>
+		<sequence>
+			<element name="LocationInContainerInBits" type="xtce:ArgumentLocationInContainerInBitsType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">The start bit 0 position for each container is local to the container, but does include space occupied by inherited containers.  When a container is "included", as opposed to inherited, then the interpreting implementation takes into account the start bit position of the referring container when finally assembling the start bits for the post-processed entry content.  The default start bit for any entry is 0 bits from the previous entry, making the content contiguous when this element is not used.</documentation>
+				</annotation>
+			</element>
+			<element name="RepeatEntry" type="xtce:ArgumentRepeatType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">May be used when this entry repeats itself in the sequence container.  When an entry repeats, it effectively specifies that the same entry is reported more than once in the container and has the same physical meaning.  This should not be construed to be equivalent to arrays.</documentation>
+				</annotation>
+			</element>
+			<element name="IncludeCondition" type="xtce:ArgumentMatchCriteriaType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">This entry will only be included in the sequence when this condition is true, otherwise it is always included.  When the include condition evaluates to false, it is as if the entry does not exist such that any start bit interpretations cannot take into account the space that would have been occupied if this included condition were true.</documentation>
+				</annotation>
+			</element>
+			<element name="AncillaryDataSet" type="xtce:AncillaryDataSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Ancillary data associated with this entry.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="shortDescription" type="xtce:ShortDescriptionType" use="optional">
+			<annotation>
+				<documentation xml:lang="en">Optional short description for this entry element.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="ServiceType">
+		<annotation>
+			<documentation xml:lang="en">Holds a set of services, logical groups of containers  OR messages (not both).</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<choice>
+					<element name="MessageRefSet" type="xtce:MessageRefSetType"/>
+					<element name="ContainerRefSet" type="xtce:ContainerRefSetType"/>
+				</choice>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="StreamSegmentEntryType">
+		<annotation>
+			<documentation xml:lang="en">An entry that is a portion of a stream (streams are by definition, assumed continuous)   It is assumed that stream segments happen sequentially in time, that is the first part if a steam first, however, if this is not the case the order of the stream segments may be supplied with the order attribute where the first segment order="0".</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:SequenceEntryType">
+				<attribute name="streamRef" type="xtce:NameReferenceType" use="required"/>
+				<attribute name="order" type="xtce:PositiveLongType"/>
+				<attribute name="sizeInBits" type="xtce:PositiveLongType" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="MessageType">
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<sequence>
+					<element name="MatchCriteria" type="xtce:MatchCriteriaType"/>
+					<element name="ContainerRef" type="xtce:ContainerRefType">
+						<annotation>
+							<documentation xml:lang="en">The ContainerRef should point to ROOT container that will describe an entire packet/minor frame or chunk of telemetry.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="MessageSetType">
+		<complexContent>
+			<extension base="xtce:OptionalNameDescriptionType">
+				<sequence>
+					<element name="Message" type="xtce:MessageType" maxOccurs="unbounded"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="RateInStreamSetType">
+		<sequence>
+			<element name="RateInStream" type="xtce:RateInStreamWithStreamNameType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="RateInStreamType">
+		<annotation>
+			<documentation xml:lang="en">Define the expected appearance (rate) of a container in a stream where the rate is defined on either a perSecond or perContainer update basis.  Many programs and platforms have variable reporting rates for containers and these can be commanded.  As a result, this element is only useful to some users and generally does not affect the processing of the received containers themselves.  See ContainerType.</documentation>
+		</annotation>
+		<attribute name="basis" type="xtce:BasisType" default="perSecond">
+			<annotation>
+				<documentation xml:lang="en">The measurement unit basis for the minimum and maximum appearance count values.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="minimumValue" type="double">
+			<annotation>
+				<documentation xml:lang="en">The minimum rate for the specified basis for which this container should appear in the stream.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="maximumValue" type="double">
+			<annotation>
+				<documentation xml:lang="en">The maximum rate for the specified basis for which this container should appear in the stream.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="RateInStreamWithStreamNameType">
+		<annotation>
+			<documentation xml:lang="en">Define the expected appearance (rate) of a container in a named stream where the rate is defined on either a perSecond or perContainer update basis.  Many programs and platforms have variable reporting rates for containers and these can be commanded.  As a result, this element is only useful to some users and generally does not affect the processing of the received containers themselves.  See ContainerType and RateInStreamType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:RateInStreamType">
+				<attribute name="streamRef" type="xtce:NameReferenceType" use="required">
+					<annotation>
+						<documentation xml:lang="en">Reference to a named stream for which this rate specification applies.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<simpleType name="ReferenceLocationType">
+		<annotation>
+			<documentation xml:lang="en">The location may be relative to the start of the container (containerStart), relative to the end of the previous entry (previousEntry), relative to the end of the container (containerEnd), or relative to the entry that follows this one (nextEntry). If going forward (containerStart and previousEntry) then the location refers to the start of the									Entry. If going backwards (containerEnd and nextEntry) then, the location refers to the end of the entry.</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="containerStart"/>
+			<enumeration value="containerEnd"/>
+			<enumeration value="previousEntry"/>
+			<enumeration value="nextEntry"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="ReferencePointType">
+		<restriction base="string">
+			<enumeration value="start"/>
+			<enumeration value="end"/>
+		</restriction>
+	</simpleType>
+	<complexType name="RestrictionCriteriaType">
+		<annotation>
+			<documentation xml:lang="en">Define one or more conditions (constraints) for container inheritance. A container is instantiable if its constraints are true.  Constraint conditions may be a comparison, a list of comparisons, a boolean expression, or a graph of containers that are instantiable (if all containers are instantiable the condition is true).  See BaseContainerType, ComparisonType, ComparisonListType, BooleanExpressionType and NextContainerType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:MatchCriteriaType">
+				<choice>
+					<element name="NextContainer" type="xtce:ContainerRefType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Reference to the named container that must follow this container in the stream sequence.</documentation>
+						</annotation>
+					</element>
+				</choice>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!--****** End of Packaging Schema **********************-->
+	<!--*************************************************************-->
+	<!--****** Telemetry Schema *******************************-->
+	<annotation>
+		<documentation xml:lang="en">This schema defines the dictionary for telemetry</documentation>
+	</annotation>
+	<complexType name="AbsoluteTimeParameterType">
+		<annotation>
+			<documentation xml:lang="en">Describe an absolute time parameter type relative to a known epoch (such as TAI).  The string representation of this time should use the [ISO 8601] extended format CCYY-MM-DDThh:mm:ss where "CC" represents the century, "YY" the year, "MM" the month and "DD" the day, preceded by an optional leading "-" sign to indicate a negative number. If the sign is omitted, "+" is assumed. The letter "T" is the date/time separator and "hh", "mm", "ss" represent hour, minute and second respectively. Additional digits can be used to increase the precision of fractional seconds if desired i.e. the format ss.ss... with any number of digits after the decimal point is supported.  See TAIType, IntegerDataEncoding and AbsoluteTimeDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:AbsoluteTimeDataType"/>
+		</complexContent>
+	</complexType>
+	<complexType name="AggregateParameterType">
+		<annotation>
+			<documentation xml:lang="en">Describe a complex data type analogous to a C-struct. Each field of the data type is called a Member.  Each Member is part of the MemberList which forms the list of items to be placed under this data type’s name.  The MemberList defines a data block and block’s size is defined by the DataEncodings of each Member’s type reference. The data members are ordered and contiguous in the MemberList element (packed).  Each member may be addressed by the dot syntax similar to C such as P.voltage if P is the referring parameter and voltage is of a member of P’s aggregate type.  See MemberType, MemberListType, DataEncodingType, NameReferenceType, and AggregateDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:AggregateDataType"/>
+		</complexContent>
+	</complexType>
+	<complexType name="ArrayParameterType">
+		<annotation>
+			<documentation xml:lang="en">Describe an array parameter type.  The size and number of dimensions are described here. See ArrayParameterRefEntryType, NameReferenceType and ArrayDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArrayDataTypeType">
+				<sequence>
+					<element name="DimensionList" type="xtce:DimensionListType">
+						<annotation>
+							<documentation xml:lang="en">Describe the dimensions of this array.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="BinaryParameterType">
+		<annotation>
+			<documentation xml:lang="en">Describe a binary engineering/calibrated parameter type (sometimes called a “blob type”). It may be of fixed or variable length, and has an optional encoding and decoding algorithm that may be defined to transform the data between space and ground.  See BinaryDataEncodingType, IntegerValueType, InputAlgorithmType and BinaryDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BinaryDataType">
+				<sequence>
+					<element name="DefaultAlarm" type="xtce:BinaryAlarmType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Optionally describe an alarm monitoring specification that is effective whenever a contextual alarm definition does not take precedence.</documentation>
+						</annotation>
+					</element>
+					<element name="BinaryContextAlarmList" type="xtce:BinaryContextAlarmListType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Optionally describe one or more alarm monitoring specifications that are effective whenever a contextual match definition evaluates to true.  The first match that evaluates to true takes precedence.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="BooleanParameterType">
+		<annotation>
+			<documentation xml:lang="en">Describe a boolean parameter type which has two values only: ‘True’ (1) or ‘False’ (0). The values one and zero may be mapped to a specific string using the attributes oneStringValue and zeroStringValue.  This type is a simplified form of the EnumeratedDataType.  See IntegerDataEncoding and BooleanDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BooleanDataType">
+				<sequence>
+					<element name="DefaultAlarm" type="xtce:BooleanAlarmType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Optionally describe an alarm monitoring specification that is effective whenever a contextual alarm definition does not take precedence.</documentation>
+						</annotation>
+					</element>
+					<element name="ContextAlarmList" type="xtce:BooleanContextAlarmListType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Optionally describe one or more alarm monitoring specifications that are effective whenever a contextual match definition evaluates to true.  The first match that evaluates to true takes precedence.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="EnumeratedParameterType">
+		<annotation>
+			<documentation xml:lang="en">Describe an enumerated parameter type.  The enumeration list consists of label/value pairs. See EnumerationListType, IntegerDataEncodingType and EnumeratedDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:EnumeratedDataType">
+				<sequence>
+					<element name="DefaultAlarm" type="xtce:EnumerationAlarmType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Describe labels for this parameter that should be in an alarm state.  The default definition applies when there are no context alarm definitions or all the context alarm definitions evaluate to false in their matching criteria.</documentation>
+						</annotation>
+					</element>
+					<element name="ContextAlarmList" type="xtce:EnumerationContextAlarmListType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Describe labels for this parameter that should be in an alarm state when another parameter and value combination evaluates to true using the described matching criteria.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="EnumerationContextAlarmListType">
+		<annotation>
+			<documentation xml:lang="en">Describe an ordered collection of context enumeration alarms, duplicates are valid. Process the contexts in list order. See EnumerationContextAlarmType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="ContextAlarm" type="xtce:EnumerationContextAlarmType" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">Describe the alarm matching context criteria and the alarm definition itself.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="FloatParameterType">
+		<annotation>
+			<documentation xml:lang="en">Describe a floating point parameter type.  Several encodings are supported.  Calibrated integer to float relationships should be described with this data type. Use the data encoding to define calibrators.  Joins integer as one of the numerics. See FloatDataEncodingType, IntegerDataEncodingType and FloatDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:FloatDataType">
+				<sequence>
+					<element name="DefaultAlarm" type="xtce:NumericAlarmType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Default alarm definitions are those which do not adjust definition logic based on the value of other parameters.  Other parameters may participate in the determination of an alarm condition for this parameter, but the definition logic of the alarm on this parameter is constant.  If the alarming logic on this parameter changes based on the value of other parameters, then it is a ContextAlarm and belongs in the ContextAlarmList element.</documentation>
+						</annotation>
+					</element>
+					<element name="ContextAlarmList" type="xtce:NumericContextAlarmListType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Context alarm definitions are those which adjust the definition logic for this parameter based on the value of other parameters.  A context which evaluates to being in effect, based on the testing of another parameter, takes precedence over the default alarms in the DefaultAlarm element.  If the no context alarm evaluates to being in effect, based on the testing of another parameter, then the default alarm definitions from the DefaultAlarm element will remain in effect.  If multiple contexts evaluate to being in effect, then the first one that appears will take precedence.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="IntegerParameterType">
+		<annotation>
+			<documentation xml:lang="en">Describe an integer parameter type. Several are supported. Calibrated integer to integer relationships should be described with this data type. Use the integer data encoding to define calibrators. Joins float as one of the numerics. See IntegerDataEncoding and IntegerDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:IntegerDataType">
+				<sequence>
+					<element name="DefaultAlarm" type="xtce:NumericAlarmType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Default alarm definitions are those which do not adjust definition logic based on the value of other parameters. Other parameters may participate in the determination of an alarm condition for this parameter, but the definition logic of the alarm on this parameter is constant. If the alarming logic on this parameter changes based on the value of other parameters, then it is a ContextAlarm and belongs in the ContextAlarmList element.</documentation>
+						</annotation>
+					</element>
+					<element name="ContextAlarmList" type="xtce:NumericContextAlarmListType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Context alarm definitions are those which adjust the definition logic for this parameter based on the value of other parameters. A context which evaluates to being in effect, based on the testing of another parameter, takes precedence over the default alarms in the DefaultAlarm element. If the no context alarm evaluates to being in effect, based on the testing of another parameter, then the default alarm definitions from the DefaultAlarm element will remain in effect. If multiple contexts evaluate to being in effect, then the first one that appears will take precedence.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="MessageRefSetType">
+		<sequence>
+			<element name="MessageRef" type="xtce:MessageRefType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="NumericContextAlarmListType">
+		<annotation>
+			<documentation xml:lang="en">An ordered collection of numeric alarms associated with a context. A context is an alarm definition on a parameter which is valid only in the case of a test on the value of other parameters. Process the contexts in list order. Used by both FloatParameterType and IntegerParameterType. See NumericContextAlarmType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="ContextAlarm" type="xtce:NumericContextAlarmType" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">A contextual alarm definition for the parameter that uses this type that is valid when a test against the value of one or more other parameters evaluates to true.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ParameterInstanceRefType">
+		<annotation>
+			<documentation xml:lang="en">A reference to an instance of a Parameter.   Used when the value of a parameter is required for a calculation or as an index value.  A positive value for instance is forward in time, a negative value for count is backward in time, a 0 value for count means use the current value of the parameter or the first value in a container.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ParameterRefType">
+				<attribute name="instance" type="long" default="0"/>
+				<attribute name="useCalibratedValue" type="boolean" default="true"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ParameterPropertiesType" mixed="false">
+		<annotation>
+			<documentation xml:lang="en">Describes extended properties/attributes of Parameter definitions.</documentation>
+		</annotation>
+		<sequence>
+			<element name="SystemName" type="string" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Optional.  Normally used when the database is built in a flat, non-hierarchical format.</documentation>
+				</annotation>
+			</element>
+			<element name="ValidityCondition" type="xtce:MatchCriteriaType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Optional condition that must be true for this Parameter to be valid.</documentation>
+				</annotation>
+			</element>
+			<element name="PhysicalAddressSet" type="xtce:PhysicalAddressSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">When present, this set of elements describes physical address location(s) of the parameter where it is stored.  Typically this is on the data source, although that is not constrained by this schema.</documentation>
+				</annotation>
+			</element>
+			<element name="TimeAssociation" type="xtce:TimeAssociationType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">This time will override any Default value for TimeAssociation.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="dataSource" type="xtce:TelemetryDataSourceType" use="optional">
+			<annotation>
+				<documentation xml:lang="en">This attribute describes the nature of the source entity for which this parameter receives a value.  Implementations assign different attributes/properties internally to a parameter based on the anticipated data source.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="readOnly" type="boolean" use="optional" default="false">
+			<annotation>
+				<documentation xml:lang="en">A Parameter marked as 'readOnly' true is non-settable by users and applications/services that do not represent the data source itself.  Note that a slight conceptual overlap exists here between the 'dataSource' attribute and this attribute when the data source is 'constant'.  For a constant data source, then 'readOnly' should be 'true'.  Application implementations may choose to implicitly enforce this.  Some implementations have both concepts of a Parameter that is settable or non-settable and a Constant in different parts of their internal data model.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="persistence" type="boolean" default="true">
+			<annotation>
+				<documentation xml:lang="en">A Parameter marked to persist should retain the latest value through resets/restarts to the extent that is possible or defined in the implementation.  The net effect is that the initial/default value on a Parameter is only seen once or when the system has a reset to revert to initial/default values.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="ParameterType">
+		<annotation>
+			<documentation xml:lang="en">Describe the properties of a telemetry parameter, including its data type (parameter type). The bulk of properties associated with a telemetry parameter are in its parameter type. The initial value specified here, overrides the initial value in the parameter type. A parameter may be local, in which case its parameter type would have no data encodings. Ideally such a definition would also set data source in parameter properties to ‘local’ but the syntax does not enforce this. See BaseDataType, BaseTimeDataType, and NameReferenceType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<sequence>
+					<element name="ParameterProperties" type="xtce:ParameterPropertiesType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Specify additional properties for this Parameter used by the implementation of tailor the behavior and attributes of the Parameter.  When not specified, the defaults on the ParameterProperties element attributes are assumed.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="parameterTypeRef" type="xtce:NameReferenceType" use="required">
+					<annotation>
+						<documentation xml:lang="en">Specify the reference to the parameter type from the ParameterTypeSet area using the path reference rules, either local to this SpaceSystem, relative, or absolute.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="initialValue" type="string" use="optional">
+					<annotation>
+						<documentation xml:lang="en">Specify as: integer data type using xs:integer, float data type using xs:double, string data type using xs:string, boolean data type using xs:boolean, binary data type using xs:hexBinary, enum data type using label name, relative time data type using xs:duration, absolute time data type using xs:dateTime.  Values must not exceed the characteristics for the data type or this is a validation error. Takes precedence over an initial value given in the data type. Values are calibrated unless there is an option to override it.</documentation>
+						<appinfo>The value type must match the Parameter type</appinfo>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ParameterTypeSetType">
+		<annotation>
+			<documentation xml:lang="en">Describe an unordered collection of parameter type definitions.  These types named for the engineering/calibrated type of the parameter.  See BaseDataType and BaseTimeDataType.</documentation>
+		</annotation>
+		<choice maxOccurs="unbounded">
+			<element name="StringParameterType" type="xtce:StringParameterType">
+				<annotation>
+					<documentation xml:lang="en">Describe a parameter type that has an engineering/calibrated value in the form of a character string.</documentation>
+				</annotation>
+			</element>
+			<element name="EnumeratedParameterType" type="xtce:EnumeratedParameterType">
+				<annotation>
+					<documentation xml:lang="en">Describe a parameter type that has an engineering/calibrated value in the form of an enumeration.</documentation>
+				</annotation>
+			</element>
+			<element name="IntegerParameterType" type="xtce:IntegerParameterType">
+				<annotation>
+					<documentation xml:lang="en">Describe a parameter type that has an engineering/calibrated value in the form of an integer.</documentation>
+				</annotation>
+			</element>
+			<element name="BinaryParameterType" type="xtce:BinaryParameterType">
+				<annotation>
+					<documentation xml:lang="en">Describe a parameter type that has an engineering/calibrated value in the form of a binary (usually hex represented).</documentation>
+				</annotation>
+			</element>
+			<element name="FloatParameterType" type="xtce:FloatParameterType">
+				<annotation>
+					<documentation xml:lang="en">Describe a parameter type that has an engineering/calibrated value in the form of a decimal.</documentation>
+				</annotation>
+			</element>
+			<element name="BooleanParameterType" type="xtce:BooleanParameterType">
+				<annotation>
+					<documentation xml:lang="en">Describe a parameter type that has an engineering/calibrated value in the form of a boolean enumeration.</documentation>
+				</annotation>
+			</element>
+			<element name="RelativeTimeParameterType" type="xtce:RelativeTimeParameterType">
+				<annotation>
+					<documentation xml:lang="en">Describe a parameter type that has an engineering/calibrated value in the form of a duration in time.</documentation>
+				</annotation>
+			</element>
+			<element name="AbsoluteTimeParameterType" type="xtce:AbsoluteTimeParameterType">
+				<annotation>
+					<documentation xml:lang="en">Describe a parameter type that has an engineering/calibrated value in the form of an instant in time.</documentation>
+				</annotation>
+			</element>
+			<element name="ArrayParameterType" type="xtce:ArrayParameterType">
+				<annotation>
+					<documentation xml:lang="en">Describe a parameter type that has an engineering/calibrated value in the form of an array of a primitive type.</documentation>
+				</annotation>
+			</element>
+			<element name="AggregateParameterType" type="xtce:AggregateParameterType">
+				<annotation>
+					<documentation xml:lang="en">Describe a parameter type that has an engineering/calibrated value in the form of a structure of parameters of other types.</documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<complexType name="ParameterRefType">
+		<annotation>
+			<documentation xml:lang="en">A reference to a Parameter. Uses Unix ‘like’ naming across the SpaceSystem Tree (e.g., SimpleSat/Bus/EPDS/BatteryOne/Voltage).  To reference an individual member of an array use the zero based bracket notation commonly used in languages like C, C++, and Java.</documentation>
+		</annotation>
+		<attribute name="parameterRef" type="xtce:NameReferenceType" use="required"/>
+	</complexType>
+	<complexType name="PhysicalAddressSetType">
+		<annotation>
+			<documentation xml:lang="en">One or more physical addresses may be associated with each Parameter.  Examples of physical addresses include a location on the spacecraft or a location on a data collection bus. </documentation>
+		</annotation>
+		<sequence>
+			<element name="PhysicalAddress" type="xtce:PhysicalAddressType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">Contains the address (e.g., channel information) required to process the spacecraft telemetry streams. May be an onboard  id, a mux address, or a physical location.</documentation>
+					<documentation xml:lang="en">Contains the address (channel information) required to process the spacecraft telemetry streams</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="PhysicalAddressType" mixed="false">
+		<annotation>
+			<documentation xml:lang="en">Describe the physical address(s) that this parameter is collected from.  Examples of physical addresses include a memory location on the spacecraft or a location on a data collection bus, with the source identified with a descriptive name for the region of memory, such as RAM, Flash, EEPROM, and other possibilities that can be adapted for program specific usage.</documentation>
+		</annotation>
+		<sequence>
+			<element name="SubAddress" type="xtce:PhysicalAddressType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">A sub-address may be used to further specify the location if it fractionally occupies the address.  Additional possibilities exist for separating partitions of memory or other address based storage mechanisms.  This specification does not specify spacecraft specific hardware properties, so usage of addressing information is largely program and platform specific.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="sourceName" type="string">
+			<annotation>
+				<documentation xml:lang="en">A descriptive name for the location, such as a memory type, where this address is located.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="sourceAddress" type="string">
+			<annotation>
+				<documentation xml:lang="en">The address within the memory location.  This specification does not specify program and hardware specific attributes, such as address size and address region starting location.  These are part of the spacecraft hardware properties.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="ServiceSetType">
+		<annotation>
+			<documentation xml:lang="en">A service is a logical grouping of container and/or messages.</documentation>
+		</annotation>
+		<sequence>
+			<element name="Service" type="xtce:ServiceType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="StringParameterType">
+		<annotation>
+			<documentation xml:lang="en">Describes a string parameter type. Three forms are supported: fixed length, variable length and variable length using a prefix. See StringDataEncodingType and StringDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:StringDataType">
+				<sequence>
+					<element name="DefaultAlarm" type="xtce:StringAlarmType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Default alarm definitions are those which do not adjust definition logic based on the value of other parameters.  Other parameters may participate in the determination of an alarm condition for this parameter, but the definition logic of the alarm on this parameter is constant.  If the alarming logic on this parameter changes based on the value of other parameters, then it is a ContextAlarm and belongs in the ContextAlarmList element.</documentation>
+						</annotation>
+					</element>
+					<element name="ContextAlarmList" type="xtce:StringContextAlarmListType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Context alarm definitions are those which adjust the definition logic for this parameter based on the value of other parameters.  A context which evaluates to being in effect, based on the testing of another parameter, takes precedence over the default alarms in the DefaultAlarm element.  If the no context alarm evaluates to being in effect, based on the testing of another parameter, then the default alarm definitions from the DefaultAlarm element will remain in effect.  If multiple contexts evaluate to being in effect, then the first one that appears will take precedence.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="RelativeTimeParameterType">
+		<annotation>
+			<documentation xml:lang="en">Describes a relative time parameter type. Relative time parameters are time offsets (e.g. 10 second, 1.24 milliseconds, etc.) See IntegerDataEncodingType, FloatDataEncoding and RelativeTimeDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:RelativeTimeDataType">
+				<sequence>
+					<element name="DefaultAlarm" type="xtce:TimeAlarmType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Default alarm definitions are those which do not adjust definition logic based on the value of other parameters.  Other parameters may participate in the determination of an alarm condition for this parameter, but the definition logic of the alarm on this parameter is constant.  If the alarming logic on this parameter changes based on the value of other parameters, then it is a ContextAlarm and belongs in the ContextAlarmList element.</documentation>
+						</annotation>
+					</element>
+					<element name="ContextAlarmList" type="xtce:TimeContextAlarmListType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Context alarm definitions are those which adjust the definition logic for this parameter based on the value of other parameters.  A context which evaluates to being in effect, based on the testing of another parameter, takes precedence over the default alarms in the DefaultAlarm element.  If the no context alarm evaluates to being in effect, based on the testing of another parameter, then the default alarm definitions from the DefaultAlarm element will remain in effect.  If multiple contexts evaluate to being in effect, then the first one that appears will take precedence.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<simpleType name="TelemetryDataSourceType">
+		<annotation>
+			<documentation xml:lang="en">A telemetered Parameter is one that will have values in telemetry. A derived Parameter is one that is calculated, usually by an Algorithm. A constant Parameter is one that is used as a constant in the system (e.g. a vehicle id). A local Parameter is one that is used purely by the software locally (e.g. a ground command counter). A ground Parameter is one that is generated by an asset which is not the spacecraft.</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="telemetered"/>
+			<enumeration value="derived"/>
+			<enumeration value="constant"/>
+			<enumeration value="local"/>
+			<enumeration value="ground"/>
+		</restriction>
+	</simpleType>
+	<complexType name="TimeAssociationType">
+		<annotation>
+			<documentation xml:lang="en">Describes a time association consisting of an instance of an absolute time parameter (parameterRef) and this entry.  Because telemetry parameter instances are oftentimes "time-tagged" with a timing signal either provided on the ground or on the space system.  This data element allows one to specify which of possibly many AbsoluteTimeParameters to use to "time-tag" parameter instances with.  See AbsoluteTimeParameterType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ParameterInstanceRefType">
+				<attribute name="interpolateTime" type="boolean" default="true">
+					<annotation>
+						<documentation xml:lang="en">If true, then the current value of the AbsoluteTime will be projected to current time.  In other words, if the value of the AbsoluteTime parameter was set 10 seconds ago, then 10 seconds will be added to its value before associating this time with the parameter.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="offset" type="double">
+					<annotation>
+						<documentation xml:lang="en">The offset is used to supply a relative time offset from the time association and to this parameter</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="unit" type="xtce:TimeAssociationUnitType" default="si_second">
+					<annotation>
+						<documentation xml:lang="en">Specify the units the offset is in, the default is si_second.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<simpleType name="TimeWindowIsRelativeToType">
+		<restriction base="string">
+			<enumeration value="commandRelease"/>
+			<enumeration value="timeLastVerifierPassed"/>
+		</restriction>
+	</simpleType>
+	<!--****** End of Telemetry Schema ***********************-->
+	<!--*************************************************************-->
+	<!--****** Command Schema *******************************-->
+	<annotation>
+		<documentation xml:lang="en">This schema defines the dictionary for commanding</documentation>
+	</annotation>
+	<complexType name="AbsoluteTimeArgumentType">
+		<annotation>
+			<documentation xml:lang="en">Describe an absolute time argument type relative to a known epoch (such as TAI).  The string representation of this time should use the [ISO 8601] extended format CCYY-MM-DDThh:mm:ss where "CC" represents the century, "YY" the year, "MM" the month and "DD" the day, preceded by an optional leading "-" sign to indicate a negative number. If the sign is omitted, "+" is assumed. The letter "T" is the date/time separator and "hh", "mm", "ss" represent hour, minute and second respectively. Additional digits can be used to increase the precision of fractional seconds if desired i.e. the format ss.ss... with any number of digits after the decimal point is supported.  See TAIType, IntegerDataEncoding and AbsoluteTimeDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentAbsoluteTimeDataType"/>
+		</complexContent>
+	</complexType>
+	<complexType name="ArrayArgumentType">
+		<annotation>
+			<documentation xml:lang="en">Describe an array argument type.  The size and number of dimension are described here. See ArrayParameterRefEntryType, NameReferenceType and ArrayDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArrayDataTypeType">
+				<sequence>
+					<element name="DimensionList" type="xtce:ArgumentDimensionListType">
+						<annotation>
+							<documentation xml:lang="en">Describe the dimensions of this array.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="AggregateArgumentType">
+		<annotation>
+			<documentation xml:lang="en">Describe a complex data type analogous to a C-struct. Each field of the data type is called a Member.  Each Member is part of the MemberList which forms the list of items to be placed under this data type’s name.  The MemberList defines a data block and block’s size is defined by the DataEncodings of each Member’s type reference. The data members are ordered and contiguous in the MemberList element (packed).  Each member may be addressed by the dot syntax similar to C such as P.voltage if P is the referring parameter and voltage is of a member of P’s aggregate type.  See MemberType, MemberListType, DataEncodingType, NameReferenceType, and AggregateDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:AggregateDataType"/>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentAssignmentListType">
+		<annotation>
+			<documentation xml:lang="en">Argument Assignments specialize a MetaCommand or BlockMetaCommand when inheriting from another MetaCommand.  General argument values can be restricted to specific values to further specialize the MetaCommand.  Use it to ‘narrow’ a MetaCommand from its base MetaCommand by specifying values of arguments for example, a power command may be narrowed to a power on’ command by assigning the value of an argument to ‘on’.  See ArgumentAssignmentType and MetaCommandType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="ArgumentAssignment" type="xtce:ArgumentAssignmentType" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">Specialize this command definition when inheriting from a more general MetaCommand by restricting the specific values of otherwise general arguments.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ArgumentAssignmentType">
+		<annotation>
+			<documentation xml:lang="en">Describe an assignment of an argument with a calibrated/engineering value. See ArgumentAssignmentListType.</documentation>
+		</annotation>
+		<attribute name="argumentName" type="xtce:NameReferenceType" use="required">
+			<annotation>
+				<documentation xml:lang="en">The named argument from the base MetaCommand to assign/restrict with a value.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="argumentValue" type="string" use="required">
+			<annotation>
+				<documentation xml:lang="en">Specify value as a string compliant with the XML schema (xs) type specified for each XTCE type: integer=xs:integer; float=xs:double; string=xs:string; boolean=xs:boolean; binary=xs:hexBinary; enum=xs:string from EnumerationList; relative time=xs:duration; absolute time=xs:dateTime.  Supplied value must be within the ValidRange specified for the type.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="ArgumentComparisonType">
+		<annotation>
+			<documentation xml:lang="en">Identical to ComparisonType but supports argument instance references.</documentation>
+		</annotation>
+		<choice>
+			<element name="ParameterInstanceRef" type="xtce:ParameterInstanceRefType">
+				<annotation>
+					<documentation xml:lang="en">This parameter instance is being compared to the value in the parent element using the comparison defined there also.</documentation>
+				</annotation>
+			</element>
+			<element name="ArgumentInstanceRef" type="xtce:ArgumentInstanceRefType">
+				<annotation>
+					<documentation xml:lang="en">This argument instance is being compared to the value in the parent element using the comparison defined there also.</documentation>
+				</annotation>
+			</element>
+		</choice>
+		<attribute name="comparisonOperator" type="xtce:ComparisonOperatorsType" default="==">
+			<annotation>
+				<documentation xml:lang="en">Comparison operator to use with equality being the common default.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="value" type="string" use="required">
+			<annotation>
+				<documentation xml:lang="en">Specify as: integer data type using xs:integer, float data type using xs:double, string data type using xs:string, boolean data type using xs:boolean, binary data type using xs:hexBinary, enum data type using label name, relative time data type using xs:duration, absolute time data type using xs:dateTime.  Values must not exceed the characteristics for the data type or this is a validation error. Takes precedence over an initial value given in the data type. Values are calibrated unless there is an option to override it.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="ArgumentComparisonCheckType">
+		<annotation>
+			<documentation xml:lang="en">Identical to ComparisonCheckType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseConditionsType">
+				<sequence>
+					<choice>
+						<element name="ParameterInstanceRef" type="xtce:ParameterInstanceRefType">
+							<annotation>
+								<documentation xml:lang="en">Left hand side parameter instance.</documentation>
+							</annotation>
+						</element>
+						<element name="ArgumentInstanceRef" type="xtce:ArgumentInstanceRefType">
+							<annotation>
+								<documentation xml:lang="en">Left hand side argument instance.</documentation>
+							</annotation>
+						</element>
+					</choice>
+					<element name="ComparisonOperator" type="xtce:ComparisonOperatorsType">
+						<annotation>
+							<documentation xml:lang="en">Comparison operator.</documentation>
+						</annotation>
+					</element>
+					<choice>
+						<choice>
+							<element name="ParameterInstanceRef" type="xtce:ParameterInstanceRefType">
+								<annotation>
+									<documentation xml:lang="en">Right hand side parameter instance.  Parameter is assumed to be of the same type as the comparison Argument or Parameter.</documentation>
+								</annotation>
+							</element>
+							<element name="ArgumentInstanceRef" type="xtce:ArgumentInstanceRefType">
+								<annotation>
+									<documentation xml:lang="en">Right hand side argument instance.  Argument is assumed to be of the same type as the comparison Argument or Parameter.</documentation>
+								</annotation>
+							</element>
+						</choice>
+						<element name="Value" type="string">
+							<annotation>
+								<documentation xml:lang="en">Specify as: integer data type using xs:integer, float data type using xs:double, string data type using xs:string, boolean data type using xs:boolean, binary data type using xs:hexBinary, enum data type using label name, relative time data type using xs:duration, absolute time data type using xs:dateTime.  Values must not exceed the characteristics for the data type or this is a validation error. Takes precedence over an initial value given in the data type. Values are calibrated unless there is an option to override it.</documentation>
+							</annotation>
+						</element>
+					</choice>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentComparisonListType">
+		<annotation>
+			<documentation xml:lang="en">Identical to ComparisonListType but supports argument instance references.</documentation>
+		</annotation>
+		<sequence>
+			<element name="Comparison" type="xtce:ArgumentComparisonType" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">List of Comparison elements must all be true for the comparison to evaluate to true.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ArgumentDiscreteLookupType">
+		<annotation>
+			<documentation xml:lang="en">Identical to ArgumentDiscreteLookupType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentMatchCriteriaType">
+				<attribute name="value" type="long" use="required">
+					<annotation>
+						<documentation xml:lang="en">Value to use when the lookup conditions are true.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentDiscreteLookupListType">
+		<annotation>
+			<documentation xml:lang="en">Identical to DiscreteLookupListType but supports argument instance references.</documentation>
+		</annotation>
+		<sequence>
+			<element name="DiscreteLookup" type="xtce:ArgumentDiscreteLookupType" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">Describe a lookup condition set using discrete values from arguments and/or parameters.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ArgumentDynamicValueType">
+		<annotation>
+			<documentation xml:lang="en">Identical to DynamicValueType but supports argument instance references.</documentation>
+		</annotation>
+		<sequence>
+			<choice>
+				<element name="ArgumentInstanceRef" type="xtce:ArgumentInstanceRefType">
+					<annotation>
+						<documentation xml:lang="en">Retrieve the value by referencing the value of an Argument.</documentation>
+					</annotation>
+				</element>
+				<element name="ParameterInstanceRef" type="xtce:ParameterInstanceRefType">
+					<annotation>
+						<documentation xml:lang="en">Retrieve the value by referencing the value of a Parameter.</documentation>
+					</annotation>
+				</element>
+			</choice>
+			<element name="LinearAdjustment" type="xtce:LinearAdjustmentType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">A slope and intercept may be applied to scale or shift the value selected from the argument or parameter.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ArgumentInputAlgorithmType">
+		<annotation>
+			<documentation xml:lang="en">Identical to InputAlgorithmType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:SimpleAlgorithmType">
+				<sequence>
+					<element name="InputSet" type="xtce:ArgumentInputSetType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">The InputSet describes the list of arguments and/or parameters that should be made available as input arguments to the algorithm.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentInputSetType">
+		<annotation>
+			<documentation xml:lang="en">Identical to InputSetType but supports argument instance references.</documentation>
+		</annotation>
+		<choice maxOccurs="unbounded">
+			<element name="InputParameterInstanceRef" type="xtce:InputParameterInstanceRefType">
+				<annotation>
+					<documentation xml:lang="en">Reference a parameter to serve as an input to the algorithm.</documentation>
+				</annotation>
+			</element>
+			<element name="InputArgumentInstanceRef" type="xtce:ArgumentInstanceRefType">
+				<annotation>
+					<documentation xml:lang="en">Reference an argument to serve as an input to the algorithm.</documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<complexType name="ArgumentInstanceRefType">
+		<annotation>
+			<documentation xml:lang="en">An argument instance is the name of an argument as the reference is always resolved locally to the metacommand.</documentation>
+		</annotation>
+		<attribute name="argumentRef" type="xtce:NameType" use="required">
+			<annotation>
+				<documentation xml:lang="en">Give the name of the argument.  There is no path, this is a local reference.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="useCalibratedValue" type="boolean" default="true">
+			<annotation>
+				<documentation xml:lang="en">Typically the calibrated/engineering value is used and that is the default.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="ArgumentListType">
+		<annotation>
+			<documentation xml:lang="en">Defines a list of Arguments for a command definition.</documentation>
+		</annotation>
+		<sequence>
+			<element name="Argument" type="xtce:ArgumentType" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">Defines an Argument for a command definition.  Arguments are local to the MetaCommand, BlockMetaCommand, and those that inherit from the definition.</documentation>
+					<appinfo>Need to ensure that the named types actually exist</appinfo>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ArgumentBooleanExpressionType">
+		<annotation>
+			<documentation xml:lang="en">Identical to BooleanExpressionType but supports argument instance references.</documentation>
+		</annotation>
+		<choice>
+			<element name="Condition" type="xtce:ArgumentComparisonCheckType">
+				<annotation>
+					<documentation xml:lang="en">Condition elements describe a test similar to the Comparison element except that the arguments/parameters used have additional flexibility.</documentation>
+				</annotation>
+			</element>
+			<element name="ANDedConditions" type="xtce:ArgumentANDedConditionsType">
+				<annotation>
+					<documentation xml:lang="en">This element describes tests similar to the ComparisonList element except that the arguments/parameters used are more flexible.</documentation>
+				</annotation>
+			</element>
+			<element name="ORedConditions" type="xtce:ArgumentORedConditionsType">
+				<annotation>
+					<documentation xml:lang="en">This element describes tests similar to the ComparisonList element except that the arguments/parameters used are more flexible.</documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<complexType name="ArgumentANDedConditionsType">
+		<annotation>
+			<documentation xml:lang="en">Identical to ANDedConditionsType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseConditionsType">
+				<choice minOccurs="2" maxOccurs="unbounded">
+					<element name="Condition" type="xtce:ArgumentComparisonCheckType">
+						<annotation>
+							<documentation xml:lang="en">Condition elements describe a test similar to the Comparison element except that the arguments/parameters used have additional flexibility for the compare.</documentation>
+						</annotation>
+					</element>
+					<element name="ORedConditions" type="xtce:ArgumentORedConditionsType">
+						<annotation>
+							<documentation xml:lang="en">This element describes tests similar to the ComparisonList element except that the arguments/parameters used are more flexible and the and/or for multiple checks can be specified.</documentation>
+						</annotation>
+					</element>
+				</choice>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentORedConditionsType">
+		<annotation>
+			<documentation xml:lang="en">Identical to ORedConditionsType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseConditionsType">
+				<choice minOccurs="2" maxOccurs="unbounded">
+					<element name="Condition" type="xtce:ArgumentComparisonCheckType">
+						<annotation>
+							<documentation xml:lang="en">Condition elements describe a test similar to the Comparison element except that the arguments/parameters used have additional flexibility for the compare.</documentation>
+						</annotation>
+					</element>
+					<element name="ANDedConditions" type="xtce:ArgumentANDedConditionsType">
+						<annotation>
+							<documentation xml:lang="en">This element describes tests similar to the ComparisonList element except that the arguments/parameters used are more flexible and the and/or for multiple checks can be specified.</documentation>
+						</annotation>
+					</element>
+				</choice>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentMatchCriteriaType">
+		<annotation>
+			<documentation xml:lang="en">Identical to MatchCriteriaType but supports argument instance references.</documentation>
+		</annotation>
+		<choice>
+			<element name="Comparison" type="xtce:ArgumentComparisonType">
+				<annotation>
+					<documentation xml:lang="en">A simple comparison check involving a single test of an argument or parameter value.</documentation>
+				</annotation>
+			</element>
+			<element name="ComparisonList" type="xtce:ArgumentComparisonListType">
+				<annotation>
+					<documentation xml:lang="en">A series of simple comparison checks with an implicit 'and' in that they all must be true for the overall condition to be true.</documentation>
+				</annotation>
+			</element>
+			<element name="BooleanExpression" type="xtce:ArgumentBooleanExpressionType">
+				<annotation>
+					<documentation xml:lang="en">An arbitrarily complex boolean expression that has additional flexibility on the terms beyond the Comparison and ComparisonList elements.</documentation>
+				</annotation>
+			</element>
+			<element name="CustomAlgorithm" type="xtce:ArgumentInputAlgorithmType">
+				<annotation>
+					<documentation xml:lang="en">An escape to an externally defined algorithm.</documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<complexType name="ArgumentType">
+		<annotation>
+			<documentation xml:lang="en">An Argument has a name and can take on values with the underlying value type described by the ArgumentTypeRef. Describe the properties of a command argument referring to a data type (argument type). The bulk of properties associated with a command argument are in its argument type. The initial value specified here, overrides the initial value in the argument type. See BaseDataType, BaseTimeDataType and NameReferenceType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<attribute name="argumentTypeRef" type="xtce:NameReferenceType" use="required">
+					<annotation>
+						<documentation xml:lang="en">Specify the reference to the argument type from the ArgumentTypeSet area using the path reference rules, either local to this SpaceSystem, relative, or absolute.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="initialValue" type="string">
+					<annotation>
+						<documentation xml:lang="en">Specify as: integer data type using xs:integer, float data type using xs:double, string data type using xs:string, boolean data type using xs:boolean, binary data type using xs:hexBinary, enum data type using label name, relative time data type using xs:duration, absolute time data type using xs:dateTime.  Values must not exceed the characteristics for the data type or this is a validation error. Takes precedence over an initial value given in the data type. Values are calibrated unless there is an option to override it.</documentation>
+						<appinfo>The value type must match the Argument type</appinfo>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentTypeSetType">
+		<annotation>
+			<documentation xml:lang="en">Describe an unordered collection of argument type definitions.  These types named for the engineering/calibrated type of the argument.  See BaseDataType and BaseTimeDataType.</documentation>
+		</annotation>
+		<choice maxOccurs="unbounded">
+			<element name="StringArgumentType" type="xtce:StringArgumentType">
+				<annotation>
+					<documentation xml:lang="en">Describe an argument type that has an engineering/calibrated value in the form of a character string.</documentation>
+				</annotation>
+			</element>
+			<element name="EnumeratedArgumentType" type="xtce:EnumeratedArgumentType">
+				<annotation>
+					<documentation xml:lang="en">Describe an argument type that has an engineering/calibrated value in the form of an enumeration.</documentation>
+				</annotation>
+			</element>
+			<element name="IntegerArgumentType" type="xtce:IntegerArgumentType">
+				<annotation>
+					<documentation xml:lang="en">Describe an argument type that has an engineering/calibrated value in the form of an integer.</documentation>
+				</annotation>
+			</element>
+			<element name="BinaryArgumentType" type="xtce:BinaryArgumentType">
+				<annotation>
+					<documentation xml:lang="en">Describe an argument type that has an engineering/calibrated value in the form of a binary (usually hex represented).</documentation>
+				</annotation>
+			</element>
+			<element name="FloatArgumentType" type="xtce:FloatArgumentType">
+				<annotation>
+					<documentation xml:lang="en">Describe an argument type that has an engineering/calibrated value in the form of a decimal.</documentation>
+				</annotation>
+			</element>
+			<element name="BooleanArgumentType" type="xtce:BooleanArgumentType">
+				<annotation>
+					<documentation xml:lang="en">Describe an argument type that has an engineering/calibrated value in the form of a boolean enumeration.</documentation>
+				</annotation>
+			</element>
+			<element name="RelativeTimeAgumentType" type="xtce:RelativeTimeArgumentType">
+				<annotation>
+					<documentation xml:lang="en">Describe an argument type that has an engineering/calibrated value in the form of a duration in time.</documentation>
+				</annotation>
+			</element>
+			<element name="AbsoluteTimeArgumentType" type="xtce:AbsoluteTimeArgumentType">
+				<annotation>
+					<documentation xml:lang="en">Describe an argument type that has an engineering/calibrated value in the form of an instant in time.</documentation>
+				</annotation>
+			</element>
+			<element name="ArrayArgumentType" type="xtce:ArrayArgumentType">
+				<annotation>
+					<documentation xml:lang="en">Describe an argument type that has an engineering/calibrated value in the form of an array of a primitive type.</documentation>
+				</annotation>
+			</element>
+			<element name="AggregateArgumentType" type="xtce:AggregateArgumentType">
+				<annotation>
+					<documentation xml:lang="en">Describe an argument type that has an engineering/calibrated value in the form of a structure of arguments of other types.</documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<complexType name="BaseMetaCommandType">
+		<annotation>
+			<documentation xml:lang="en">When specified, a BaseMetaCommand element identifies that this MetaCommand inherits (extends) another MetaCommand.  It’s required ArgumentAssignmentList narrows or this command from the parent.  This is typically used when specializing a generic MetaCommand to a specific MetaCommand.  See MetaCommandType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="ArgumentAssignmentList" type="xtce:ArgumentAssignmentListType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Argument Assignments specialize a MetaCommand or BlockMetaCommand when inheriting from another MetaCommand.  General argument values can be restricted to specific values to further specialize the MetaCommand.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="metaCommandRef" type="xtce:NameReferenceType" use="required">
+			<annotation>
+				<documentation xml:lang="en">Reference to the MetaCommand definition that this MetaCommand extends.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="BinaryArgumentType">
+		<annotation>
+			<documentation xml:lang="en">Defines a binary engineering/calibrated argument type (often called “blob type”). The binary data may be of fixed or variable length, and has an optional encoding and decoding algorithm that may be defined to transform the data between space and ground.  See BinaryDataEncodingType, IntegerValueType, InputAlgorithmType, and BinaryDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentBinaryDataType"/>
+		</complexContent>
+	</complexType>
+	<complexType name="BlockMetaCommandType">
+		<annotation>
+			<documentation xml:lang="en">Describe an ordered grouping of MetaCommands into a list, duplicates are valid. The block contains argument values fully specified.  See MetaCommandStepListType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<sequence>
+					<element name="MetaCommandStepList" type="xtce:MetaCommandStepListType">
+						<annotation>
+							<documentation xml:lang="en">List of the MetaCommands to include in this BlockMetaCommand.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="BooleanArgumentType">
+		<annotation>
+			<documentation xml:lang="en">Defines a boolean argument type which has two values only: ‘True’ (1) or ‘False’ (0). The values one and zero may be mapped to a specific string using the attributes oneStringValue and zeroStringValue.  This type is a simplified form of the EnumeratedDataType.  See IntegerDataEncoding and BooleanDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentBooleanDataType"/>
+		</complexContent>
+	</complexType>
+	<complexType name="CommandContainerEntryListType">
+		<annotation>
+			<documentation xml:lang="en">Describe an entry list for a CommandContainer which is associated with a MetaCommand. The entry list for a MetaCommand CommandContainer element operates in a similar fashion as the entry list element for a SequenceContainer element.  It adds fixed value and argument entries to the entry list not present in sequence containers.  See MetaCommandType, CommandContainerType and EntryListType.</documentation>
+		</annotation>
+		<choice minOccurs="0" maxOccurs="unbounded">
+			<element name="ParameterRefEntry" type="xtce:ArgumentParameterRefEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify a Parameter to be a part of this container layout definition.</documentation>
+				</annotation>
+			</element>
+			<element name="ParameterSegmentRefEntry" type="xtce:ArgumentParameterSegmentRefEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify a portion of a Parameter to be a part of this container layout definition.  This is used when the Parameter is reported in fractional parts in the container before being fully updated.</documentation>
+				</annotation>
+			</element>
+			<element name="ContainerRefEntry" type="xtce:ArgumentContainerRefEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify the content of another Container to be a part of this container layout definition.</documentation>
+				</annotation>
+			</element>
+			<element name="ContainerSegmentRefEntry" type="xtce:ArgumentContainerSegmentRefEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify a portion of another Container to be a part of this container layout definition.</documentation>
+				</annotation>
+			</element>
+			<element name="StreamSegmentEntry" type="xtce:ArgumentStreamSegmentEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify a portion of a Stream to be a part of this container layout definition.</documentation>
+				</annotation>
+			</element>
+			<element name="IndirectParameterRefEntry" type="xtce:ArgumentIndirectParameterRefEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify a previous (not last reported) value of a Parmeter to be a part of this container layout definition.</documentation>
+				</annotation>
+			</element>
+			<element name="ArrayParameterRefEntry" type="xtce:ArgumentArrayParameterRefEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify an Array Type Parameter to be a part of this container layout definition when the Container does not populate the entire space of the Array contents.  If the entire space of the Array is populated, a tolerant implementation will accept ParameterRefEntry also.</documentation>
+				</annotation>
+			</element>
+			<element name="ArgumentRefEntry" type="xtce:ArgumentArgumentRefEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify an Argument to be a part of this container layout definition.</documentation>
+				</annotation>
+			</element>
+			<element name="ArrayArgumentRefEntry" type="xtce:ArgumentArrayArgumentRefEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify an Array Type Argument to be a part of this container layout definition when the Container does not populate the entire space of the Array contents.  If the entire space of the Array is populated, a tolerant implementation will accept ArgumentRefEntry also.</documentation>
+				</annotation>
+			</element>
+			<element name="FixedValueEntry" type="xtce:ArgumentFixedValueEntryType">
+				<annotation>
+					<documentation xml:lang="en">Specify an immutable value to be a part of this container layout definition.</documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<complexType name="CommandContainerSetType">
+		<annotation>
+			<documentation xml:lang="en">Contains an unordered Set of Command Containers</documentation>
+		</annotation>
+		<sequence>
+			<element name="CommandContainer" type="xtce:SequenceContainerType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="CommandContainerType" mixed="false">
+		<annotation>
+			<documentation xml:lang="en">Describe a MetaCommand command container.  The command container may contain arguments, parameters, other basic containers, and fixed values.  Arguments are supplied by the user of a commanding application; parameters are supplied by the controlling system.  Parameters and arguments map source data types to encodings.   See MetaCommandType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ContainerType">
+				<sequence>
+					<element name="EntryList" type="xtce:CommandContainerEntryListType">
+						<annotation>
+							<documentation xml:lang="en">List of item entries to pack/encode into this container definition.</documentation>
+						</annotation>
+					</element>
+					<element name="BaseContainer" type="xtce:BaseContainerType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">When a MetaCommand inherits/extends another MetaCommand, this references the CommandContainer from the BaseMetaCommand.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="CommandVerifierType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">A command verifier is used to check that the command has been successfully executed. Command Verifiers may be either a Custom Algorithm or a Boolean Check or the presence of a Container for a relative change in the value of a Parameter.  The CheckWindow is a time period where the verification must test true to pass.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:OptionalNameDescriptionType">
+				<sequence>
+					<choice>
+						<element name="ComparisonList" type="xtce:ComparisonListType">
+							<annotation>
+								<documentation xml:lang="en">Verification is a list of comparisons.</documentation>
+							</annotation>
+						</element>
+						<element name="ContainerRef" type="xtce:ContainerRefType">
+							<annotation>
+								<documentation xml:lang="en">Verification is a new instance of the referenced container. For example, sending a command to download memory then receiving a packet with the memory download would be verified upon receipt of the packet.</documentation>
+							</annotation>
+						</element>
+						<element name="ParameterValueChange" type="xtce:ParameterValueChangeType">
+							<annotation>
+								<documentation xml:lang="en">Verification is a telemetry parameter value change on the ground.  For example, a command counter.</documentation>
+							</annotation>
+						</element>
+						<element name="CustomAlgorithm" type="xtce:InputAlgorithmType">
+							<annotation>
+								<documentation xml:lang="en">Verification is outside the scope of regular command and telemetry processing.</documentation>
+							</annotation>
+						</element>
+						<element name="BooleanExpression" type="xtce:BooleanExpressionType">
+							<annotation>
+								<documentation xml:lang="en">Verification is a boolean expression of conditions.</documentation>
+							</annotation>
+						</element>
+						<element name="Comparison" type="xtce:ComparisonType">
+							<annotation>
+								<documentation xml:lang="en">Verification is a single comparison.</documentation>
+							</annotation>
+						</element>
+					</choice>
+					<choice>
+						<element name="CheckWindow" type="xtce:CheckWindowType">
+							<annotation>
+								<documentation xml:lang="en">Define a time window for checking for verification.</documentation>
+							</annotation>
+						</element>
+						<element name="CheckWindowAlgorithms" type="xtce:CheckWindowAlgorithmsType">
+							<annotation>
+								<documentation xml:lang="en">Define a time window algorithmically for verification.</documentation>
+							</annotation>
+						</element>
+					</choice>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="EnumeratedArgumentType">
+		<annotation>
+			<documentation xml:lang="en">Describes an enumerated argument type.  The enumeration list consists of label/value pairs. See EnumerationListType, IntegerDataEncodingType and EnumeratedDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentEnumeratedDataType"/>
+		</complexContent>
+	</complexType>
+	<complexType name="FloatArgumentType">
+		<annotation>
+			<documentation xml:lang="en">Describe a floating point argument type.  Several encodings are supported.  Calibrated integer to float relationships should be described with this data type. Use the data encoding to define calibrators.  Joins integer as one of the numerics. See FloatDataEncodingType, IntegerDataEncodingType and FloatDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentFloatDataType">
+				<sequence>
+					<element name="ValidRangeSet" type="xtce:ValidFloatRangeSetType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Provides additional platform/program specific ranging information.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="IntegerArgumentType">
+		<annotation>
+			<documentation xml:lang="en">Describes an integer argument type. Several encodings supported.  Calibrated integer to integer relationships should be described with this data type. Use the integer data encoding to define calibrators. Joins float as one of the numerics. See IntegerDataEncoding and IntegerDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentIntegerDataType">
+				<sequence>
+					<element name="ValidRangeSet" type="xtce:ValidIntegerRangeSetType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Provides additional platform/program specific ranging information.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="MetaCommandSetType">
+		<annotation>
+			<documentation xml:lang="en">Describes an unordered collection of command definitions.  Duplicates are invalid based on the name attribute of MetaCommand and BlockMetaCommand.  See MetaCommandType and BlockMetaCommandType.</documentation>
+		</annotation>
+		<choice maxOccurs="unbounded">
+			<element name="MetaCommand" type="xtce:MetaCommandType">
+				<annotation>
+					<documentation xml:lang="en">All atomic commands to be sent on this mission are listed here.  In addition this area has verification and validation information.</documentation>
+				</annotation>
+				<key name="ArgumentNameKey">
+					<selector xpath="xtce:ArgumentList/*"/>
+					<field xpath="@name"/>
+				</key>
+			</element>
+			<element name="MetaCommandRef" type="xtce:NameReferenceType">
+				<annotation>
+					<documentation xml:lang="en">Used to include a MetaCommand defined in another sub-system in this sub-system.</documentation>
+				</annotation>
+			</element>
+			<element name="BlockMetaCommand" type="xtce:BlockMetaCommandType">
+				<annotation>
+					<documentation xml:lang="en">Used to define a command that includes more than one atomic MetaCommand definition.</documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<complexType name="MetaCommandStepListType">
+		<annotation>
+			<documentation xml:lang="en">Describe the list of MetaCommand definitions that form the block command.  Contains an ordered list of MetaCommandSteps where each step is a MetaCommand with associated arguments, duplicates are valid.  See BlockMetaCommandType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="MetaCommandStep" type="xtce:MetaCommandStepType" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">A MetaCommand with specific specified argument values to include in the BlockMetaCommand.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="MetaCommandStepType">
+		<annotation>
+			<documentation>Describe a MetaCommand step, consisting MetaCommand reference and argument list. See MetaCommandStepListType and NameReferenceType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="ArgumentAssigmentList" type="xtce:ArgumentAssignmentListType" minOccurs="0"/>
+		</sequence>
+		<attribute name="metaCommandRef" type="xtce:NameReferenceType" use="required"/>
+	</complexType>
+	<complexType name="MetaCommandType" mixed="false">
+		<annotation>
+			<documentation xml:lang="en">Describe a command which consists of an abstract portion (MetaCommand) and an optional packaging portion (MetaCommand CommandContainer).  An argument list is provided. MetaCommand may extend other MetaCommands and their CommandContainer may extend other CommandContainer or SequenceContainers.  A MetaCommand’s CommandContainer is private except as referred to in BaseMetaCommand (they are not visible to other containers and cannot be used in an entry list). MetaCommands may also define various other behavioral aspects of a command such as command verifiers.  See CommandContainerType, ArgumentListType, BaseMetaCommandType and BaseContainerType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<sequence>
+					<element name="BaseMetaCommand" type="xtce:BaseMetaCommandType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Optional inheritance for this MetaCommand from another named MetaCommand.</documentation>
+						</annotation>
+					</element>
+					<element name="SystemName" type="string" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Optional.  Normally used when the database is built in a flat, non-hierarchical format.  May be used by implementations to group MetaCommands together.</documentation>
+						</annotation>
+					</element>
+					<element name="ArgumentList" type="xtce:ArgumentListType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Many commands have one or more options.  These are called command arguments.  Command arguments may be of any of the standard data types.  MetaCommand arguments are local to the MetaCommand, but may be referenced in inherited MetaCommand definitions, generally to apply Argument Assignments to the values.</documentation>
+						</annotation>
+					</element>
+					<element name="CommandContainer" type="xtce:CommandContainerType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Tells how to package/encode this command definition in binary form.</documentation>
+						</annotation>
+					</element>
+					<element name="TransmissionConstraintList" type="xtce:TransmissionConstraintListType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">List of constraints to check when sending this command.</documentation>
+						</annotation>
+					</element>
+					<element name="DefaultSignificance" type="xtce:SignificanceType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Some Command and Control Systems may require special user access or confirmations before transmitting commands with certain levels.  The level is inherited from the Base MetaCommand.</documentation>
+						</annotation>
+					</element>
+					<element name="ContextSignificanceList" type="xtce:ContextSignificanceListType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Some Command and Control Systems may require special user access or confirmations before transmitting commands with certain levels.  In addition to the default, Significance can be defined in contexts where it changes based on the values of parameters.</documentation>
+						</annotation>
+					</element>
+					<element name="Interlock" type="xtce:InterlockType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">An Interlock is a type of Constraint, but not on Command instances of this MetaCommand; Interlocks apply instead to the next command.  An Interlock will block successive commands until this command has reached a certain stage (through verifications).  Interlocks are scoped to a SpaceSystem basis.</documentation>
+						</annotation>
+					</element>
+					<element name="VerifierSet" type="xtce:VerifierSetType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Functional list of conditions/changes to check after sending this command to determine success or failure.</documentation>
+						</annotation>
+					</element>
+					<element name="ParameterToSetList" type="xtce:ParameterToSetListType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">List of parameters to set new values upon completion of sending this command.</documentation>
+						</annotation>
+					</element>
+					<element name="ParametersToSuspendAlarmsOnSet" type="xtce:ParametersToSuspendAlarmsOnSetType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">List of parameters to suspend alarm processing/detection upon completion of sending this command.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="abstract" type="boolean" default="false">
+					<annotation>
+						<documentation xml:lang="en">Abstract MetaCommand definitions that are not instantiated, rather only used as bases to inherit from to create specialized command definitions.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="RelativeTimeArgumentType">
+		<annotation>
+			<documentation xml:lang="en">Describes a relative time argument type. Relative time parameters are time offsets (e.g. 10 second, 1.24 milliseconds, etc.) See IntegerDataEncodingType, FloatDataEncoding and RelativeTimeDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentRelativeTimeDataType"/>
+		</complexContent>
+	</complexType>
+	<complexType name="SignificanceType" mixed="false">
+		<annotation>
+			<documentation xml:lang="en">Significance provides some cautionary information about the potential consequence of each MetaCommand.</documentation>
+		</annotation>
+		<attribute name="spaceSystemAtRisk" type="xtce:NameReferenceType">
+			<annotation>
+				<documentation xml:lang="en">If none is supplied, then the current SpaceSystem is assumed to be the one at risk by the issuance of this command</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="reasonForWarning" type="string"/>
+		<attribute name="consequenceLevel" type="xtce:ConsequenceLevelType" default="normal"/>
+	</complexType>
+	<complexType name="StringArgumentType">
+		<annotation>
+			<documentation xml:lang="en">Describes a string parameter type. Three forms are supported: fixed length, variable length and variable length using a prefix. See StringDataEncodingType and StringDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentStringDataType"/>
+		</complexContent>
+	</complexType>
+	<!--*************************************************************-->
+	<!--******** Types used with Cmd Execution Control ****-->
+	<complexType name="AcceptedVerifierType">
+		<annotation>
+			<documentation xml:lang="en">A verifier that means the SpaceSystem has accepted the command</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:CommandVerifierType"/>
+		</complexContent>
+	</complexType>
+	<complexType name="CheckWindowType">
+		<annotation>
+			<documentation xml:lang="en">Used by CommandVerifiers to limit the time allocated to check for the verification.  See CheckWindowAlgorithmsType.</documentation>
+		</annotation>
+		<attribute name="timeToStartChecking" type="xtce:RelativeTimeType"/>
+		<attribute name="timeToStopChecking" type="xtce:RelativeTimeType" use="required"/>
+		<attribute name="timeWindowIsRelativeTo" type="xtce:TimeWindowIsRelativeToType" default="timeLastVerifierPassed"/>
+	</complexType>
+	<complexType name="CheckWindowAlgorithmsType">
+		<annotation>
+			<documentation xml:lang="en">Used by CommandVerifiers to limit the time allocated to check for the verification.  See CommandVerifierType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="StartCheck" type="xtce:InputAlgorithmType"/>
+			<element name="StopTime" type="xtce:InputAlgorithmType"/>
+		</sequence>
+	</complexType>
+	<complexType name="CompleteVerifierType">
+		<annotation>
+			<documentation xml:lang="en">A possible set of verifiers that all must be true for the command be considered completed.  </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:CommandVerifierType">
+				<sequence minOccurs="0">
+					<element name="ReturnParmRef" type="xtce:ParameterRefType"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ContextSignificanceType">
+		<annotation>
+			<documentation xml:lang="en">Describe a significance level for a MetaCommand definition where the significance level depends on matching a context value.  See ContextMatchType and SignificanceType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="ContextMatch" type="xtce:ContextMatchType">
+				<annotation>
+					<documentation xml:lang="en">Describe the context matching value and source that will enable the Significance listed in the Significance element.</documentation>
+				</annotation>
+			</element>
+			<element name="Significance" type="xtce:SignificanceType">
+				<annotation>
+					<documentation xml:lang="en">Describe the signficance of this MetaCommand definition.  See SignificanceType.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ContextSignificanceListType">
+		<annotation>
+			<documentation xml:lang="en">Describe an ordered list of ContextSignificance elements where the significance on the first context match to test true is used as the significance of the MetaCommand.  If there is a DefaultSignificance, it is overrideen by the matching context.  See ContextSignificantType and MetaCommandType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="ContextSignificance" type="xtce:ContextSignificanceType" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">Describe a significance level for a MetaCommand definition where the significance level depends on matching a context value.  See ContextMatchType and SignificanceType.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ExecutionVerifierType">
+		<annotation>
+			<documentation xml:lang="en">A verifier that indicates that the command is being executed.  An optional Element indicates how far along the command has progressed either as a fixed value or an (possibly scaled) ParameterInstance value.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:CommandVerifierType">
+				<sequence minOccurs="0">
+					<element name="PercentComplete" type="xtce:PercentCompleteType"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="FailedVerifierType">
+		<annotation>
+			<documentation xml:lang="en">When true, indicates that the command failed.  timeToWait is how long to wait for the FailedVerifier to test true.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:CommandVerifierType">
+				<sequence minOccurs="0">
+					<element name="ReturnParmRef" type="xtce:ParameterRefType"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="InterlockType">
+		<annotation>
+			<documentation xml:lang="en">Describe a type of constraint on the next command, rather than this command. Interlocks apply only to the next command.  An interlock will block successive commands until this command has reached a certain stage of verifier.  Interlocks are scoped to a SpaceSystem basis:  they by default apply to the SpaceSystem the MetaCommand is defined in but this may be overridden.  See MetaCommandType and VerifierSetType.</documentation>
+		</annotation>
+		<attribute name="scopeToSpaceSystem" type="xtce:NameReferenceType">
+			<annotation>
+				<documentation xml:lang="en">The name of a SpaceSystem this Interlock applies to.  By default, it only applies to the SpaceSystem that contains this MetaCommand.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="verificationToWaitFor" type="xtce:VerifierEnumerationType" default="complete">
+			<annotation>
+				<documentation xml:lang="en">The verification stage of the command that releases the interlock, with the default being complete.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="verificationProgressPercentage" type="double">
+			<annotation>
+				<documentation xml:lang="en">Only applies when the verificationToWaitFor attribute is 'queued' or 'executing'.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="suspendable" type="boolean" default="false">
+			<annotation>
+				<documentation xml:lang="en">A flag that indicates that under special circumstances, this Interlock can be suspended.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="ParameterToSetType">
+		<annotation>
+			<documentation xml:lang="en">Sets a Parameter to a new value (either from a derivation or explicitly) after the command has been verified (all verifications have passed).</documentation>
+			<appinfo>Value type must match Parameter type.</appinfo>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ParameterRefType">
+				<choice>
+					<element name="Derivation" type="xtce:MathOperationType">
+						<annotation>
+							<documentation xml:lang="en">Specify a MathOperation to use to set the Parameter value.  See MathOperationType.</documentation>
+						</annotation>
+					</element>
+					<element name="NewValue" type="string">
+						<annotation>
+							<documentation xml:lang="en">Specify value as a string compliant with the XML schema (xs) type specified for each XTCE type: integer=xs:integer; float=xs:double; string=xs:string; boolean=xs:boolean; binary=xs:hexBinary; enum=xs:string from EnumerationList; relative time= xs:duration; absolute time=xs:dateTime.  Supplied value must be within the ValidRange specified for the Parameter and appropriate for the type.</documentation>
+						</annotation>
+					</element>
+				</choice>
+				<attribute name="setOnVerification" type="xtce:VerifierEnumerationType" default="complete">
+					<annotation>
+						<documentation xml:lang="en">This attribute provides more specific control over when the Parameter value is set.  By default, it is when the command have all verifications complete.  See VerifierEnumerationType.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ParameterToSetListType">
+		<annotation>
+			<documentation xml:lang="en">Parameters that are set with a new value after the command has been sent.  Appended to the Base Command list</documentation>
+		</annotation>
+		<sequence>
+			<element name="ParameterToSet" type="xtce:ParameterToSetType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="ParameterToSuspendAlarmsOnType">
+		<annotation>
+			<documentation xml:lang="en">Will suspend all Alarms associated with this Parameter for the given suspense time after the given verifier</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ParameterRefType">
+				<attribute name="suspenseTime" type="xtce:RelativeTimeType" use="required"/>
+				<attribute name="verifierToTriggerOn" type="xtce:VerifierEnumerationType" default="release"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ParametersToSuspendAlarmsOnSetType">
+		<annotation>
+			<documentation xml:lang="en">Sometimes it is necessary to suspend alarms - particularly 'change' alarms for commands that will change the value of a Parameter</documentation>
+		</annotation>
+		<sequence>
+			<element name="ParameterToSuspendAlarmsOn" type="xtce:ParameterToSuspendAlarmsOnType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="ParameterValueChangeType">
+		<annotation>
+			<documentation xml:lang="en">A parameter change in value or specified delta change in value.</documentation>
+		</annotation>
+		<sequence>
+			<element name="ParameterRef" type="xtce:ParameterRefType"/>
+			<element name="Change" type="xtce:ChangeValueType"/>
+		</sequence>
+	</complexType>
+	<complexType name="QueuedVerifierType">
+		<annotation>
+			<documentation xml:lang="en">A verifer that means the command is scheduled for execution by the SpaceSystem.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:CommandVerifierType"/>
+		</complexContent>
+	</complexType>
+	<complexType name="ReceivedVerifierType">
+		<annotation>
+			<documentation xml:lang="en">A verifier that simply means the SpaceSystem has received the command.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:CommandVerifierType"/>
+		</complexContent>
+	</complexType>
+	<complexType name="SentFromRangeVerifierType">
+		<annotation>
+			<documentation xml:lang="en">Sent from range means the command has been transmitted to the spacecraft by the network that connects the ground system to the spacecraft.  Obviously, this verifier must come from something other than the spacecraft. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:CommandVerifierType"/>
+		</complexContent>
+	</complexType>
+	<simpleType name="TimeAssociationUnitType">
+		<annotation>
+			<documentation>Time units the time association decimal value is in.</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="si_nanosecond"/>
+			<enumeration value="si_microsecond"/>
+			<enumeration value="si_millsecond"/>
+			<enumeration value="si_second"/>
+			<enumeration value="minute"/>
+			<enumeration value="day"/>
+			<enumeration value="julianYear"/>
+		</restriction>
+	</simpleType>
+	<complexType name="TransferredToRangeVerifierType">
+		<annotation>
+			<documentation xml:lang="en">Transferred to range means the command has been received to the network that connects the ground system to the spacecraft.  Obviously, this verifier must come from something other than the spacecraft. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:CommandVerifierType"/>
+		</complexContent>
+	</complexType>
+	<complexType name="TransmissionConstraintType">
+		<annotation>
+			<documentation xml:lang="en">A CommandTransmission constraint is used to check that the command can be run in the current operating mode and may block the transmission of the command if the constraint condition is true.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:MatchCriteriaType">
+				<attribute name="timeOut" type="xtce:RelativeTimeType">
+					<annotation>
+						<documentation xml:lang="en">Pause during timeOut, fail when the timeout passes</documentation>
+					</annotation>
+					<!-- removed for CASTOR: default="PT0S" -->
+				</attribute>
+				<attribute name="suspendable" type="boolean" default="false">
+					<annotation>
+						<documentation xml:lang="en">Indicates whether the constraints for a Command may be suspended.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="TransmissionConstraintListType">
+		<annotation>
+			<documentation xml:lang="en">Appended to the TramsmissionConstraint List of the base command.  Constraints are checked in order.  </documentation>
+		</annotation>
+		<sequence>
+			<element name="TransmissionConstraint" type="xtce:TransmissionConstraintType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<simpleType name="VerifierEnumerationType">
+		<annotation>
+			<documentation xml:lang="en">An enumerated list of verifier types</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="release"/>
+			<enumeration value="transferredToRange"/>
+			<enumeration value="sentFromRange"/>
+			<enumeration value="received"/>
+			<enumeration value="accepted"/>
+			<enumeration value="queued"/>
+			<enumeration value="executing"/>
+			<enumeration value="complete"/>
+			<enumeration value="failed"/>
+		</restriction>
+	</simpleType>
+	<complexType name="VerifierSetType">
+		<annotation>
+			<documentation xml:lang="en">Describe a collection of unordered verifiers.  A command verifier is a conditional check on the telemetry from a SpaceSystem that that provides positive indication on the processing state of a command.  There are eight different verifiers each associated with difference states in command processing: TransferredToRange, TransferredFromRange, Received, Accepted, Queued, Execution, Complete, and Failed.  There may be multiple ‘complete’ and 'execution' verifiers. If the MetaCommand is part of an inheritance relation (BaseMetaCommand), the 'complete' and 'execution' verifier sets are appended to any defined in the parent MetaCommand. All others will override a verifier defined in a BaseMetaCommand.  Duplicate verifiers in the list of CompleteVerifiers and ExecutionVerifiers before and after appending to the verifiers in BaseMetaCommand should be avoided. See MetaCommandType and BaseMetaCommandType for additional information.</documentation>
+		</annotation>
+		<sequence>
+			<element name="TransferredToRangeVerifier" type="xtce:TransferredToRangeVerifierType" minOccurs="0"/>
+			<element name="SentFromRangeVerifier" type="xtce:SentFromRangeVerifierType" minOccurs="0"/>
+			<element name="ReceivedVerifier" type="xtce:ReceivedVerifierType" minOccurs="0"/>
+			<element name="AcceptedVerifier" type="xtce:AcceptedVerifierType" minOccurs="0"/>
+			<element name="QueuedVerifier" type="xtce:QueuedVerifierType" minOccurs="0"/>
+			<element name="ExecutionVerifier" type="xtce:ExecutionVerifierType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="CompleteVerifier" type="xtce:CompleteVerifierType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="FailedVerifier" type="xtce:FailedVerifierType" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<!--******** End of Command Schema *********************-->
+	<!--*************************************************************-->
+	<!--****** Algorithm Schema ********************************-->
+	<annotation>
+		<documentation xml:lang="en">This schema defines the structure for an Algorithm.   An Algorithm may be one of a growing set of pre-defined algorithms or a named escape into a user defined algorithm where (depending on the system) the name of the algorithm may be a java class, a function in a shared library, an external program or some other reference to an outside algorithm.  At some later date, this schema may also allow the logic of the user defined algorithm to be defined within the instance document itself (perhaps using MathML?).</documentation>
+	</annotation>
+	<complexType name="AlgorithmTextType">
+		<annotation>
+			<documentation xml:lang="en">This optional element may be used to enter Pseudo or actual code for the algorithm.  The language for the algorithm is specified with the language attribute</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="string">
+				<attribute name="language" type="string" default="pseudo"/>
+			</extension>
+		</simpleContent>
+	</complexType>
+	<complexType name="BaseTriggerType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">A base type for the various triggers, purely to improve the mappings created by data binding compilers.</documentation>
+		</annotation>
+	</complexType>
+	<complexType name="ChecksumType">
+		<annotation>
+			<documentation>Describe checksum information.</documentation>
+		</annotation>
+		<sequence>
+			<element name="InputAlgorithm" type="xtce:InputAlgorithmType" minOccurs="0">
+				<annotation>
+					<documentation>Assumed to return the computed checksum.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="bitsFromReference" type="xtce:NonNegativeLongType"/>
+		<attribute name="reference" type="xtce:ReferencePointType" default="start"/>
+		<attribute name="name" use="required">
+			<annotation>
+				<documentation>Qualified list of name checksum algorithms. If custom is chosen, InputAlgorithm must be set.</documentation>
+			</annotation>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="unix_sum"/>
+					<enumeration value="sum8"/>
+					<enumeration value="sum16"/>
+					<enumeration value="sum24"/>
+					<enumeration value="sum32"/>
+					<enumeration value="fletcher4"/>
+					<enumeration value="fletcher8"/>
+					<enumeration value="fletcher16"/>
+					<enumeration value="fletcher32"/>
+					<enumeration value="adler32"/>
+					<enumeration value="luhn"/>
+					<enumeration value="verhoeff"/>
+					<enumeration value="damm"/>
+					<enumeration value="custom">
+						<annotation>
+							<documentation>Document a custom checksum algorithm</documentation>
+						</annotation>
+					</enumeration>
+				</restriction>
+			</simpleType>
+		</attribute>
+		<attribute name="hashSizeInBits" type="xtce:PositiveLongType"/>
+	</complexType>
+	<complexType name="ConstantType">
+		<annotation>
+			<documentation xml:lang="en">Names and provides a value for a constant input to the algorithm.  There are two attributes to Constant, constantName and value.  constantName is a variable name in the algorithm to be executed.  value is the value of the constant to be used.</documentation>
+		</annotation>
+		<attribute name="constantName" type="string"/>
+		<attribute name="value" type="string" use="required"/>
+	</complexType>
+	<complexType name="ContextCalibratorListType">
+		<annotation>
+			<documentation xml:lang="en">Describe an ordered list of calibrators with a context match.  Useful when different calibrations must be used depending on a matching value.  The first context that matches determines which calibrator to use. See IntegerDataEncodingType and FloatDataEncodingType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="ContextCalibrator" type="xtce:ContextCalibratorType" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">Describe a calibrator that depends on a matching value using a ContextMatch.  When the context matches for the calibrator, the default calibrator is overridden, if it exists.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ExternalAlgorithmType">
+		<annotation>
+			<documentation xml:lang="en">This is the external algorithm.  Multiple entries are provided so that the same database may be used for multiple implementation s</documentation>
+		</annotation>
+		<attribute name="implementationName" type="string" use="required"/>
+		<attribute name="algorithmLocation" type="string" use="required"/>
+	</complexType>
+	<complexType name="ExternalAlgorithmSetType">
+		<sequence>
+			<element name="ExternalAlgorithm" type="xtce:ExternalAlgorithmType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="InputAlgorithmType">
+		<annotation>
+			<documentation xml:lang="en">A set of labeled inputs is added to the SimpleAlgorithmType</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:SimpleAlgorithmType">
+				<sequence>
+					<element name="InputSet" type="xtce:InputSetType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">The InputSet describes the list of parameters that should be made available as input arguments to the algorithm.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="InputOutputAlgorithmType">
+		<annotation>
+			<documentation xml:lang="en">A set of labeled outputs are added to the SimpleInputAlgorithmType</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:InputAlgorithmType">
+				<sequence>
+					<element name="OutputSet" type="xtce:OutputSetType" minOccurs="0"/>
+				</sequence>
+				<attribute name="thread" type="boolean" use="optional" default="false"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="InputOutputTriggerAlgorithmType">
+		<annotation>
+			<documentation xml:lang="en">Input output algorithm is extended with a set of labeled triggers. See InputOutputAlgorithmType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:InputOutputAlgorithmType">
+				<sequence>
+					<element name="TriggerSet" type="xtce:TriggerSetType" minOccurs="0"/>
+				</sequence>
+				<attribute name="triggerContainer" type="xtce:NameReferenceType" use="optional">
+					<annotation>
+						<documentation xml:lang="en">First telemetry container from which the output parameter should be calculated.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="priority" type="int" use="optional">
+					<annotation>
+						<documentation xml:lang="en">Algorithm processing priority. If more than one algorithm is triggered by the same container, the lowest priority algorithm should be calculated first.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="InputParameterInstanceRefType">
+		<annotation>
+			<documentation xml:lang="en">Names an input parameter to the algorithm.  There are two attributes to InputParm, inputName and parameterName. parameterName is a parameter reference name for a parameter that will be used in this algorithm.  inputName is an optional "friendly" name for the input parameter. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ParameterInstanceRefType">
+				<attribute name="inputName" type="string"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="InputSetType">
+		<choice maxOccurs="unbounded">
+			<element name="InputParameterInstanceRef" type="xtce:InputParameterInstanceRefType"/>
+			<element name="Constant" type="xtce:ConstantType" minOccurs="0"/>
+		</choice>
+	</complexType>
+	<complexType name="MathAlgorithmType">
+		<annotation>
+			<documentation xml:lang="en">Describe a postfix (Reverse Polish Notation (RPN)) notation based mathmatical equations. See MathOperationType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<sequence>
+					<element name="MathOperation" type="xtce:TriggeredMathOperationType">
+						<annotation>
+							<documentation xml:lang="en">The contents of the Math Operation as an algorithm definition in RPN.  See TriggeredMathOperationType.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="OnContainerUpdateTriggerType">
+		<annotation>
+			<documentation xml:lang="en">Describe a reference to container that triggers an event when the telemetry container referred to is updated (processed).  See TriggerSetType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseTriggerType">
+				<attribute name="containerRef" type="xtce:NameReferenceType" use="required">
+					<annotation>
+						<documentation xml:lang="en">Reference to the Container whose update/receipt triggers this algorithm to evaluate.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="OnPeriodicRateTriggerType">
+		<annotation>
+			<documentation xml:lang="en">Describe a periodic time basis to trigger an event.  See TriggerSetType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseTriggerType">
+				<attribute name="fireRateInSeconds" type="double" use="required">
+					<annotation>
+						<documentation xml:lang="en">The periodic rate in time in which this algorithm is triggered to evaluate.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="OnParameterUpdateTriggerType">
+		<annotation>
+			<documentation xml:lang="en">Describe a reference to parameter that triggers an event when the telemetry parameter referred to is updated (processed) with a new value.  See TriggerSetType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseTriggerType">
+				<attribute name="parameterRef" type="xtce:NameReferenceType" use="required">
+					<annotation>
+						<documentation xml:lang="en">Reference to the Parameter whose update triggers this algorithm to evaluate.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="OutputParameterRefType">
+		<annotation>
+			<documentation xml:lang="en">Names an output parameter to the algorithm.  There are two attributes to OutputParm, outputName and parameterName. parameterName is a parameter reference name for a parameter that will be updated by this algorithm.  outputName is an optional "friendly" name for the output parameter.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ParameterRefType">
+				<attribute name="outputName" type="string"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="OutputSetType">
+		<sequence>
+			<element name="OutputParameterRef" type="xtce:OutputParameterRefType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="SimpleAlgorithmType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">The simplest form of algorithm, a SimpleAlgorithmType contains an area for a free-form pseudo code description of the algorithm plus a Set of references to external algorithms.  External algorithms are usually unique to a ground system type.   Multiple external algorithms are possible because XTCE documents may be used across multiple ground systems.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<sequence>
+					<element name="AlgorithmText" type="xtce:AlgorithmTextType" minOccurs="0"/>
+					<element name="ExternalAlgorithmSet" type="xtce:ExternalAlgorithmSetType" minOccurs="0"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="TriggeredMathOperationType">
+		<complexContent>
+			<extension base="xtce:MathOperationType">
+				<sequence>
+					<element name="TriggerSet" type="xtce:TriggerSetType"/>
+				</sequence>
+				<attribute name="outputParameterRef" type="xtce:NameReferenceType" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="TriggerSetType">
+		<annotation>
+			<documentation xml:lang="en">A trigger is used to initiate the processing of some algorithm.  A trigger may be based on an update of a Parameter, receipt of a Container, or on a time basis.  Triggers may also have a maximum rate that limits how often the trigger can be invoked.</documentation>
+		</annotation>
+		<choice maxOccurs="unbounded">
+			<element name="OnParameterUpdateTrigger" type="xtce:OnParameterUpdateTriggerType">
+				<annotation>
+					<documentation xml:lang="en">This element instructs the trigger to invoke the algorithm evaluation when a Parameter update is received.</documentation>
+				</annotation>
+			</element>
+			<element name="OnContainerUpdateTrigger" type="xtce:OnContainerUpdateTriggerType">
+				<annotation>
+					<documentation xml:lang="en">This element instructs the trigger to invoke the algorithm evaluation when a Container is received.</documentation>
+				</annotation>
+			</element>
+			<element name="OnPeriodicRateTrigger" type="xtce:OnPeriodicRateTriggerType">
+				<annotation>
+					<documentation xml:lang="en">This element instructs the trigger to invoke the algorithm evaluation using a timer.</documentation>
+				</annotation>
+			</element>
+		</choice>
+		<attribute name="name" type="string" use="optional">
+			<annotation>
+				<documentation xml:lang="en">Triggers may optionally be named.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="triggerRate" type="xtce:NonNegativeLongType" use="optional" default="1">
+			<annotation>
+				<documentation xml:lang="en">This attribute is a maximum rate that constrains how quickly this trigger may evaluate the algorithm to avoid flooding the implementation.  The default is once per second.  Setting to 0 results in no maximum.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<!--*************************************************************-->
+	<!--******** Calibrator Algorithm Types ***********************-->
+	<complexType name="BaseCalibratorType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Supplies an optional non-reference-able name and short description for calibrators.  Also includes an optional ancillary data for any special local flags, note that these may not necessarily transfer to another recipient of an instance document.</documentation>
+		</annotation>
+		<sequence>
+			<element name="AncillaryDataSet" type="xtce:AncillaryDataSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Optional additional ancillary information for this calibrator/algorithm</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="name" type="string">
+			<annotation>
+				<documentation xml:lang="en">Optional name for this calibrator/algorithm</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="shortDescription" type="xtce:ShortDescriptionType">
+			<annotation>
+				<documentation xml:lang="en">Optional description for this calibrator/algorithm</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="CalibratorType">
+		<annotation>
+			<documentation xml:lang="en">Describe a calibrator to transform a source data type raw/uncalibrated value (e.g. an integer count from a spacecraft) to an engineering unit/calibrated value for users (e.g. a float).</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseCalibratorType">
+				<choice>
+					<element name="SplineCalibrator" type="xtce:SplineCalibratorType">
+						<annotation>
+							<documentation xml:lang="en">Describes a calibrator in the form of a piecewise defined function</documentation>
+						</annotation>
+					</element>
+					<element name="PolynomialCalibrator" type="xtce:PolynomialCalibratorType">
+						<annotation>
+							<documentation xml:lang="en">Describes a calibrator in the form of a polynomial function</documentation>
+						</annotation>
+					</element>
+					<element name="MathOperationCalibrator" type="xtce:MathOperationCalibratorType">
+						<annotation>
+							<documentation xml:lang="en">Describes a calibrator in the form of a user/program/implementation defined function</documentation>
+						</annotation>
+					</element>
+				</choice>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ChangeValueType">
+		<annotation>
+			<documentation xml:lang="en">Describe a change value used to test verification status. See CommandVerifierType.</documentation>
+		</annotation>
+		<attribute name="value" type="double" use="required">
+			<annotation>
+				<documentation xml:lang="en">Value as a floating point number.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="MathOperationCalibratorType">
+		<annotation>
+			<documentation xml:lang="en">Describe a mathematical function for calibration where the mathematical function is defined using the MathOperationType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseCalibratorType">
+				<choice maxOccurs="unbounded">
+					<annotation>
+						<documentation xml:lang="en">Describe a postfix (aka Reverse Polish Notation (RPN)) expression for mathematical equations. It uses a stack where operands (either fixed values or ParameterInstances) are pushed onto the stack from first to last in the XML. As the operators are specified, each pops off operands as it evaluates them, and pushes the result back onto the stack. For example, the stack, 4 8 /, would result as 0.5.  In this case postfix is used to avoid having to specify parenthesis. To convert from infix to postfix, use Dijkstra's "shunting yard" algorithm.</documentation>
+					</annotation>
+					<element name="ValueOperand" type="string">
+						<annotation>
+							<documentation xml:lang="en">Use a constant in the calculation.</documentation>
+						</annotation>
+					</element>
+					<element name="ThisParameterOperand" type="string" fixed="">
+						<annotation>
+							<documentation xml:lang="en">Use the value of this parameter in the calculation. It is the calibrator's value only.  If the raw value is needed, specify it explicitly using ParameterInstanceRefOperand. Note this element has no content.</documentation>
+						</annotation>
+					</element>
+					<element name="Operator" type="xtce:MathOperatorsType">
+						<annotation>
+							<documentation xml:lang="en">All operators utilize operands on the top values in the stack and leaving the result on the top of the stack.  Ternary operators utilize the top three operands on the stack, binary operators utilize the top two operands on the stack, and unary operators use the top operand on the stack.</documentation>
+						</annotation>
+					</element>
+					<element name="ParameterInstanceRefOperand" type="xtce:ParameterInstanceRefType">
+						<annotation>
+							<documentation xml:lang="en">This element is used to reference the last received/assigned value of any Parameter in this math operation.</documentation>
+						</annotation>
+					</element>
+				</choice>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="PolynomialCalibratorType">
+		<annotation>
+			<documentation xml:lang="en">Describe a polynomial equation for calibration. This is a calibration type where a curve in a raw vs calibrated plane is described using a set of polynomial coefficients.  Raw values are converted to calibrated values by finding a position on the curve corresponding to the raw value. The first coefficient belongs with the X^0 term, the next coefficient belongs to the X^1 term and so on. See CalibratorType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseCalibratorType">
+				<sequence>
+					<element name="Term" type="xtce:TermType" maxOccurs="unbounded">
+						<annotation>
+							<documentation xml:lang="en">A single term in the polynomial function.</documentation>
+							<appinfo>Generally only up to second order powers are reflexive.  Implementations may limit the maximum number of terms supported.</appinfo>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="SplineCalibratorType">
+		<annotation>
+			<documentation xml:lang="en">Describe a spline function for calibration using a set of at least 2 points.  Raw values are converted to calibrated values by finding a position on the line corresponding to the raw value.  The line may be interpolated and/or extrapolated as needed. The interpolation order may be specified for all the points and overridden on individual points.  The algorithm triggers on the input parameter. See CalibratorType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseCalibratorType">
+				<sequence>
+					<element name="SplinePoint" type="xtce:SplinePointType" minOccurs="2" maxOccurs="unbounded">
+						<annotation>
+							<documentation xml:lang="en">Describes a single point of the spline or piecewise function.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="order" type="xtce:NonNegativeLongType" default="1">
+					<annotation>
+						<documentation xml:lang="en">The interpolation order to apply to the overall spline function.  Order 0 is no slope between the points (flat).  Order 1 is linear interpolation.  Order 2 would be quadratic and in this special case, 3 points would be required, etc.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="extrapolate" type="boolean" default="false">
+					<annotation>
+						<documentation xml:lang="en">Extrapolation allows the closest outside point and the associated interpolation to extend outside of the range of the points in the spline function.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!--******** End of Algorithm Schema *********************-->
+	<!--*************************************************************-->
+	<!--******** Stream Definitions Schema *******************-->
+	<annotation>
+		<documentation xml:lang="en">This schema provides a language for defining binary stream data.</documentation>
+	</annotation>
+	<complexType name="AutoInvertType">
+		<annotation>
+			<documentation xml:lang="en">After searching for the frame sync marker for some number of bits, it may be desirable to invert the incoming data, and then look for frame sync.  In some cases this will require an external algorithm</documentation>
+		</annotation>
+		<sequence>
+			<element name="InvertAlgorithm" type="xtce:InputAlgorithmType" minOccurs="0"/>
+		</sequence>
+		<attribute name="badFramesToAutoInvert" type="xtce:PositiveLongType" default="1024"/>
+	</complexType>
+	<complexType name="CustomStreamType">
+		<annotation>
+			<documentation xml:lang="en">A stream type where some level of custom processing (e.g. convolutional, encryption, compression) is performed.  Has a reference to external algorithms for encoding and decoding algorithms.</documentation>
+			<appinfo>Must check to ensure that the attributes encodedStreamRef and decodedStreamRef point to valid Streams</appinfo>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:PCMStreamType">
+				<sequence>
+					<element name="EncodingAlgorithm" type="xtce:InputAlgorithmType"/>
+					<element name="DecodingAlgorithm" type="xtce:InputOutputAlgorithmType">
+						<annotation>
+							<documentation xml:lang="en">Algorithm outputs may be used to set decoding quality parameters.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="encodedStreamRef" type="xtce:NameReferenceType" use="required"/>
+				<attribute name="decodedStreamRef" type="xtce:NameReferenceType" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<simpleType name="FlagBitType">
+		<restriction base="string">
+			<enumeration value="zeros"/>
+			<enumeration value="ones"/>
+		</restriction>
+	</simpleType>
+	<complexType name="FlagType">
+		<annotation>
+			<documentation xml:lang="en">The pattern of bits used to look for frame synchronization.</documentation>
+		</annotation>
+		<attribute name="flagSizeInBits" type="xtce:PositiveLongType" default="6"/>
+		<attribute name="flagBitType" type="xtce:FlagBitType" default="ones"/>
+	</complexType>
+	<complexType name="FrameStreamType">
+		<annotation>
+			<documentation xml:lang="en">The top level type definition for all data streams that are frame based.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:PCMStreamType">
+				<sequence>
+					<choice>
+						<element name="ContainerRef" type="xtce:ContainerRefType">
+							<annotation>
+								<documentation xml:lang="en">This Container (usually abstract) is the container that is in the fixed frame stream.  Normally, this is a general container type from which many specific containers are inherited.</documentation>
+							</annotation>
+						</element>
+						<element name="ServiceRef" type="xtce:ServiceRefType"/>
+					</choice>
+					<element name="StreamRef" type="xtce:StreamRefType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">This is a reference to a connecting stream - say a custom stream.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="FixedFrameStreamType">
+		<annotation>
+			<documentation xml:lang="en">For streams that contain a series of frames with a fixed frame length where the frames are found by looking for a marker in the data.  This marker is sometimes called the frame sync pattern and sometimes the Asynchronous Sync Marker (ASM).  This marker need not be contiguous although it usually is.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:FrameStreamType">
+				<sequence>
+					<element name="SyncStrategy" type="xtce:FixedFrameSyncStrategyType"/>
+				</sequence>
+				<attribute name="syncApertureInBits" type="xtce:NonNegativeLongType" default="0">
+					<annotation>
+						<documentation xml:lang="en">Allowed slip (in bits) in either direction for the sync pattern</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="frameLengthInBits" type="long" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="FixedFrameSyncStrategyType">
+		<annotation>
+			<documentation xml:lang="en">Describe a sync pattern and an optional reference to an algorithm used to invert the stream if the frame sync pattern is not found. See FixedFrameStreamType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:SyncStrategyType">
+				<sequence>
+					<element name="SyncPattern" type="xtce:SyncPatternType">
+						<annotation>
+							<documentation xml:lang="en">The pattern of bits used to look for frame synchronization.  See SyncPatternType.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="PCMStreamType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">A PCM Stream Type is the high level definition for all Pulse Code Modulated (PCM) (i.e., binary) streams.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<attribute name="bitRateInBPS" type="double"/>
+				<attribute name="pcmType" type="xtce:PCMType" default="NRZL"/>
+				<attribute name="inverted" type="boolean" default="false"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<simpleType name="PCMType">
+		<restriction base="string">
+			<enumeration value="NRZL"/>
+			<enumeration value="NRZM"/>
+			<enumeration value="NRZS"/>
+			<enumeration value="BiPhaseL"/>
+			<enumeration value="BiPhaseM"/>
+			<enumeration value="BiPhaseS"/>
+		</restriction>
+	</simpleType>
+	<complexType name="StreamRefType">
+		<annotation>
+			<documentation xml:lang="en">Holds a reference to a stream</documentation>
+		</annotation>
+		<attribute name="streamRef" type="xtce:NameReferenceType" use="required">
+			<annotation>
+				<documentation xml:lang="en">name of reference stream</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="StreamSetType">
+		<annotation>
+			<documentation xml:lang="en">Contains an unordered set of Streams.</documentation>
+		</annotation>
+		<choice maxOccurs="unbounded">
+			<element name="FixedFrameStream" type="xtce:FixedFrameStreamType"/>
+			<element name="VariableFrameStream" type="xtce:VariableFrameStreamType"/>
+			<element name="CustomStream" type="xtce:CustomStreamType"/>
+		</choice>
+	</complexType>
+	<complexType name="SyncStrategyType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">A Sync Strategy specifies the strategy on how to find frames within a stream of PCM data.  The sync strategy is based upon a state machine that begins in the 'Search' state until the first sync marker is found.  Then it goes into the 'Verify' state until a specified number of successive good sync markers are found.  Then, the state machine goes into the 'Lock' state, in the 'Lock' state frames are considered good.  Should a sync marker be missed in the 'Lock' state, the state machine will transition into the 'Check' state, if the next sync marker is where it's expected within a specified number of frames, then the state machine will transition back to the 'Lock' state, it not it will transition back to 'Search'.  </documentation>
+		</annotation>
+		<sequence>
+			<element name="AutoInvert" type="xtce:AutoInvertType" minOccurs="0"/>
+		</sequence>
+		<attribute name="verifyToLockGoodFrames" type="xtce:NonNegativeLongType" default="4"/>
+		<attribute name="checkToLockGoodFrames" type="xtce:NonNegativeLongType" default="1"/>
+		<attribute name="maxBitErrorsInSyncPattern" type="xtce:NonNegativeLongType" default="0">
+			<annotation>
+				<documentation xml:lang="en">Maximum number of bit errors in the sync pattern (marker).</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="SyncPatternType">
+		<annotation>
+			<documentation xml:lang="en">The pattern of bits used to look for frame synchronization.</documentation>
+		</annotation>
+		<attribute name="pattern" type="hexBinary" use="required">
+			<annotation>
+				<documentation xml:lang="en">CCSDS ASM for non-turbocoded frames = 1acffc1d</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="bitLocationFromStartOfContainer" type="long" default="0"/>
+		<attribute name="mask" type="hexBinary"/>
+		<attribute name="maskLengthInBits" type="xtce:PositiveLongType">
+			<annotation>
+				<documentation xml:lang="en">truncate the mask from the left</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="patternLengthInBits" type="xtce:PositiveLongType" use="required">
+			<annotation>
+				<documentation xml:lang="en">truncate the pattern from the left</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="VariableFrameStreamType">
+		<annotation>
+			<documentation xml:lang="en">For streams that contain a series of frames with a variable frame length where the frames are found by looking for a series of one's or zero's (usually one's).  The series is called the flag.   in the PCM stream that are usually made to be illegal in the PCM stream by zero or one bit insertion.  </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:FrameStreamType">
+				<sequence>
+					<element name="SyncStrategy" type="xtce:VariableFrameSyncStrategyType"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="VariableFrameSyncStrategyType">
+		<complexContent>
+			<extension base="xtce:SyncStrategyType">
+				<sequence>
+					<element name="Flag" type="xtce:FlagType"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!--******** End of Stream Definition Schema ************-->
+	<!--*************************************************************-->
+	<!--******** DataTypes ***************************************-->
+	<complexType name="ArgumentAbsoluteTimeDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">A base schema type for describing an absolute time data type. Contains an absolute (to a known epoch) time.  Use the [ISO 8601] extended format CCYY-MM-DDThh:mm:ss where "CC" represents the century, "YY" the year, "MM" the month and "DD" the day, preceded by an optional leading "-" sign to indicate a negative number. If the sign is omitted, "+" is assumed. The letter "T" is the date/time separator and "hh", "mm", "ss" represent hour, minute and second respectively. Additional digits can be used to increase the precision of fractional seconds if desired i.e. the format ss.ss... with any number of digits after the decimal point is supported. See AbsoluteTimeParameterType and AbsoluteTimeArgumentType.  See AbsouteTimeParameterType, AbsoluteTimeArgumentType and BaseTimeDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentBaseTimeDataType">
+				<attribute name="initialValue" type="dateTime">
+					<annotation>
+						<documentation xml:lang="en">Default/Initial value is always given in calibrated form.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="AbsoluteTimeDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">A base schema type for describing an absolute time data type. Contains an absolute (to a known epoch) time.  Use the [ISO 8601] extended format CCYY-MM-DDThh:mm:ss where "CC" represents the century, "YY" the year, "MM" the month and "DD" the day, preceded by an optional leading "-" sign to indicate a negative number. If the sign is omitted, "+" is assumed. The letter "T" is the date/time separator and "hh", "mm", "ss" represent hour, minute and second respectively. Additional digits can be used to increase the precision of fractional seconds if desired i.e. the format ss.ss... with any number of digits after the decimal point is supported. See AbsoluteTimeParameterType and AbsoluteTimeArgumentType.  See AbsouteTimeParameterType, AbsoluteTimeArgumentType and BaseTimeDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseTimeDataType">
+				<attribute name="initialValue" type="dateTime">
+					<annotation>
+						<documentation xml:lang="en">Default/Initial value is always given in calibrated form.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="AggregateDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">A base schema type for describing a complex data type analogous to a C-struct. Each field of the data type is called a Member.  Each Member is part of the MemberList which forms the list of items to be placed under this data type’s name.  The MemberList defines a data block and block’s size is defined by the DataEncodings of each Member’s type reference. The data members are ordered and contiguous in the MemberList element (packed).  Each member may be addressed by the dot syntax similar to C such as P.voltage if P is the referring parameter and voltage is of a member of P’s aggregate type.  See MemberType, MemberListType, DataEncodingType, NameReferenceType, AggregateParameterType and AggregateArgumentType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<sequence>
+					<element name="MemberList" type="xtce:MemberListType">
+						<annotation>
+							<documentation xml:lang="en">Ordered list of the members of the aggregate/structure.  Members are contiguous.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArrayDataTypeType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">A base schema type for describing an array data type.  The number of and size of each dimension is defined in its two child types. See NameReferenceType, ArrayArgumentType and ArrayParameterType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<attribute name="arrayTypeRef" type="xtce:NameReferenceType" use="required">
+					<annotation>
+						<documentation xml:lang="en">Reference to the data type that represents the type of the elements for this array.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="BaseDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">An abstract schema type used by within the schema to derive the other simple/primitive engineering form data types:  BooleanDataType, BinaryDataType, StringDataType, EnumeratedDataType, FloatDataType and IntegerDataType.  The encoding elements are optional because they describe the raw wire encoded form of the data type.  Encoding is only necessary when the type is telemetered in some form.  Local variables and derived typically do not require encoding.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<sequence>
+					<element name="UnitSet" type="xtce:UnitSetType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">When appropriate, describe the units of measure that are represented by this parameter value.</documentation>
+						</annotation>
+					</element>
+					<choice minOccurs="0">
+						<element name="BinaryDataEncoding" type="xtce:BinaryDataEncodingType">
+							<annotation>
+								<documentation xml:lang="en">Binary encoding is typically a "pass through" raw encoding form where one of the more common encodings is not required for the parameter.  A custom transformation capability is available if needed.</documentation>
+							</annotation>
+						</element>
+						<element name="FloatDataEncoding" type="xtce:FloatDataEncodingType">
+							<annotation>
+								<documentation xml:lang="en">Float encoding is a common encoding where the raw binary is in a form that gets interpreted as a decimal numeric value.</documentation>
+							</annotation>
+						</element>
+						<element name="IntegerDataEncoding" type="xtce:IntegerDataEncodingType">
+							<annotation>
+								<documentation xml:lang="en">Integer encoding is a common encoding where the raw binary is in a form that gets interpreted as an integral value, either signed or unsigned.</documentation>
+							</annotation>
+						</element>
+						<element name="StringDataEncoding" type="xtce:StringDataEncodingType">
+							<annotation>
+								<documentation xml:lang="en">String encoding is a common encoding where the raw binary is in a form that gets interpreted as a character sequence.</documentation>
+							</annotation>
+						</element>
+					</choice>
+				</sequence>
+				<attribute name="baseType" type="xtce:NameReferenceType">
+					<annotation>
+						<appinfo>Must be derived from a like type (e.g,, String from String).  No circular derivations.</appinfo>
+						<documentation xml:lang="en">Used to derive one Data Type from another - will inherit all the attributes from the baseType any of which may be redefined in this type definition.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentBaseDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Identical to BaseDataType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<sequence>
+					<element name="UnitSet" type="xtce:UnitSetType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">When appropriate, describe the units of measure that are represented by this argument value.</documentation>
+						</annotation>
+					</element>
+					<choice minOccurs="0">
+						<element name="BinaryDataEncoding" type="xtce:ArgumentBinaryDataEncodingType">
+							<annotation>
+								<documentation xml:lang="en">Binary encoding is typically a "pass through" raw encoding form where one of the more common encodings is not required for the argument.  A custom transformation capability is available if needed.</documentation>
+							</annotation>
+						</element>
+						<element name="FloatDataEncoding" type="xtce:FloatDataEncodingType">
+							<annotation>
+								<documentation xml:lang="en">Float encoding is a common encoding where the raw binary is in a form that gets interpreted as a decimal numeric value.</documentation>
+							</annotation>
+						</element>
+						<element name="IntegerDataEncoding" type="xtce:IntegerDataEncodingType">
+							<annotation>
+								<documentation xml:lang="en">Integer encoding is a common encoding where the raw binary is in a form that gets interpreted as an integral value, either signed or unsigned.</documentation>
+							</annotation>
+						</element>
+						<element name="StringDataEncoding" type="xtce:ArgumentStringDataEncodingType">
+							<annotation>
+								<documentation xml:lang="en">String encoding is a common encoding where the raw binary is in a form that gets interpreted as a character sequence.</documentation>
+							</annotation>
+						</element>
+					</choice>
+				</sequence>
+				<attribute name="baseType" type="xtce:NameReferenceType">
+					<annotation>
+						<appinfo>Must be derived from a like type (e.g,, String from String).  No circular derivations.</appinfo>
+						<documentation xml:lang="en">Used to derive one Data Type from another - will inherit all the attributes from the baseType any of which may be redefined in this type definition.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentBaseTimeDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Identical to BaseTimeDataType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<sequence>
+					<element name="Encoding" type="xtce:EncodingType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Describes how the raw base counts of the time type are encoded/decoded.</documentation>
+						</annotation>
+					</element>
+					<element name="ReferenceTime" type="xtce:ReferenceTimeType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Describes origin (epoch or reference) of this time type.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="baseType" type="xtce:NameReferenceType">
+					<annotation>
+						<documentation xml:lang="en">Extend another absolute or relative time type.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="BaseTimeDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">An abstract schema type used within the schema to derive other time based data types: RelativeTimeDataType and AbsoluteTimeDataType.  An absolute time data type is a telemetered source/destination data type.  A data encoding must be set.  An optional epoch may be set.  Time types are an exception to other primitives because, if the time data type is not telemetered, it still must have a data encoding set.  See DataEncodingType, AbsoluteTimeDataType and RelativeTimeDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<sequence>
+					<element name="Encoding" type="xtce:EncodingType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Describes how the raw base counts of the time type are encoded/decoded.</documentation>
+						</annotation>
+					</element>
+					<element name="ReferenceTime" type="xtce:ReferenceTimeType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Describes origin (epoch or reference) of this time type.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="baseType" type="xtce:NameReferenceType">
+					<annotation>
+						<documentation xml:lang="en">Extend another absolute or relative time type.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentBinaryDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Identical to BinaryDataType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentBaseDataType">
+				<attribute name="initialValue" type="hexBinary">
+					<annotation>
+						<documentation xml:lang="en">Default/Initial value is always given in calibrated form.  Extra bits are truncated from the MSB (leftmost).</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="BinaryDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">A base schema type for describing a binary data engineering/calibrated type (often called “blob type”). The binary data may be of fixed or variable length, and has an optional encoding and decoding algorithm that may be defined to transform the data between space and ground.  See BaseDataType, BinaryParameterType and BinaryArgumentType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseDataType">
+				<attribute name="initialValue" type="hexBinary">
+					<annotation>
+						<documentation xml:lang="en">Default/Initial value is always given in calibrated form.  Extra bits are truncated from the MSB (leftmost).</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentBooleanDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Identical to BooleanDataType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentBaseDataType">
+				<attribute name="initialValue" type="string">
+					<annotation>
+						<appinfo>Initial value must match either the oneStringValue or the zeroStringValue</appinfo>
+						<documentation xml:lang="en">Default/Initial value is always given in calibrated form.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="oneStringValue" type="string" default="True">
+					<annotation>
+						<documentation xml:lang="en">Enumeration string representing the 1 value, with the default being 'True'.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="zeroStringValue" type="string" default="False">
+					<annotation>
+						<documentation xml:lang="en">Enumeration string representing the 0 value, with the default being 'False'.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="BooleanDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">A base schema type for describing a boolean data type which has two values only: ‘True’ (1) or ‘False’ (0). The values one and zero may be mapped to a specific string using the attributes oneStringValue and zeroStringValue.  This type is a simplified form of the EnumeratedDataType.  See BaseDataType, BooleanParameterType and BooleanArgumentType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseDataType">
+				<attribute name="initialValue" type="string">
+					<annotation>
+						<appinfo>Initial value must match either the oneStringValue or the zeroStringValue</appinfo>
+						<documentation xml:lang="en">Default/Initial value is always given in calibrated form.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="oneStringValue" type="string" default="True">
+					<annotation>
+						<documentation xml:lang="en">Enumeration string representing the 1 value, with the default being 'True'.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="zeroStringValue" type="string" default="False">
+					<annotation>
+						<documentation xml:lang="en">Enumeration string representing the 0 value, with the default being 'False'.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="DimensionType" mixed="false">
+		<annotation>
+			<documentation xml:lang="en">For partial entries of an array, the starting and ending index for each dimension, OR the Size must be specified.  Indexes are zero based.</documentation>
+		</annotation>
+		<sequence>
+			<element name="StartingIndex" type="xtce:IntegerValueType">
+				<annotation>
+					<documentation xml:lang="en">zero based index</documentation>
+				</annotation>
+			</element>
+			<element name="EndingIndex" type="xtce:IntegerValueType"/>
+		</sequence>
+	</complexType>
+	<complexType name="ArgumentDimensionType">
+		<annotation>
+			<documentation xml:lang="en">Identical to DimensionType but supports argument instance references.</documentation>
+		</annotation>
+		<sequence>
+			<element name="StartingIndex" type="xtce:ArgumentIntegerValueType">
+				<annotation>
+					<documentation xml:lang="en">zero based index</documentation>
+				</annotation>
+			</element>
+			<element name="EndingIndex" type="xtce:ArgumentIntegerValueType"/>
+		</sequence>
+	</complexType>
+	<complexType name="DimensionListType">
+		<annotation>
+			<documentation xml:lang="en">Where the Dimension list is in this form:  Array[1stDim][2ndDim][lastDim].  The last dimension is assumed to be the least significant - that is this dimension will cycle through its combination before the next to last dimension changes.  The order MUST ascend or the array will need to be broken out entry by entry. </documentation>
+		</annotation>
+		<sequence>
+			<element name="Dimension" type="xtce:DimensionType" maxOccurs="unbounded">
+				<annotation>
+					<appinfo>For an ArrayParameterType of size N, their should be N Dimensions</appinfo>
+					<appinfo>An array made up by multiple Entries should not have indexes that overlap, but should be continuous.</appinfo>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ArgumentDimensionListType">
+		<annotation>
+			<documentation xml:lang="en">Identical to DimensionListType but supports argument instance references.</documentation>
+		</annotation>
+		<sequence>
+			<element name="Dimension" type="xtce:ArgumentDimensionType" maxOccurs="unbounded">
+				<annotation>
+					<appinfo>For an ArrayParameterType of size N, their should be N Dimensions</appinfo>
+					<appinfo>An array made up by multiple Entries should not have indexes that overlap, but should be continuous.</appinfo>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ArgumentEnumeratedDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Identical to EnumeratedDataType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentBaseDataType">
+				<sequence>
+					<element name="EnumerationList" type="xtce:EnumerationListType">
+						<annotation>
+							<documentation xml:lang="en">Unordered list of label/value pairs where values cannot be duplicated.</documentation>
+							<appinfo>Check that values do not overlap in the mappings.</appinfo>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="initialValue" type="string">
+					<annotation>
+						<documentation xml:lang="en">Default/Initial value is always given in calibrated form.  Use the label, it must be in the enumeration list to be valid.</documentation>
+						<appinfo>Label must be in the enumeration list to be valid.</appinfo>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="EnumeratedDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Describes an enumerated parameter type.  The enumeration list consists of label/value pairs. See EnumerationListType, EnumeratedParameterType and EnumeratedArgumentType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseDataType">
+				<sequence>
+					<element name="EnumerationList" type="xtce:EnumerationListType">
+						<annotation>
+							<documentation xml:lang="en">Unordered list of label/value pairs where values cannot be duplicated.</documentation>
+							<appinfo>Check that values do not overlap in the mappings.</appinfo>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="initialValue" type="string">
+					<annotation>
+						<documentation xml:lang="en">Default/Initial value is always given in calibrated form.  Use the label, it must be in the enumeration list to be valid.</documentation>
+						<appinfo>Label must be in the enumeration list to be valid.</appinfo>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="EnumerationListType">
+		<sequence>
+			<element name="Enumeration" type="xtce:ValueEnumerationType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="ArgumentFloatDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Identical to FloatDataType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentBaseDataType">
+				<sequence>
+					<element name="ToString" type="xtce:ToStringType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">This element provides the implementation with assistance rendering the value as a string for users.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="initialValue" type="double">
+					<annotation>
+						<documentation xml:lang="en">Default/Initial value is always given in calibrated form.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="sizeInBits" type="xtce:FloatSizeInBitsType" default="32">
+					<annotation>
+						<documentation xml:lang="en">Optional hint to the implementation about the size of the engineering/calibrated data type to use internally.  Generally this can be determined by examination of the space required to capture the full range of the encoding, but it is not always clear when calibrators are in use.  A tolerant implementation will endeavor to always make sufficient size engineering data types to capture the entire range of possible values.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="FloatDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">A base schema type for describing a floating point engineering/calibrated data type. Several encodings are supported.  Calibrated integer to float relationships should be described with this data type. Use the data encoding to define calibrators.  Joins integer as one of the numerics. See BaseDataType, FloatParameterType and FloatArgumentType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseDataType">
+				<sequence>
+					<element name="ToString" type="xtce:ToStringType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">This element provides the implementation with assistance rendering the value as a string for users.</documentation>
+						</annotation>
+					</element>
+					<element name="ValidRange" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">The Valid Range provides additional boundary/constraint information beyond that of the data encoding in the range of possible values that are meaningful to this parameter.  Not to be construed as an alarm definition, violations of the valid range make a parameter value "unreasonable", as opposed to reasonable to be reported, but in a state which should be of concern.</documentation>
+						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="xtce:FloatRangeType">
+									<attribute name="validRangeAppliesToCalibrated" type="boolean" default="true">
+										<annotation>
+											<documentation xml:lang="en">By default and general recommendation, the valid range is specified in engineering/calibrated values, although this can be adjusted.</documentation>
+										</annotation>
+									</attribute>
+								</extension>
+							</complexContent>
+						</complexType>
+					</element>
+				</sequence>
+				<attribute name="initialValue" type="double">
+					<annotation>
+						<documentation xml:lang="en">Initial value is always given in calibrated form</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="sizeInBits" type="xtce:FloatSizeInBitsType" default="32">
+					<annotation>
+						<documentation xml:lang="en">Optional hint to the implementation about the size of the engineering/calibrated data type to use internally.  Generally this can be determined by examination of the space required to capture the full range of the encoding, but it is not always clear when calibrators are in use.  A tolerant implementation will endeavor to always make sufficient size engineering data types to capture the entire range of possible values.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentIntegerDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Identical to IntegerDataType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentBaseDataType">
+				<sequence>
+					<element name="ToString" type="xtce:ToStringType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">This element provides the implementation with assistance rendering the value as a string for users.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="initialValue" type="xtce:FixedIntegerValueType">
+					<annotation>
+						<documentation xml:lang="en">Default/Initial value is always given in calibrated form.  Default is base 10 form; binary, octal, or hexadecimal values may be given by preceding value with 0[b|B], 0[o|O|, 0[x|X] respectively.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="sizeInBits" type="xtce:PositiveLongType" default="32">
+					<annotation>
+						<documentation xml:lang="en">Optional hint to the implementation about the size of the engineering/calibrated data type to use internally.  Generally this can be determined by examination of the space required to capture the full range of the encoding, but it is not always clear when calibrators are in use.  A tolerant implementation will endeavor to always make sufficient size engineering data types to capture the entire range of possible values.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="signed" type="boolean" default="true">
+					<annotation>
+						<documentation xml:lang="en">Flag indicating if the engineering/calibrated data type used should support signed representation.  This should not be confused with the encoding type for the raw value.  The default is true.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="IntegerDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Describe an integer engineering/calibrated data type. Several encodings are supported.  See BaseDataType, IntegerParameterType and IntegerArgumentType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseDataType">
+				<sequence>
+					<element name="ToString" type="xtce:ToStringType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">This element provides the implementation with assistance rendering the value as a string for users.</documentation>
+						</annotation>
+					</element>
+					<element name="ValidRange" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">The Valid Range provides additional boundary/constraint information beyond that of the data encoding in the range of possible values that are meaningful to this parameter.  Not to be construed as an alarm definition, violations of the valid range make a parameter value "unreasonable", as opposed to reasonable to be reported, but in a state which should be of concern.</documentation>
+						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="xtce:IntegerRangeType">
+									<attribute name="validRangeAppliesToCalibrated" type="boolean" default="true">
+										<annotation>
+											<documentation xml:lang="en">By default and general recommendation, the valid range is specified in engineering/calibrated values, although this can be adjusted.</documentation>
+										</annotation>
+									</attribute>
+								</extension>
+							</complexContent>
+						</complexType>
+					</element>
+				</sequence>
+				<attribute name="initialValue" type="long">
+					<annotation>
+						<documentation xml:lang="en">Default/Initial value is always given in calibrated form.  Default is base 10 form; binary, octal, or hexadecimal values may be given by preceding value with 0[b|B], 0[o|O|, 0[x|X] respectively.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="sizeInBits" type="xtce:PositiveLongType" default="32">
+					<annotation>
+						<documentation xml:lang="en">Optional hint to the implementation about the size of the engineering/calibrated data type to use internally.  Generally this can be determined by examination of the space required to capture the full range of the encoding, but it is not always clear when calibrators are in use.  A tolerant implementation will endeavor to always make sufficient size engineering data types to capture the entire range of possible values.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="signed" type="boolean" default="true">
+					<annotation>
+						<documentation xml:lang="en">Flag indicating if the engineering/calibrated data type used should support signed representation.  This should not be confused with the encoding type for the raw value.  The default is true.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="MemberType">
+		<annotation>
+			<documentation xml:lang="en">Describe a member field in an AggregateDataType. Each member has a name and a type reference to a data type for the aggregate member name.  If this aggregate is a Parameter aggregate, then the typeRef is a parameter type reference.  If this aggregate is an Argument aggregate, then the typeRef is an argument type reference.  References to an array data type is currently not supported. Circular references are not allowed.  See MemberListType. AggregateParameterType and AggregateArgumentType.</documentation>
+			<appinfo>ensure no circular references</appinfo>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NameDescriptionType">
+				<attribute name="typeRef" type="xtce:NameReferenceType" use="required"/>
+				<attribute name="initialValue" type="string" use="optional">
+					<annotation>
+						<documentation xml:lang="en">Used to set the initial calibrated values of Parameters.  Will overwrite an initial value defined for the ParameterType.  For integer types base 10 (decimal) form is assumed unless: if proceeded by a 0b or 0B, value is in base two (binary form, if proceeded by a 0o or 0O, values is in base 8 (octal) form, or if proceeded by a 0x or 0X, value is in base 16 (hex) form.  Floating point types may be specified in normal (100.0) or scientific (1.0e2) form.  Time types are specified using the ISO 8601 formats described for XTCE time data types.  Initial values for string types, may include C language style (\n, \t, \", \\, etc.) escape sequences.</documentation>
+						<appinfo>The value type must match the Parameter type</appinfo>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="MemberListType">
+		<annotation>
+			<documentation>Order is important only if the name of the AggregateParameter or Aggregate Argument is directly referenced in SequenceContainers.  In this case the members are assued to be added sequentially (in the order listed here) into the Container.</documentation>
+		</annotation>
+		<sequence>
+			<element name="Member" type="xtce:MemberType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="ArgumentRelativeTimeDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Used to contain a relative time value.  Used to describe a relative time.  Normally used for time offsets.  A Relative time is expressed as PnYn MnDTnH nMnS, where nY represents the number of years, nM the number of months, nD the number of days, 'T' is the date/time separator, nH the number of hours, nM the number of minutes and nS the number of seconds. The number of seconds can include decimal digits to arbitrary precision.  For example, to indicate a duration of 1 year, 2 months, 3 days, 10 hours, and 30 minutes, one would write: P1Y2M3DT10H30M. One could also indicate a duration of minus 120 days as: -P120D.  An extension of Schema duration type. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentBaseTimeDataType">
+				<attribute name="initialValue" type="duration"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="RelativeTimeDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Used to contain a relative time value.  Used to describe a relative time.  Normally used for time offsets.  A Relative time is expressed as PnYn MnDTnH nMnS, where nY represents the number of years, nM the number of months, nD the number of days, 'T' is the date/time separator, nH the number of hours, nM the number of minutes and nS the number of seconds. The number of seconds can include decimal digits to arbitrary precision.  For example, to indicate a duration of 1 year, 2 months, 3 days, 10 hours, and 30 minutes, one would write: P1Y2M3DT10H30M. One could also indicate a duration of minus 120 days as: -P120D.  An extension of Schema duration type. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseTimeDataType">
+				<attribute name="initialValue" type="duration"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ArgumentStringDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Identical to StringDataType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ArgumentBaseDataType">
+				<sequence>
+					<element name="SizeRangeInCharacters" type="xtce:IntegerRangeType" minOccurs="0"/>
+				</sequence>
+				<attribute name="initialValue" type="string">
+					<annotation>
+						<documentation xml:lang="en">Initial values for string types, may include C language style (\n, \t, \", \\, etc.) escape sequences.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="restrictionPattern" type="string">
+					<annotation>
+						<documentation xml:lang="en">restriction pattern is a regular expression</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="characterWidth" type="xtce:CharacterWidthType"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="StringDataType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Defines a base schema type for StringParameterType and StringArgumentType, adding initial value, restriction pattern, character width, and size range in characters.  The initial value if set is the initial value of all instances of the child types.  The restriction pattern is a regular expression enforcing the string value to this pattern.  The character width is on the local data type side.  And the size range in character restricts the character set.  For telemetered values, if the restriction pattern of size range in character is not met, the item is invalid. See BaseDataType, StringParameterType, StringArgumentType, CharacterWidthType and IntegerRangeType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseDataType">
+				<sequence>
+					<element name="SizeRangeInCharacters" type="xtce:IntegerRangeType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">The size in bits may be greater than or equal to minInclusive.  It may be less than or equal to maxInclusive.  They both may be set indicating a closed range.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="initialValue" type="string">
+					<annotation>
+						<documentation xml:lang="en">Initial values for string types, may include C language style (\n, \t, \", \\, etc.) escape sequences.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="restrictionPattern" type="string">
+					<annotation>
+						<documentation xml:lang="en">restriction pattern is a regular expression</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="characterWidth" type="xtce:CharacterWidthType"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="UnitSetType">
+		<annotation>
+			<documentation xml:lang="en">Describe an ordered collection of units that form a unit-expression.  Units may be described for both calibrated/engineering values and also potentially uncalibrated/raw values.  See UnitType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="Unit" type="xtce:UnitType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">Describe the exponent, factor, form, and description for a unit.  The attributes are optional because different programs use this element in different ways, depending on vendor support.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ValidFloatRangeSetType">
+		<annotation>
+			<documentation xml:lang="en">Numerical ranges that define the universe of valid values for this argument.  A single range is the most common, although it is possible to define multiple ranges when the valid values are not contiguous.</documentation>
+		</annotation>
+		<sequence>
+			<element name="ValidRange" type="xtce:FloatRangeType" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">A valid range constrains the whole set of possible values that could be encoded by the data type to a more "valid" or "reasonable" set of values.  This should be treated as a boundary check in an implementation to validate the input or output value.  Typically, only 1 range is used.  In cases where multiple ranges are used, then the value is valid when it is valid in any of the provided ranges.  Implementations may also use these ranges to enhance user interface displays and other visualization widgets as appropriate for the type.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="validRangeAppliesToCalibrated" type="boolean" default="true">
+			<annotation>
+				<documentation xml:lang="en">By default and general recommendation, the valid range is specified in engineering/calibrated values, although this can be adjusted.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="ValidIntegerRangeSetType">
+		<annotation>
+			<documentation xml:lang="en">Numerical ranges that define the universe of valid values for this argument.  A single range is the most common, although it is possible to define multiple ranges when the valid values are not contiguous.</documentation>
+		</annotation>
+		<sequence>
+			<element name="ValidRange" type="xtce:IntegerRangeType" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">A valid range constrains the whole set of possible values that could be encoded by the data type to a more "valid" or "reasonable" set of values.  This should be treated as a boundary check in an implementation to validate the input or output value.  Typically, only 1 range is used.  In cases where multiple ranges are used, then the value is valid when it is valid in any of the provided ranges.  Implementations may also use these ranges to enhance user interface displays and other visualization widgets as appropriate for the type.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="validRangeAppliesToCalibrated" type="boolean" default="true">
+			<annotation>
+				<documentation xml:lang="en">By default and general recommendation, the valid range is specified in engineering/calibrated values, although this can be adjusted.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<!--*************************************************************-->
+	<!--******** Data Types used with Encoding **************-->
+	<simpleType name="BitOrderType">
+		<annotation>
+			<documentation xml:lang="en">Defines two bit-order types: most significant bit first and least significant bit first.  See DataEncodingType.</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="leastSignificantBitFirst"/>
+			<enumeration value="mostSignificantBitFirst"/>
+		</restriction>
+	</simpleType>
+	<complexType name="ArgumentBinaryDataEncodingType">
+		<annotation>
+			<documentation xml:lang="en">Identical to BinaryDataEncodingType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:DataEncodingType">
+				<sequence>
+					<element name="SizeInBits" type="xtce:ArgumentIntegerValueType">
+						<annotation>
+							<documentation xml:lang="en">Number of bits this value occupies on the stream being encoded/decoded.</documentation>
+						</annotation>
+					</element>
+					<element name="FromBinaryTransformAlgorithm" type="xtce:ArgumentInputAlgorithmType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Used to convert binary data to an application data type</documentation>
+						</annotation>
+					</element>
+					<element name="ToBinaryTransformAlgorithm" type="xtce:ArgumentInputAlgorithmType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Used to convert binary data from an application data type to binary data</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="BinaryDataEncodingType">
+		<annotation>
+			<documentation xml:lang="en">Describe binary data that is unmolested in the decoding/encoding or cannot be represented in any of the other data encoding formats.  Optionally use the FromBinaryTransformAlgorithm and ToBinaryTransformAlgorithm element to describe the transformation process.  See InputAlgorithmType for the transformation structure.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:DataEncodingType">
+				<sequence>
+					<element name="SizeInBits" type="xtce:IntegerValueType">
+						<annotation>
+							<documentation xml:lang="en">Number of bits this value occupies on the stream being encoded/decoded.</documentation>
+						</annotation>
+					</element>
+					<element name="FromBinaryTransformAlgorithm" type="xtce:InputAlgorithmType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Used to convert binary data to an application data type</documentation>
+						</annotation>
+					</element>
+					<element name="ToBinaryTransformAlgorithm" type="xtce:InputAlgorithmType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Used to convert binary data from an application data type to binary data</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ByteType">
+		<attribute name="byteSignificance" type="xtce:NonNegativeLongType" use="required"/>
+	</complexType>
+	<simpleType name="CharacterWidthType">
+		<restriction base="integer">
+			<enumeration value="8"/>
+			<enumeration value="16"/>
+		</restriction>
+	</simpleType>
+	<complexType name="CRCType">
+		<annotation>
+			<documentation xml:lang="en">Cyclic Redundancy Check (CRC) definition. The polynomial coefficients for the CRC
+are defined as a truncated hex value.  The coefficient for the nth bit of an n-bit CRC will always be 1 and is not
+represented in the truncated hex value.  For example, the truncated hex value of CRC-32 (width=32 bits) used in the
+Ethernet specification is 0x04C11DB7, where each non-zero bit of the truncated hex represents a coefficient of 1 in
+the polynomial and the bit position represents the exponent. There may also be an initial remainder "InitRemainder"
+and a final XOR "FinalXOR" to fully specify the CRC.  reflectData and reflectRemainder may also be specified to
+reverse the bit order in the incoming data and/or the result.
+      </documentation>
+		</annotation>
+		<sequence>
+			<element name="Polynomial" type="hexBinary"/>
+			<element name="InitRemainder" type="hexBinary" minOccurs="0"/>
+			<element name="FinalXOR" type="hexBinary" minOccurs="0"/>
+		</sequence>
+		<attribute name="width" type="xtce:PositiveLongType"/>
+		<attribute name="reflectData" type="boolean" default="false"/>
+		<attribute name="reflectRemainder" type="boolean" default="false"/>
+		<attribute name="bitsFromReference" type="xtce:NonNegativeLongType"/>
+		<attribute name="reference" type="xtce:ReferencePointType" default="start"/>
+	</complexType>
+	<complexType name="DataEncodingType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Describes how a particular piece of data is sent or received from some non-native, off-platform device. (e.g. a spacecraft)</documentation>
+		</annotation>
+		<sequence>
+			<element name="ErrorDetectCorrect" type="xtce:ErrorDetectCorrectType" minOccurs="0"/>
+		</sequence>
+		<attribute name="bitOrder" type="xtce:BitOrderType" default="mostSignificantBitFirst"/>
+		<attribute name="byteOrder" type="xtce:ByteOrderType" default="mostSignificantByteFirst"/>
+	</complexType>
+	<complexType name="EncodingType">
+		<annotation>
+			<documentation xml:lang="en">Describe the data encoding for a time data type.  It includes the units and other attributes scale and offset.  Use scale and offset to describe a y=mx+b relationship (where m is the slope/scale and b is the intercept/offset) to make adjustments to the encoded time value so that it matches the time units.  For binary encoded time use transform algorithms to convert time data formats that are too difficult to describe in XTCE. See AbsoluteTimeDataType and RelativeTimeDataType.</documentation>
+		</annotation>
+		<choice>
+			<element name="BinaryDataEncoding" type="xtce:BinaryDataEncodingType">
+				<annotation>
+					<documentation xml:lang="en">Binary encoding is typically a "pass through" raw encoding form where one of the more common encodings is not required for the parameter.  A custom transformation capability is available if needed.</documentation>
+				</annotation>
+			</element>
+			<element name="FloatDataEncoding" type="xtce:FloatDataEncodingType">
+				<annotation>
+					<documentation xml:lang="en">Float encoding is a common encoding where the raw binary is in a form that gets interpreted as a decimal numeric value.</documentation>
+				</annotation>
+			</element>
+			<element name="IntegerDataEncoding" type="xtce:IntegerDataEncodingType">
+				<annotation>
+					<documentation xml:lang="en">Integer encoding is a common encoding where the raw binary is in a form that gets interpreted as an integral value, either signed or unsigned.</documentation>
+				</annotation>
+			</element>
+			<element name="StringDataEncoding" type="xtce:StringDataEncodingType">
+				<annotation>
+					<documentation xml:lang="en">String encoding is a common encoding where the raw binary is in a form that gets interpreted as a character sequence.</documentation>
+				</annotation>
+			</element>
+		</choice>
+		<attribute name="units" type="xtce:TimeUnitsType" default="seconds">
+			<annotation>
+				<documentation xml:lang="en">Time units, with the default being in seconds.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="scale" type="double" default="1">
+			<annotation>
+				<documentation xml:lang="en">Linear slope used as a shorter form of specifying a calibrator to convert between the raw value and the engineering units.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="offset" type="double" default="0">
+			<annotation>
+				<documentation xml:lang="en">Linear intercept used as a shorter form of specifying a calibrator to convert between the raw value and the engineering units.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<simpleType name="EpochType">
+		<annotation>
+			<documentation xml:lang="en">Epochs may be specified as an xs date where time is implied to be 00:00:00, xs dateTime, or string enumeration of common epochs.  The enumerations are TAI (used by CCSDS and others), J2000, UNIX (also known as POSIX), and GPS.</documentation>
+		</annotation>
+		<union memberTypes="date dateTime xtce:EpochTimeEnumsType"/>
+	</simpleType>
+	<complexType name="FloatDataEncodingType">
+		<annotation>
+			<documentation xml:lang="en">For common encodings of floating point data</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:DataEncodingType">
+				<sequence>
+					<element name="DefaultCalibrator" type="xtce:CalibratorType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Calibrator to be applied to the raw uncalibrated value to arrive at the engineering/calibrated value when no Context Calibrators are provided or evaluate to true, based on their MatchCriteria.</documentation>
+						</annotation>
+					</element>
+					<element name="ContextCalibratorList" type="xtce:ContextCalibratorListType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Calibrator to be applied to the raw uncalibrated value to arrive at the engineering/calibrated value when a MatchCriteria evaluates to true.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="encoding" type="xtce:FloatEncodingType" default="IEEE754_1985">
+					<annotation>
+						<documentation xml:lang="en">Specifies real/decimal numeric value to raw encoding method, with the default being "IEEE754_1985".</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="sizeInBits" type="xtce:FloatEncodingSizeInBitsType" default="32">
+					<annotation>
+						<documentation xml:lang="en">Number of bits to use for the float raw encoding method, with 32 being the default.  Not every number of bits is valid for each encoding method.</documentation>
+						<appinfo>Verify the number of bits for encoding is valid for the encoding method.</appinfo>
+					</annotation>
+				</attribute>
+				<attribute name="changeThreshold" type="double" use="optional">
+					<annotation>
+						<documentation>A changeThreshold may optionally be specified to inform systems of the minimum change in value that is significant.  This is used by some systems to limit the telemetry processing and/or recording requirements. If the value is unspecified or zero, any change is significant.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<simpleType name="FloatEncodingSizeInBitsType">
+		<restriction base="unsignedShort">
+			<enumeration value="16">
+				<annotation>
+					<documentation xml:lang="en">At the time of this writing, 16 bit encoding size is only valid in cases of IEEE754 and vendor specific MILSTD_1750A variation that is not a part of the standard.  This is not meant to preclude use in the event that future floating point formats may also define this value.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="32">
+				<annotation>
+					<documentation xml:lang="en">At the time of this writing, 32 bit encoding size is only valid in cases of IEEE754_1985, IEEE754, MILSTD_1750A, DEC, IBM, and TI.  This is not meant to preclude use in the event that future floating point formats may also define this value.  The IEEE754 enumeration and the IEEE754_1985 enumeration are allowed in this case and the interpretation is the same.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="40">
+				<annotation>
+					<documentation xml:lang="en">At the time of this writing, 40 bit encoding size is only valid in the case of TI.  This is not meant to preclude use in the event that future floating point formats may also define this value.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="48">
+				<annotation>
+					<documentation xml:lang="en">At the time of this writing, 48 bit encoding size is only valid in the case of MILSTD_1750A.  This is not meant to preclude use in the event that future floating point formats may also define this value.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="64">
+				<annotation>
+					<documentation xml:lang="en">At the time of this writing, 64 bit encoding size is only valid in cases of IEEE754_1985, IEEE754, DEC, and IBM.  This is not meant to preclude use in the event that future floating point formats may also define this value.  The IEEE754 enumeration and the IEEE754_1985 enumeration are allowed in this case and the interpretation is the same.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="80">
+				<annotation>
+					<documentation xml:lang="en">At the time of this writing, 80 bit encoding size is only valid in the case of IEEE754_1985.  This is not meant to preclude use in the event that future floating point formats may also define this value.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="128">
+				<annotation>
+					<documentation xml:lang="en">At the time of this writing, 128 bit encoding size is only valid in the case of IEEE754_1985 and IEEE754.  This is not meant to preclude use in the event that future floating point formats may also define this value.  The IEEE754 enumeration and the IEEE754_1985 enumeration are allowed in this case and the interpretation is the same.</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="FloatEncodingType">
+		<restriction base="string">
+			<enumeration value="IEEE754_1985"/>
+			<enumeration value="IEEE754"/>
+			<enumeration value="MILSTD_1750A"/>
+			<enumeration value="DEC"/>
+			<enumeration value="IBM"/>
+			<enumeration value="TI"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="FloatSizeInBitsType">
+		<restriction base="xtce:PositiveLongType">
+			<enumeration value="32"/>
+			<enumeration value="64"/>
+			<enumeration value="128"/>
+		</restriction>
+	</simpleType>
+	<complexType name="IntegerDataEncodingType">
+		<annotation>
+			<documentation xml:lang="en">For all major encodings of integer data</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:DataEncodingType">
+				<sequence>
+					<element name="DefaultCalibrator" type="xtce:CalibratorType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Calibrator to be applied to the raw uncalibrated value to arrive at the engineering/calibrated value when no Context Calibrators are provided or evaluate to true, based on their MatchCriteria.</documentation>
+						</annotation>
+					</element>
+					<element name="ContextCalibratorList" type="xtce:ContextCalibratorListType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Calibrator to be applied to the raw uncalibrated value to arrive at the engineering/calibrated value when a MatchCriteria evaluates to true.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="encoding" type="xtce:IntegerEncodingType" default="unsigned">
+					<annotation>
+						<documentation xml:lang="en">Specifies integer numeric value to raw encoding method, with the default being "unsigned".</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="sizeInBits" type="xtce:PositiveLongType" default="8">
+					<annotation>
+						<documentation xml:lang="en">Number of bits to use for the raw encoding, with 8 being the default.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="changeThreshold" type="xtce:NonNegativeLongType" use="optional">
+					<annotation>
+						<documentation xml:lang="en">A changeThreshold may optionally be specified to inform systems of the minimum change in value that is significant.  This is used by some systems to limit the telemetry processing and/or recording requirements, such as for an analog-to-digital converter that dithers in the least significant bit. If the value    is unspecified or zero, any change is significant.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<simpleType name="IntegerEncodingType">
+		<restriction base="string">
+			<enumeration value="unsigned"/>
+			<enumeration value="signMagnitude"/>
+			<enumeration value="twosComplement"/>
+			<enumeration value="onesComplement"/>
+			<enumeration value="BCD"/>
+			<enumeration value="packedBCD"/>
+		</restriction>
+	</simpleType>
+	<complexType name="LeadingSizeType">
+		<annotation>
+			<documentation xml:lang="en">Like PASCAL strings, the size of the string is given as an integer at the start of the string.  SizeTag must be an unsigned Integer</documentation>
+		</annotation>
+		<attribute name="sizeInBitsOfSizeTag" type="xtce:PositiveLongType" default="16"/>
+	</complexType>
+	<simpleType name="ParityFormType">
+		<restriction base="string">
+			<enumeration value="Even"/>
+			<enumeration value="Odd"/>
+		</restriction>
+	</simpleType>
+	<complexType name="ParityType">
+		<annotation>
+			<documentation xml:lang="en">Bit position starts with 'zero'.</documentation>
+		</annotation>
+		<attribute name="type" type="xtce:ParityFormType" use="required"/>
+		<attribute name="bitsFromReference" type="xtce:NonNegativeLongType" use="required"/>
+		<attribute name="reference" type="xtce:ReferencePointType" default="start"/>
+	</complexType>
+	<complexType name="SizeInBitsType">
+		<sequence>
+			<element name="Fixed">
+				<annotation>
+					<documentation xml:lang="en">This is the simplest case of a string data type where the encoding size of the string does not change.</documentation>
+				</annotation>
+				<complexType>
+					<sequence>
+						<element name="FixedValue" type="xtce:PositiveLongType">
+							<annotation>
+								<documentation xml:lang="en">Size in bits of this string data type for both the memory allocation in the implementing software and also the size in bits for this parameter when it appears in a container.</documentation>
+							</annotation>
+						</element>
+					</sequence>
+				</complexType>
+			</element>
+			<element name="TerminationChar" type="hexBinary" default="00" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">The termination character that represents the end of the string contents.  For C and most strings, this is null (00), which is the default.</documentation>
+				</annotation>
+			</element>
+			<element name="LeadingSize" type="xtce:LeadingSizeType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">In some string implementations, the size of the string contents (not the memory allocation size) is determined by a leading numeric value.  This is sometimes referred to as Pascal strings.  If a LeadingSize is specified, then the TerminationChar element does not have a functional meaning.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ArgumentVariableStringType">
+		<annotation>
+			<documentation>Identical to VariableStringType but supports argument instance references.</documentation>
+		</annotation>
+		<sequence>
+			<choice>
+				<element name="DynamicValue" type="xtce:ArgumentDynamicValueType">
+					<annotation>
+						<documentation xml:lang="en">Determine the container size in bits by interrogating an instance of a parameter or argument.</documentation>
+					</annotation>
+				</element>
+				<element name="DiscreteLookupList" type="xtce:ArgumentDiscreteLookupListType">
+					<annotation>
+						<documentation xml:lang="en">Determine the container size in bits by interrogating an instance of a parameter or argument and selecting a specified value based on tests of the value of that parameter or argument.</documentation>
+					</annotation>
+				</element>
+			</choice>
+			<element name="LeadingSize" type="xtce:LeadingSizeType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">In some string implementations, the size of the string contents (not the memory allocation size) is determined by a leading numeric value.  This is sometimes referred to as Pascal strings.  If a LeadingSize is specified, then the TerminationChar element does not have a functional meaning.</documentation>
+				</annotation>
+			</element>
+			<element name="TerminationChar" type="hexBinary" default="00" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">The termination character that represents the end of the string contents.  For C and most strings, this is null (00), which is the default.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="maxSizeInBits" type="xtce:PositiveLongType" use="required">
+			<annotation>
+				<documentation xml:lang="en">The upper bound of the size of this string data type so that the implementation can reserve/allocate enough memory to capture all reported instances of the string.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="VariableStringType">
+		<annotation>
+			<documentation xml:lang="en">Describe a variable string whose length may change between samples.</documentation>
+		</annotation>
+		<sequence>
+			<choice>
+				<element name="DynamicValue" type="xtce:DynamicValueType">
+					<annotation>
+						<documentation xml:lang="en">Determine the container size in bits by interrogating an instance of a parameter.</documentation>
+					</annotation>
+				</element>
+				<element name="DiscreteLookupList" type="xtce:DiscreteLookupListType">
+					<annotation>
+						<documentation xml:lang="en">Determine the container size in bits by interrogating an instance of a parameter and selecting a specified value based on tests of the value of that parameter.</documentation>
+					</annotation>
+				</element>
+			</choice>
+			<element name="LeadingSize" type="xtce:LeadingSizeType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">In some string implementations, the size of the string contents (not the memory allocation size) is determined by a leading numeric value.  This is sometimes referred to as Pascal strings.  If a LeadingSize is specified, then the TerminationChar element does not have a functional meaning.</documentation>
+				</annotation>
+			</element>
+			<element name="TerminationChar" type="hexBinary" default="00" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">The termination character that represents the end of the string contents.  For C and most strings, this is null (00), which is the default.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="maxSizeInBits" type="xtce:PositiveLongType" use="required">
+			<annotation>
+				<documentation xml:lang="en">The upper bound of the size of this string data type so that the implementation can reserve/allocate enough memory to capture all reported instances of the string.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="ArgumentStringDataEncodingType">
+		<annotation>
+			<documentation xml:lang="en">Identical to StringDataEncodingType but supports argument instance references.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:DataEncodingType">
+				<choice>
+					<element name="SizeInBits" type="xtce:SizeInBitsType">
+						<annotation>
+							<documentation xml:lang="en">Static length strings do not change in overall length between samples.   They may terminate before the end of their buffer using a terminating character, or by various lookups, or calculations.  But they have a maximum fixed size, and the data itself is always within that maximum size.</documentation>
+						</annotation>
+					</element>
+					<element name="Variable" type="xtce:ArgumentVariableStringType">
+						<annotation>
+							<documentation xml:lang="en">Variable length strings are those where the space occupied in a container can vary.  If the string has variable content but occupies the same amount of space when encoded should use the SizeInBits element.  Specification of a variable length string needs to consider that the implementation needs to allocate space to store the string.  Specify the maximum possible length of the string data type for memory purposes and also specify the bit size of the string to use in containers with the dynamic elements.</documentation>
+						</annotation>
+					</element>
+				</choice>
+				<attribute name="encoding" type="xtce:StringEncodingType" default="UTF-8">
+					<annotation>
+						<documentation xml:lang="en">The character set encoding of this string data type.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="StringDataEncodingType">
+		<annotation>
+			<documentation xml:lang="en">Describe common encodings of string data: UTF-8 and UTF-16. See StringDataType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:DataEncodingType">
+				<choice>
+					<element name="SizeInBits" type="xtce:SizeInBitsType">
+						<annotation>
+							<documentation xml:lang="en">Static length strings do not change in overall length between samples.   They may terminate before the end of their buffer using a terminating character, or by various lookups, or calculations.  But they have a maximum fixed size, and the data itself is always within that maximum size.</documentation>
+						</annotation>
+					</element>
+					<element name="Variable" type="xtce:VariableStringType">
+						<annotation>
+							<documentation xml:lang="en">Variable length strings are those where the space occupied in a container can vary.  If the string has variable content but occupies the same amount of space when encoded should use the SizeInBits element.  Specification of a variable length string needs to consider that the implementation needs to allocate space to store the string.  Specify the maximum possible length of the string data type for memory purposes and also specify the bit size of the string to use in containers with the dynamic elements.</documentation>
+						</annotation>
+					</element>
+				</choice>
+				<attribute name="encoding" type="xtce:StringEncodingType" default="UTF-8">
+					<annotation>
+						<documentation xml:lang="en">The character set encoding of this string data type.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<simpleType name="StringEncodingType">
+		<annotation>
+			<documentation xml:lang="en">Defines string encodings.  US-ASCII (7-bit), ISO-8859-1 (8-bit Extended ASCII), Windows-1252 (8-bit Extended ASCII), UTF-8 (Unicode), UTF-16 (Unicode with Byte Order Mark), UTF-16LE (Unicode Little Endian), UTF-16BE (Unicode Big Endian).  See StringDataEncodingType.</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="US-ASCII"/>
+			<enumeration value="ISO-8859-1"/>
+			<enumeration value="Windows-1252"/>
+			<enumeration value="UTF-8"/>
+			<enumeration value="UTF-16">
+				<annotation>
+					<documentation xml:lang="en">With UTF-16, encoded bits must be prepended with a Byte Order Mark.  This mark indicates whether the data is encoded in big or little endian.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="UTF-16LE">
+				<annotation>
+					<documentation xml:lang="en">With UTF-16LE, encoded bits will always be represented as little endian.  Bits are not prepended with a Byte Order Mark.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="UTF-16BE">
+				<annotation>
+					<documentation xml:lang="en">With UTF-16BE, encoded bits will always be represented as big endian.  Bits are not prepended with a Byte Order Mark.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="UTF-32">
+				<annotation>
+					<documentation xml:lang="en">With UTF-32, encoded bits must be prepended with a Byte Order Mark.  This mark indicates whether the data is encoded in big or little endian.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="UTF-32LE">
+				<annotation>
+					<documentation xml:lang="en">With UTF-32LE, encoded bits will always be represented as little endian.  Bits are not prepended with a Byte Order Mark.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="UTF-32BE">
+				<annotation>
+					<documentation xml:lang="en">With UTF-32BE, encoded bits will always be represented as big endian.  Bits are not prepended with a Byte Order Mark.</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<complexType name="ToStringType">
+		<sequence>
+			<element name="NumberFormat" type="xtce:NumberFormatType" minOccurs="1" maxOccurs="1">
+				<annotation>
+					<documentation xml:lang="en">This element describes how a numeric value should be represented in engineering/calibrated form.  The defaults reflect the most common form.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<simpleType name="EpochTimeEnumsType">
+		<annotation>
+			<documentation xml:lang="en">Union values of common epoch definitions for document convenience.</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="TAI"/>
+			<enumeration value="J2000"/>
+			<enumeration value="UNIX"/>
+			<enumeration value="GPS"/>
+		</restriction>
+	</simpleType>
+	<!--******** DataTypes **************************************-->
+	<!--*************************************************************-->
+	<!--******** Common Types Schema **********************-->
+	<!-- Basic elements used for in all dictionaries -->
+	<complexType name="AlgorithmSetType" mixed="false">
+		<annotation>
+			<documentation xml:lang="en">An unordered collection of algorithms</documentation>
+		</annotation>
+		<choice maxOccurs="unbounded">
+			<element name="CustomAlgorithm" type="xtce:InputOutputTriggerAlgorithmType"/>
+			<element name="MathAlgorithm" type="xtce:MathAlgorithmType"/>
+		</choice>
+	</complexType>
+	<complexType name="AliasSetType">
+		<annotation>
+			<documentation xml:lang="en">Contains an unordered collection of Alias elements to describe alternate names or IDs for this named item.</documentation>
+			<appinfo>Applications should enforce uniqueness of individual nameSpace attribute values.  Aliases are usually unique within the same nameSpace attribute value, depending on the physical meaning of that nameSpace.  There are some cases where Alias values can be duplicated in a single nameSpace value.</appinfo>
+		</annotation>
+		<sequence>
+			<element name="Alias" type="xtce:AliasType" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">An alternate name, ID number, and sometimes flight software variable name in the code for this item.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="AliasType">
+		<annotation>
+			<documentation xml:lang="en">Used to contain an alias (alternate) name or ID for the object.   For example, a parameter may have a mnemonic, an on-board id, and special IDs used by various ground software applications; all of these are alias's.  Some ground system processing equipment has some severe naming restrictions on parameters (e.g., names must less then 12 characters, single case or integral id's only); their alias's provide a means of capturing each name in a "nameSpace".  Note: the name is not reference-able (it cannot be used in a name reference substituting for the name of the item of interest).  See NameDescriptionType.</documentation>
+		</annotation>
+		<attribute name="nameSpace" type="string" use="required">
+			<annotation>
+				<documentation xml:lang="en">Aliases should be grouped together in a "namespace" so that they can be switched in and out of data extractions.  The namespace generally identifies the purpose of the alternate name, whether for software variable names, additional operator names, or whatever the purpose.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="alias" type="string" use="required">
+			<annotation>
+				<documentation xml:lang="en">The alternate name or ID to use.  The alias does not have the restrictions that apply to name attributes.  This is useful for capturing legacy identifiers for systems with unusual naming conventions.  It is also useful for capturing variable names in software, amongst other things.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="AncillaryDataType">
+		<annotation>
+			<documentation xml:lang="en">Use for any other data associated with a named item.  May be used to include administrative data (e.g., version, CM or tags) or potentially any MIME type.  Data may be included or given as an href.</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="string">
+				<attribute name="name" type="string" use="required">
+					<annotation>
+						<documentation xml:lang="en">Identifier for this Ancillary Data characteristic, feature, or data.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="mimeType" type="string" default="text/plain">
+					<annotation>
+						<documentation xml:lang="en">Optional text encoding method for the element text content of this element.  The default is "text/plain".</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="href" type="anyURI">
+					<annotation>
+						<documentation xml:lang="en">Optional Uniform Resource Identifier for this characteristic, feature, or data.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</simpleContent>
+	</complexType>
+	<complexType name="AncillaryDataSetType">
+		<annotation>
+			<documentation xml:lang="en">Describe an unordered collection of ancillary data.  AncillaryData elements capture platform/program/implementation specific data about the parent element object that is non-standard and would not fit into the schema.  See AncillaryDataType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="AncillaryData" type="xtce:AncillaryDataType" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">Optional list of AncillaryData elements associated with this item.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ANDedConditionsType">
+		<annotation>
+			<documentation xml:lang="en">Describe two or more conditions that are logically anded together. Conditions may be a mix of Condition and ORedCondition.   See ORedConditionType and BooleanExpressionType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseConditionsType">
+				<choice minOccurs="2" maxOccurs="unbounded">
+					<element name="Condition" type="xtce:ComparisonCheckType">
+						<annotation>
+							<documentation xml:lang="en">Condition elements describe a test similar to the Comparison element except that the parameters used have additional flexibility for the compare.</documentation>
+						</annotation>
+					</element>
+					<element name="ORedConditions" type="xtce:ORedConditionsType">
+						<annotation>
+							<documentation xml:lang="en">This element describes tests similar to the ComparisonList element except that the parameters used are more flexible and the and/or for multiple checks can be specified.</documentation>
+						</annotation>
+					</element>
+				</choice>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="AuthorSetType">
+		<annotation>
+			<documentation xml:lang="en">Describe an unordered collection of authors.  See AuthorType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="Author" type="xtce:AuthorType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">Contains information about an author, maintainer, or data source regarding this document.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<simpleType name="AuthorType">
+		<annotation>
+			<documentation xml:lang="en">Type definition that describes the format of the contents of the Author element.</documentation>
+		</annotation>
+		<restriction base="string"/>
+	</simpleType>
+	<complexType name="BaseConditionsType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">A base type for boolean expression related elements that improves the mapping produced by data binding tools.</documentation>
+		</annotation>
+	</complexType>
+	<simpleType name="BinaryType">
+		<annotation>
+			<documentation xml:lang="en">A simple restriction on string for hexadecimal numbers.  Must be in 0b or 0B form.</documentation>
+		</annotation>
+		<restriction base="string">
+			<pattern value="0[bB][0-1]+"/>
+		</restriction>
+	</simpleType>
+	<complexType name="BooleanExpressionType">
+		<annotation>
+			<documentation xml:lang="en">Holds an arbitrarily complex boolean expression</documentation>
+		</annotation>
+		<choice>
+			<element name="Condition" type="xtce:ComparisonCheckType">
+				<annotation>
+					<documentation xml:lang="en">Condition elements describe a test similar to the Comparison element except that the parameters used have additional flexibility.</documentation>
+				</annotation>
+			</element>
+			<element name="ANDedConditions" type="xtce:ANDedConditionsType">
+				<annotation>
+					<documentation xml:lang="en">This element describes tests similar to the ComparisonList element except that the parameters used are more flexible.</documentation>
+				</annotation>
+			</element>
+			<element name="ORedConditions" type="xtce:ORedConditionsType">
+				<annotation>
+					<documentation xml:lang="en">This element describes tests similar to the ComparisonList element except that the parameters used are more flexible.</documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<simpleType name="ByteOrderType">
+		<annotation>
+			<documentation xml:lang="en">Describe a byte order: big/little or byte list.</documentation>
+		</annotation>
+		<union memberTypes="xtce:ByteOrderCommonType xtce:ByteOrderArbitraryType"/>
+	</simpleType>
+	<simpleType name="ByteOrderCommonType">
+		<annotation>
+			<documentation xml:lang="en">Common byte orderings: most significant byte first (also known as big endian) and least significant byte first (also known as little endian).</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="mostSignificantByteFirst"/>
+			<enumeration value="leastSignificantByteFirst"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="ByteOrderArbitraryType">
+		<annotation>
+			<documentation xml:lang="en">Describe a byte order using a byte list. The list is viewed as representing memory, the first item in the list is address 0. For mostSignificantByteFirst/big endian, the high order byte is the first byte in the list and has the highest significance followed by the less significant bytes ending with the least significant byte. For leastSignificantByteFirst/little endian, the first byte starts with the least significant byte which is first in the least and ends at the highest significant byte. For example given the value 0x0A0B0C0D the following example orderings can be formed. For mostSignificantByteFirst/big endian the significances would be listed as 3 (0x0A), 2 (0x0B), 1 (0x0C), 0 (0x0D) with ‘3’ being first in the list, and for leastSignificantByteFirst/little endian as 0 (0x0D), 1 (0x0C), 2 (0x0B), 3 (0x0A) with ‘0’ being first in the list. See DataEncodingType.</documentation>
+		</annotation>
+		<restriction base="string">
+			<pattern value="(0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15)(,(0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15))*"/>
+		</restriction>
+	</simpleType>
+	<complexType name="ComparisonCheckType">
+		<annotation>
+			<documentation xml:lang="en">Describe the comparison between the instance (value) of a parameter against either a specified value or another parameter instance.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseConditionsType">
+				<sequence>
+					<element name="ParameterInstanceRef" type="xtce:ParameterInstanceRefType">
+						<annotation>
+							<documentation xml:lang="en">Left hand side parameter instance.</documentation>
+						</annotation>
+					</element>
+					<element name="ComparisonOperator" type="xtce:ComparisonOperatorsType">
+						<annotation>
+							<documentation xml:lang="en">Comparison operator.</documentation>
+						</annotation>
+					</element>
+					<choice>
+						<element name="ParameterInstanceRef" type="xtce:ParameterInstanceRefType">
+							<annotation>
+								<documentation xml:lang="en">Right hand side parameter instance.  Parameter is assumed to be of the same type as the comparison Parameter.</documentation>
+							</annotation>
+						</element>
+						<element name="Value" type="string">
+							<annotation>
+								<documentation xml:lang="en">Right hand side value.  Specify as: integer data type using xs:integer, float data type using xs:double, string data type using xs:string, boolean data type using xs:boolean, binary data type using xs:hexBinary, enum data type using label name, relative time data type using xs:duration, absolute time data type using xs:dateTime.  Values must not exceed the characteristics for the data type or this is a validation error. Takes precedence over an initial value given in the data type. Values are calibrated unless there is an option to override it.</documentation>
+							</annotation>
+						</element>
+					</choice>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ComparisonListType">
+		<annotation>
+			<documentation xml:lang="en">All comparisons must be true</documentation>
+		</annotation>
+		<sequence>
+			<element name="Comparison" type="xtce:ComparisonType" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">List of Comparison elements must all be true for the comparison to evaluate to true.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<simpleType name="ComparisonOperatorsType">
+		<annotation>
+			<documentation xml:lang="en">Operators to use when testing a boolean condition for a validity check</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="=="/>
+			<enumeration value="!="/>
+			<enumeration value="&lt;"/>
+			<enumeration value="&lt;="/>
+			<enumeration value=">"/>
+			<enumeration value=">="/>
+		</restriction>
+	</simpleType>
+	<complexType name="ComparisonType">
+		<annotation>
+			<documentation xml:lang="en">A simple ParameterInstanceRef to value comparison.  The string supplied in the value attribute needs to be converted to a type matching the Parameter being compared to.  Numerical values are assumed to be base 10 unless proceeded by 0x (hexadecimal), 0o (octal), or 0b (binary).  The value is truncated  to use the least significant bits that match the bit size of the Parameter being compared to.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:ParameterInstanceRefType">
+				<attribute name="comparisonOperator" type="xtce:ComparisonOperatorsType" default="==">
+					<annotation>
+						<documentation xml:lang="en">Operator to use for the comparison with the common equality operator as the default.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="value" type="string" use="required">
+					<annotation>
+						<documentation xml:lang="en">Specify value as a string compliant with the XML schema (xs) type specified for each XTCE type: integer=xs:integer; float=xs:double; string=xs:string; boolean=xs:boolean; binary=xs:hexBinary; enum=xs:string from EnumerationList; relative time= xs:duration; absolute time=xs:dateTime.  Supplied value must be within the ValidRange specified for the type.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ContextCalibratorType">
+		<annotation>
+			<documentation xml:lang="en">Context calibrations are applied when the ContextMatch is true.  Context calibrators overide Default calibrators</documentation>
+		</annotation>
+		<sequence>
+			<element name="ContextMatch" type="xtce:ContextMatchType"/>
+			<element name="Calibrator" type="xtce:CalibratorType"/>
+		</sequence>
+	</complexType>
+	<complexType name="ContextMatchType">
+		<annotation>
+			<documentation xml:lang="en">A MatchCriteriaType used for Context selection.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:MatchCriteriaType"/>
+		</complexContent>
+	</complexType>
+	<complexType name="CustomAlarmType">
+		<annotation>
+			<documentation xml:lang="en">Describe a custom, algorithmic alarm condition. The algorithm is assumed to return a boolean value: true or false. See AlarmType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseAlarmType">
+				<sequence>
+					<element name="InputAlgorithm" type="xtce:InputAlgorithmType">
+						<annotation>
+							<documentation xml:lang="en">Algorithm returns a boolean.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="PercentCompleteType">
+		<annotation>
+			<documentation xml:lang="en">Describe a percentage complete that is fixed from 0 to 100, or as value from a parameter. See ExecutionVerifierType.</documentation>
+		</annotation>
+		<choice>
+			<element name="FixedValue">
+				<annotation>
+					<documentation xml:lang="en">0 to 100 percent</documentation>
+				</annotation>
+				<simpleType>
+					<restriction base="double">
+						<minInclusive value="0.0"/>
+						<maxInclusive value="100.0"/>
+					</restriction>
+				</simpleType>
+			</element>
+			<element name="DynamicValue" type="xtce:DynamicValueType">
+				<annotation>
+					<documentation xml:lang="en">Uses a parameter instance to obtain the value. The parameter value may be optionally adjusted by a Linear function or use a series of boolean expressions to lookup the value. Anything more complex and a DynamicValue with a CustomAlgorithm may be used.</documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<complexType name="DescriptionType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Defines an abstract schema type used as basis for NameDescriptionType and OptionalNameDescriptionType, includes an attribute for a short description and an element for a longer unbounded description.  This type also provides alias set and ancillary data set  See AliasSetType and AncillaryDataSetType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="LongDescription" type="xtce:LongDescriptionType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Optional long form description to be used for explanatory descriptions of this item and may include HTML markup using CDATA.  Long Descriptions are of unbounded length.</documentation>
+				</annotation>
+			</element>
+			<element name="AliasSet" type="xtce:AliasSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Used to contain an alias (alternate) name or ID for this item.   See AliasSetType for additional explanation.</documentation>
+				</annotation>
+			</element>
+			<element name="AncillaryDataSet" type="xtce:AncillaryDataSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">Use for any non-standard data associated with this named item.  See AncillaryDataSetType for additional explanation.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="shortDescription" type="xtce:ShortDescriptionType" use="optional">
+			<annotation>
+				<documentation xml:lang="en">Optional short description to be used for explanation of this item.  It is recommended that the short description be kept under 80 characters in length.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="DiscreteLookupListType">
+		<annotation>
+			<documentation xml:lang="en">Describe an ordered table of integer values and associated conditions, forming a lookup table. The list may have duplicates.  The table is evaluated from first to last, the first condition to be true returns the value associated with it.  See DiscreteLookupType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="DiscreteLookup" type="xtce:DiscreteLookupType" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">Describe a lookup condition set using discrete values from parameters.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="DynamicValueType">
+		<annotation>
+			<documentation xml:lang="en">Uses a parameter instance to obtain the value.  The parameter value may be optionally adjusted by a Linear function or use a series of boolean expressions to lookup the value.  Anything more complex and a DynamicValue with a CustomAlgorithm may be used  </documentation>
+		</annotation>
+		<sequence>
+			<element name="ParameterInstanceRef" type="xtce:ParameterInstanceRefType">
+				<annotation>
+					<documentation xml:lang="en">Retrieve the value by referencing the value of a Parameter.</documentation>
+				</annotation>
+			</element>
+			<element name="LinearAdjustment" type="xtce:LinearAdjustmentType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">A slope and intercept may be applied to scale or shift the value selected from the argument or parameter.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ErrorDetectCorrectType">
+		<annotation>
+			<documentation>Describe error detection/correction algorithm.</documentation>
+		</annotation>
+		<choice>
+			<element name="Checksum" type="xtce:ChecksumType"/>
+			<element name="CRC" type="xtce:CRCType"/>
+			<element name="Parity" type="xtce:ParityType"/>
+		</choice>
+	</complexType>
+	<simpleType name="FixedIntegerValueType">
+		<annotation>
+			<documentation xml:lang="en">A simple union type combining integer, octal, binary, and hexadecimal types</documentation>
+		</annotation>
+		<union memberTypes="integer xtce:HexadecimalType xtce:OctalType xtce:BinaryType"/>
+	</simpleType>
+	<complexType name="HeaderType">
+		<annotation>
+			<documentation xml:lang="en">Schema for a Header record.  A header contains general information about the system or subsystem.</documentation>
+		</annotation>
+		<sequence>
+			<element name="AuthorSet" type="xtce:AuthorSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">The AuthorSet contains optional contact information for this document.</documentation>
+				</annotation>
+			</element>
+			<element name="NoteSet" type="xtce:NoteSetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">The NoteSet contains optional technical information related to the content of this document.</documentation>
+				</annotation>
+			</element>
+			<element name="HistorySet" type="xtce:HistorySetType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">The HistorySet contains optional evolutionary information for data contained in this document.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="version" type="string">
+			<annotation>
+				<documentation xml:lang="en">This attribute contains an optional version descriptor for this document.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="date" type="string">
+			<annotation>
+				<documentation xml:lang="en">This attribute contains an optional date to be associated with this document.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="classification" type="string" default="NotClassified">
+			<annotation>
+				<documentation xml:lang="en">This attribute contains optional classification status for use by programs for which that is applicable.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="classificationInstructions" type="string">
+			<annotation>
+				<documentation xml:lang="en">This attribute contains an optional additional instructions attribute to be interpreted by programs that use this attribute.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="validationStatus" type="xtce:ValidationStatusType" use="required">
+			<annotation>
+				<documentation xml:lang="en">This attribute contains a flag describing the state of this document in the evolution of the project using it.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<simpleType name="HexadecimalType">
+		<annotation>
+			<documentation xml:lang="en">A simple restriction on string for hexadecimal numbers.  Must be in 0x or 0X form.</documentation>
+		</annotation>
+		<restriction base="string">
+			<pattern value="0[xX][0-9a-fA-F]+"/>
+		</restriction>
+	</simpleType>
+	<complexType name="HistorySetType">
+		<annotation>
+			<documentation xml:lang="en">Describe an unordered collection of History elements.  Usage is user defined.  See HistoryType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="History" type="xtce:HistoryType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">Contains a history record related to the evolution of this document.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<simpleType name="HistoryType">
+		<restriction base="string"/>
+	</simpleType>
+	<complexType name="IntegerValueType">
+		<annotation>
+			<documentation xml:lang="en">Contains an Integer value; value may be provided directly or via the value in a parameter.</documentation>
+		</annotation>
+		<choice>
+			<element name="FixedValue" type="long">
+				<annotation>
+					<documentation xml:lang="en">Use a fixed integer value.</documentation>
+				</annotation>
+			</element>
+			<element name="DynamicValue" type="xtce:DynamicValueType">
+				<annotation>
+					<documentation xml:lang="en">Determine the value by interrogating an instance of a parameter.</documentation>
+				</annotation>
+			</element>
+			<element name="DiscreteLookupList" type="xtce:DiscreteLookupListType">
+				<annotation>
+					<documentation xml:lang="en">Determine the value by interrogating an instance of a parameter and selecting a specified value based on tests of the value of that parameter.</documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<complexType name="ArgumentIntegerValueType">
+		<annotation>
+			<documentation xml:lang="en">Identical to IntegerValueType but supports argument instance references.</documentation>
+		</annotation>
+		<choice>
+			<element name="FixedValue" type="long">
+				<annotation>
+					<documentation xml:lang="en">Use a fixed integer value.</documentation>
+				</annotation>
+			</element>
+			<element name="DynamicValue" type="xtce:ArgumentDynamicValueType">
+				<annotation>
+					<documentation xml:lang="en">Determine the value by interrogating an instance of an argument or parameter.</documentation>
+				</annotation>
+			</element>
+			<element name="DiscreteLookupList" type="xtce:ArgumentDiscreteLookupListType">
+				<annotation>
+					<documentation xml:lang="en">Determine the value by interrogating an instance of an argument or parameter and selecting a specified value based on tests of the value of that argument or parameter.</documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<simpleType name="LongDescriptionType">
+		<annotation>
+			<documentation xml:lang="en">The Long Description is intended to be used for explanatory descriptions of the object and may include HTML markup.  Long Descriptions are of unbounded length</documentation>
+		</annotation>
+		<restriction base="string"/>
+	</simpleType>
+	<simpleType name="MathOperatorsType">
+		<annotation>
+			<documentation xml:lang="en">Mathematical operators used in the math operation.  Behavior of each operator on the stack is described using notation (before -- after), where "before" represents the stack before execution of the operator and "after" represent the stack after execution.</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="+">
+				<annotation>
+					<documentation xml:lang="en">addition (x1 x2 -- x1+x2)</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="-">
+				<annotation>
+					<documentation xml:lang="en">subtraction (x1 x2 -- x1-x2)</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="*">
+				<annotation>
+					<documentation xml:lang="en">multiplication (x1 x2 -- x1*x2)</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="/">
+				<annotation>
+					<documentation xml:lang="en">division (x1 x2 -- x1/x2)</documentation>
+					<appinfo>An undefined condition exists if x2 is 0</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="%">
+				<annotation>
+					<documentation xml:lang="en">modulo (x1 x2 -- x3) Divide x1 by x2, giving the modulo x3</documentation>
+					<appinfo>An undefined condition exists if x2 is 0.  Implementations should verify modulo versus remainder behavior.</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="^">
+				<annotation>
+					<documentation xml:lang="en">power function (x1 x2 -- x1**x2)</documentation>
+					<appinfo>An undefined condition exists if an imaginary number is the result.  Imaginary numbers are not supported</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="y^x">
+				<annotation>
+					<documentation xml:lang="en">reverse power function (x1 x2 -- x2**x1)</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="ln">
+				<annotation>
+					<documentation xml:lang="en">natural (base e) logarithm (x -- ln(x))</documentation>
+					<appinfo>An undefined condition exists if x is less than or equal to 0</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="log">
+				<annotation>
+					<documentation xml:lang="en">base-10 logarithm (x-- log(x))</documentation>
+					<appinfo>An undefined condition exists if x is less than or equal to 0</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="e^x">
+				<annotation>
+					<documentation xml:lang="en">exponentiation (x -- exp(x))</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="1/x">
+				<annotation>
+					<documentation xml:lang="en">inversion (x -- 1/x)</documentation>
+					<appinfo>An undefined condition exists if x is less than 0</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="x!">
+				<annotation>
+					<documentation xml:lang="en">factorial (x -- x!)</documentation>
+					<appinfo>An undefined condition exists if x is less than 0</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="tan">
+				<annotation>
+					<documentation xml:lang="en">tangent (x -- tan(x)) radians</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="cos">
+				<annotation>
+					<documentation xml:lang="en">cosine (x -- cos(x)) radians</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="sin">
+				<annotation>
+					<documentation xml:lang="en">sine (x -- sin(x)) radians</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="atan">
+				<annotation>
+					<documentation xml:lang="en">arctangent (x -- atan(x)) radians</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="atan2">
+				<annotation>
+					<documentation xml:lang="en">arctangent (x1 x2 -- atan2(x2, x1)) radians</documentation>
+					<appinfo>An undefined condition exists if x1 and x2 are 0</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="acos">
+				<annotation>
+					<documentation xml:lang="en">arccosine (x -- acos(x)) radians</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="asin">
+				<annotation>
+					<documentation xml:lang="en">arcsine (x -- asin(x)) radians</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="tanh">
+				<annotation>
+					<documentation xml:lang="en">hyperbolic tangent (x -- tanh(x))</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="cosh">
+				<annotation>
+					<documentation xml:lang="en">hyperbolic cosine (x -- cosh(x))</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="sinh">
+				<annotation>
+					<documentation xml:lang="en">hyperbolic sine (x -- sinh(x))</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="atanh">
+				<annotation>
+					<documentation xml:lang="en">hyperbolic arctangent (x -- atanh(x))</documentation>
+					<appinfo>An undefined condition exists if x is outside the range [-1.0,+1.0]</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="acosh">
+				<annotation>
+					<documentation xml:lang="en">hyperbolic arccosine (x -- acosh(x))</documentation>
+					<appinfo>An undefined condition exists if n is less than 1</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="asinh">
+				<annotation>
+					<documentation xml:lang="en">hyperbolic arcsine (x -- asinh(x))</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="swap">
+				<annotation>
+					<documentation xml:lang="en">swap the top two stack items (x1 x2 -- x2 x1)</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="drop">
+				<annotation>
+					<documentation xml:lang="en">Remove top item from the stack (x -- )</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="dup">
+				<annotation>
+					<documentation xml:lang="en">Duplicate top item on the stack (x -- x x)</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="over">
+				<annotation>
+					<documentation xml:lang="en">Duplicate top item on the stack (x1 x2 -- x1 x2 x1)</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="&lt;&lt;">
+				<annotation>
+					<documentation xml:lang="en">signed bitwise left shift (x1 x2 -- x1 &lt;&lt; x2)</documentation>
+					<appinfo>Limitation from SEI INT13-C. Use bitwise operators only on unsigned operands</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="&gt;&gt;">
+				<annotation>
+					<documentation xml:lang="en">signed bitwise right shift (x1 x2 -- x1 &gt;&gt; x2)</documentation>
+					<appinfo>Limitation from SEI INT13-C. Use bitwise operators only on unsigned operands</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="&amp;">
+				<annotation>
+					<documentation xml:lang="en">bitwise and (x1 x2 -- x1 &amp; x2)</documentation>
+					<appinfo>Limitation from SEI INT13-C. Use bitwise operators only on unsigned operands</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="|">
+				<annotation>
+					<documentation xml:lang="en">bitwise or (x1 x2 -- x1 | x2)</documentation>
+					<appinfo>Limitation from SEI INT13-C. Use bitwise operators only on unsigned operands</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="&amp;&amp;">
+				<annotation>
+					<documentation xml:lang="en">logical and (x1 x2 -- x1 &amp;&amp; x2)</documentation>
+					<appinfo>The result of this can only be 0 or 1</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="||">
+				<annotation>
+					<documentation xml:lang="en">logical or (x1 x2 -- x1 || x2)</documentation>
+					<appinfo>The result of this can only be 0 or 1</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="!">
+				<annotation>
+					<documentation xml:lang="en">logical not (x1 x2 -- x1 ! x2)</documentation>
+					<appinfo>The result of this can only be 0 or 1</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="abs">
+				<annotation>
+					<documentation xml:lang="en">absolute value (x1 -- abs(x1))</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="div">
+				<annotation>
+					<documentation xml:lang="en">Euclidean division quotient (x1 -- div(x1))</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="int">
+				<annotation>
+					<documentation xml:lang="en">integer part (x1 -- int(x1))</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="&gt;">
+				<annotation>
+					<documentation xml:lang="en">greater than x,y (x1 x2 -- x1 &gt; x2)</documentation>
+					<appinfo>The result of this can only be 0 or 1</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="&gt;=">
+				<annotation>
+					<documentation xml:lang="en">greater than or equal x,y (x1 x2 -- x1 &gt;= x2)</documentation>
+					<appinfo>The result of this can only be 0 or 1</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="&lt;">
+				<annotation>
+					<documentation xml:lang="en">less than x,y (x1 x2 -- x1 &lt; x2)</documentation>
+					<appinfo>The result of this can only be 0 or 1</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="&lt;=">
+				<annotation>
+					<documentation xml:lang="en">less than or equal x,y (x1 x2 -- x1 &lt;= x2)</documentation>
+					<appinfo>The result of this can only be 0 or 1</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="==">
+				<annotation>
+					<documentation xml:lang="en">equal x,y (x1 x2 -- x1 == x2)</documentation>
+					<appinfo>The result of this can only be 0 or 1</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="!=">
+				<annotation>
+					<documentation xml:lang="en">not equal x,y (x1 x2 -- x1 != x2)</documentation>
+					<appinfo>The result of this can only be 0 or 1</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="min">
+				<annotation>
+					<documentation xml:lang="en">minimum of x,y (x1 x2 -- min(x1, x2))</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="max">
+				<annotation>
+					<documentation xml:lang="en">maximum of x,y (x1 x2 -- max(x1, x2))</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="xor">
+				<annotation>
+					<documentation xml:lang="en">Bitwise exclusive or (XOR) (x1 x2 -- x1 xor x2)</documentation>
+					<appinfo>Limitation from SEI INT13-C. Use bitwise operators only on unsigned operands</appinfo>
+				</annotation>
+			</enumeration>
+			<enumeration value="~">
+				<annotation>
+					<documentation xml:lang="en">Bitwise not operation (x1 x2 -- x1 ~ x2) The result of this can only be 0 or 1</documentation>
+					<appinfo>Limitation from SEI INT13-C. Use bitwise operators only on unsigned operands</appinfo>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<complexType name="MatchCriteriaType">
+		<annotation>
+			<documentation xml:lang="en">Contains either a simple Comparison, a ComparisonList, an arbitrarily complex BooleanExpression or an escape to an externally defined algorithm</documentation>
+		</annotation>
+		<choice>
+			<element name="Comparison" type="xtce:ComparisonType">
+				<annotation>
+					<documentation xml:lang="en">A simple comparison check involving a single test of a parameter value.</documentation>
+				</annotation>
+			</element>
+			<element name="ComparisonList" type="xtce:ComparisonListType">
+				<annotation>
+					<documentation xml:lang="en">A series of simple comparison checks with an implicit 'and' in that they all must be true for the overall condition to be true.</documentation>
+				</annotation>
+			</element>
+			<element name="BooleanExpression" type="xtce:BooleanExpressionType">
+				<annotation>
+					<documentation xml:lang="en">An arbitrarily complex boolean expression that has additional flexibility on the terms beyond the Comparison and ComparisonList elements.</documentation>
+				</annotation>
+			</element>
+			<element name="CustomAlgorithm" type="xtce:InputAlgorithmType">
+				<annotation>
+					<documentation xml:lang="en">An escape to an externally defined algorithm.</documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<complexType name="MathOperationType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Postfix (aka Reverse Polish Notation (RPN)) notation is used to describe mathmatical equations. It uses a stack where operands (either fixed values or ParameterInstances) are pushed onto the stack from first to last in the XML. As the operators are specified, each pops off operands as it evaluates them, and pushes the result back onto the stack. In this case postfix is used to avoid having to specify parenthesis. To convert from infix to postfix, use Dijkstra's "shunting yard" algorithm.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:MathOperationCalibratorType"/>
+		</complexContent>
+	</complexType>
+	<simpleType name="NameType">
+		<annotation>
+			<documentation>Defines a name where all characters are allowed except '.', '[', ']', ':',  ' ', and '/'.  See NameDescriptionType.</documentation>
+		</annotation>
+		<restriction base="normalizedString">
+			<pattern value="[^./:\[\] ]+"/>
+		</restriction>
+	</simpleType>
+	<complexType name="NameDescriptionType">
+		<annotation>
+			<documentation xml:lang="en">Defines a base schema type definition used by many other schema types throughout schema.  Use it to describe a name with optional descriptions, aliases, and ancillary data.  See NameType, LongDescriptionType, ShortDescriptionType, AliasSetType and AncillaryDataSetType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:DescriptionType">
+				<attribute name="name" type="xtce:NameType" use="required">
+					<annotation>
+						<documentation xml:lang="en">The name of this defined item.  See NameType for restriction information.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<simpleType name="NameReferenceType">
+		<annotation>
+			<documentation>Describe a reference to a named item in an XTCE instance document.  The named must be of schema type NameType.  All name references use a Unix style file system name format where the SpaceSystem names form a path in the SpaceSystem tree. The following characters are reserved for the path: '/', ‘..’ and ‘.’ (multiple consecutive ‘/’s are treated as one).  The path portion is similar to the directory path used in file system names and the path characters have similar meaning (e.g., SimpleSat/Bus/EPDS/BatteryOne/Voltage). There are three overall forms for name references:  absolute path, relative path and just the name.  The first two forms are called qualified name references; the last form is called an unqualified name reference.  The unqualified form refers to an item in the SpaceSystem the reference is used in.  The unqualified form refers to an item in the SpaceSystem the reference is used in.  It is illegal for a name reference to point to no item (“a dangling name reference”).</documentation>
+		</annotation>
+		<restriction base="normalizedString">
+			<pattern value="/?(([^./:\[\]]+|\.|\.\.)/)*([^./:\[\]]+)+"/>
+		</restriction>
+	</simpleType>
+	<complexType name="NoteSetType">
+		<annotation>
+			<documentation xml:lang="en">Contains an unordered collection of Notes.  Usage is user defined.  See NoteType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="Note" type="xtce:NoteType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">Contains a program defined technical note regarding this document.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<simpleType name="NoteType">
+		<restriction base="string"/>
+	</simpleType>
+	<complexType name="NumberFormatType">
+		<annotation>
+			<documentation xml:lang="en">This type describes how a numeric value should be represented in engineering/calibrated form.  The defaults reflect the most common form.</documentation>
+		</annotation>
+		<attribute name="numberBase" type="xtce:RadixType" use="optional" default="Decimal">
+			<annotation>
+				<documentation xml:lang="en">Describes how the engineering/calibrated value of this number should be displayed with respect to the radix.  Default is base 10.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="minimumFractionDigits" type="xtce:NonNegativeLongType" use="optional" default="0">
+			<annotation>
+				<documentation xml:lang="en">Describes how the engineering/calibrated value of this number should be displayed with respect to the minimum number of fractional digits.  The default is 0.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="maximumFractionDigits" type="xtce:NonNegativeLongType" use="optional">
+			<annotation>
+				<documentation xml:lang="en">Describes how the engineering/calibrated value of this number should be displayed with respect to the maximum or upper bound of the number of digits.  There is no default.  No value specified should be interpreted as no upper bound such that all requires digits are used to fully characterize the value.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="minimumIntegerDigits" type="xtce:NonNegativeLongType" use="optional" default="1">
+			<annotation>
+				<documentation xml:lang="en">Describes how the engineering/calibrated value of this number should be displayed with respect to the minimum number of integer digits.  The default is 1.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="maximumIntegerDigits" type="xtce:NonNegativeLongType" use="optional">
+			<annotation>
+				<documentation xml:lang="en">Describes how the engineering/calibrated value of this number should be displayed with respect to the maximum or upper bound of the integer digits.  There is no default.  No value specified should be interpreted as no upper bound such that all requires digits are used to fully characterize the value.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="negativeSuffix" type="string" use="optional" default="">
+			<annotation>
+				<documentation xml:lang="en">Describes how the engineering/calibrated value of this number should be displayed with respect to negative values.  This attribute specifies the character or characters that should be appended to the numeric value to indicate negative values.  The default is none.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="positiveSuffix" type="string" use="optional" default="">
+			<annotation>
+				<documentation xml:lang="en">Describes how the engineering/calibrated value of this number should be displayed with respect to positive values.  This attribute specifies the character or characters that should be appended to the numeric value to indicate positive values.  The default is none.  Zero is considered to be specific to the implementation/platform and is not implied here.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="negativePrefix" type="string" use="optional" default="-">
+			<annotation>
+				<documentation xml:lang="en">Describes how the engineering/calibrated value of this number should be displayed with respect to negative values.  This attribute specifies the character or characters that should be prepended to the numeric value to indicate negative values.  The default is a minus character "-".</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="positivePrefix" type="string" use="optional" default="">
+			<annotation>
+				<documentation xml:lang="en">Describes how the engineering/calibrated value of this number should be displayed with respect to positive values.  This attribute specifies the character or characters that should be prepended to the numeric value to indicate positive values.  The default is none.  Zero is considered to be specific to the implementation/platform and is not implied here.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="showThousandsGrouping" type="boolean" use="optional" default="false">
+			<annotation>
+				<documentation xml:lang="en">Describes how the engineering/calibrated value of this number should be displayed with respect to larger values.  Groupings by thousand are specific to locale, so the schema only specifies whether they will be present and not which character separators are used.  The default is false.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="notation" type="xtce:FloatingPointNotationType" use="optional" default="normal">
+			<annotation>
+				<documentation xml:lang="en">Describes how the engineering/calibrated value of this number should be displayed with respect to notation.  Engineering, scientific, or traditional decimal notation may be specified.  The precise characters used is locale specific for the implementation/platform.  The default is "normal" for the traditional notation.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<simpleType name="OctalType">
+		<annotation>
+			<documentation xml:lang="en">A simple restriction on string for hexadecimal numbers.  Must be in 0o or 0O form.</documentation>
+		</annotation>
+		<restriction base="string">
+			<pattern value="0[oO][0-7]+"/>
+		</restriction>
+	</simpleType>
+	<complexType name="OptionalNameDescriptionType">
+		<annotation>
+			<documentation xml:lang="en">The type definition used by most elements that have an optional name with optional descriptions.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:DescriptionType">
+				<attribute name="name" type="xtce:NameType" use="optional">
+					<annotation>
+						<documentation xml:lang="en">Optional name of this defined item.  See NameType for restriction information.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ORedConditionsType">
+		<annotation>
+			<documentation xml:lang="en">Describe two or more conditions that are logically ored together. Conditions may be a mix of Condition and ANDedCondition.   See ORedConditionType and BooleanExpressionType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseConditionsType">
+				<choice minOccurs="2" maxOccurs="unbounded">
+					<element name="Condition" type="xtce:ComparisonCheckType">
+						<annotation>
+							<documentation xml:lang="en">Condition elements describe a test similar to the Comparison element except that the parameters used have additional flexibility for the compare.</documentation>
+						</annotation>
+					</element>
+					<element name="ANDedConditions" type="xtce:ANDedConditionsType">
+						<annotation>
+							<documentation xml:lang="en">This element describes tests similar to the ComparisonList element except that the parameters used are more flexible and the and/or for multiple checks can be specified.</documentation>
+						</annotation>
+					</element>
+				</choice>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ParameterSetType">
+		<annotation>
+			<documentation xml:lang="en">Describe an unordered collection of parameters where duplicates defined by the Parameter name attribute are invalid. The ParameterSet exists in both the TelemetryMetaData and the CommandMetaData element so that each may be built independently but from a single namespace.  See TelemetryMetaDataType and CommandMetaDataType.</documentation>
+		</annotation>
+		<choice maxOccurs="unbounded">
+			<element name="Parameter" type="xtce:ParameterType">
+				<annotation>
+					<documentation xml:lang="en">Defines a named and typed Parameter.</documentation>
+					<appinfo>Need to ensure that the named types actually exist</appinfo>
+				</annotation>
+			</element>
+			<element name="ParameterRef" type="xtce:ParameterRefType">
+				<annotation>
+					<documentation xml:lang="en">Used to include a Parameter defined in another sub-system in this sub-system.</documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<simpleType name="RadixType">
+		<annotation>
+			<documentation xml:lang="en">Specifies the number base</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="Decimal"/>
+			<enumeration value="Hexadecimal"/>
+			<enumeration value="Octal"/>
+			<enumeration value="Binary"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="RangeFormType">
+		<annotation>
+			<documentation>Defines whether the defined range between the minimum and maximum is the outside or inside the range being defined. The default, outside matches values less than the minimum and greater than the maximum.  Inside matches values between the minimum and maximum.</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="outside"/>
+			<enumeration value="inside"/>
+		</restriction>
+	</simpleType>
+	<complexType name="ReferenceTimeType">
+		<annotation>
+			<documentation xml:lang="en">Most time values are relative to another time e.g. seconds are relative to minutes, minutes are relative to hours.  This type is used to describe this relationship starting with the least significant time Parameter to and progressing to the most significant time parameter.  </documentation>
+		</annotation>
+		<choice>
+			<element name="OffsetFrom" type="xtce:ParameterInstanceRefType"/>
+			<element name="Epoch" type="xtce:EpochType">
+				<annotation>
+					<documentation xml:lang="en">Epochs may be specified as an xs date where time is implied to be 00:00:00, xs dateTime, or string enumeration of common epochs.  The enumerations are TAI (used by CCSDS and others), J2000, UNIX (also known as POSIX), and GPS.</documentation>
+				</annotation>
+			</element>
+		</choice>
+	</complexType>
+	<simpleType name="RelativeTimeType">
+		<annotation>
+			<documentation xml:lang="en">Used to describe a relative time.  Normally used for time offsets.  A Relative time is expressed as PnYn MnDTnH nMnS, where nY represents the number of years, nM the number of months, nD the number of days, 'T' is the date/time separator, nH the number of hours, nM the number of minutes and nS the number of seconds. The number of seconds can include decimal digits to arbitrary precision.  For example, to indicate a duration of 1 year, 2 months, 3 days, 10 hours, and 30 minutes, one would write: P1Y2M3DT10H30M. One could also indicate a duration of minus 120 days as: -P120D.  An extension of Schema duration type. </documentation>
+		</annotation>
+		<restriction base="duration"/>
+	</simpleType>
+	<complexType name="RepeatType">
+		<annotation>
+			<documentation xml:lang="en">Hold a structure that can be repeated X times, where X is the Count</documentation>
+		</annotation>
+		<sequence>
+			<element name="Count" type="xtce:IntegerValueType">
+				<annotation>
+					<documentation xml:lang="en">Value (either fixed or dynamic) that contains the count of repeated structures.</documentation>
+				</annotation>
+			</element>
+			<element name="Offset" type="xtce:IntegerValueType" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="ArgumentRepeatType">
+		<annotation>
+			<documentation xml:lang="en">Identical to RepeatType but supports argument instance references.</documentation>
+		</annotation>
+		<sequence>
+			<element name="Count" type="xtce:ArgumentIntegerValueType">
+				<annotation>
+					<documentation xml:lang="en">Value (either fixed or dynamic) that contains the count of repeated structures.</documentation>
+				</annotation>
+			</element>
+			<element name="Offset" type="xtce:ArgumentIntegerValueType" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="ServiceRefType">
+		<annotation>
+			<documentation xml:lang="en">A reference to a Service</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="xtce:NameReferenceType">
+				<attribute name="serviceRef" type="xtce:NameReferenceType" use="required"/>
+			</extension>
+		</simpleContent>
+	</complexType>
+	<simpleType name="ShortDescriptionType">
+		<annotation>
+			<documentation xml:lang="en">It is strongly recommended that the short description be kept under 80 characters in length</documentation>
+		</annotation>
+		<restriction base="string"/>
+	</simpleType>
+	<complexType name="SplinePointType">
+		<annotation>
+			<documentation xml:lang="en">A spline, or piecewise defined function, is a set on points from which a curve may be drawn to interpolate raw to calibrated values</documentation>
+		</annotation>
+		<attribute name="order" type="xtce:NonNegativeLongType" default="1">
+			<annotation>
+				<documentation xml:lang="en">The order of a SplineCalibrator refers to the interpolation function.  Order 0 is a flat line from the defined point (inclusive) to the next point (exclusive).  Order 1 is linear interpolation between two points.  Order 2 is quadratic fit and requires at least 3 points (unusual case).  This order is generally not needed, but may be used to override the interpolation order for this point.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="raw" type="double" use="required">
+			<annotation>
+				<documentation xml:lang="en">The raw encoded value.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="calibrated" type="double" use="required">
+			<annotation>
+				<documentation xml:lang="en">The engineering/calibrated value associated with the raw value for this point.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="TermType">
+		<annotation>
+			<documentation xml:lang="en">A term in a polynomial expression.</documentation>
+		</annotation>
+		<attribute name="coefficient" type="double" use="required">
+			<annotation>
+				<documentation xml:lang="en">The coefficient in a single term of a polynomial expression.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="exponent" type="xtce:NonNegativeLongType" use="required">
+			<annotation>
+				<documentation xml:lang="en">The exponent in a single term of a polynomial expression.  Should negative exponents be required, use a Math Calibrator style of definition for this type.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<simpleType name="TimeUnitsType">
+		<annotation>
+			<documentation xml:lang="en">base time units.  days, months, years have obvoius ambiguity and should be avoided</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="seconds"/>
+			<enumeration value="picoSeconds"/>
+			<enumeration value="days"/>
+			<enumeration value="months"/>
+			<enumeration value="years"/>
+		</restriction>
+	</simpleType>
+	<complexType name="UnitType" mixed="true">
+		<annotation>
+			<documentation xml:lang="en">Describe the exponent, factor, form, and description for a unit.  The unit itself is in element Unit in UnitSet.  See UnitSetType.  The attributes are optional because different programs use this element in different ways, depending on vendor support.</documentation>
+		</annotation>
+		<attribute name="power" type="double" use="optional" default="1">
+			<annotation>
+				<documentation xml:lang="en">Optional attribute used in conjunction with the "factor" attribute where some programs choose to specify the unit definition with these machine processable algebraic features.  For example, a unit text of "meters" may have a "power" attribute of 2, resulting "meters squared" as the actual unit.  This is not commonly used.  The most common method for "meters squared" is to use the text content of the Unit element in a form like "m^2".</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="factor" type="string" use="optional" default="1">
+			<annotation>
+				<documentation xml:lang="en">Optional attribute used in conjunction with the "power" attribute where some programs choose to specify the unit definition with these machine processable algebraic features.  For example, a unit text of "meters" may have a "factor" attribute of 2, resulting "2 times meters" as the actual unit.  This is not commonly used.  The most common method for "2 times meters" is to use the text content of the Unit element in a form like "2*m".</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="description" type="xtce:ShortDescriptionType" use="optional">
+			<annotation>
+				<documentation xml:lang="en">A description of the unit, which may be for expanded human readability or for specification of the nature/property of the unit.  For example, meters per second squared is of a nature/property of acceleration.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="form" type="xtce:UnitFormType" use="optional" default="calibrated">
+			<annotation>
+				<documentation xml:lang="en">The default value "calibrated" is most common practice to specify units at the engineering/calibrated value, it is possible to specify an additional Unit element for the raw/uncalibrated value.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<simpleType name="ValidationStatusType">
+		<restriction base="string">
+			<enumeration value="Unknown"/>
+			<enumeration value="Working"/>
+			<enumeration value="Draft"/>
+			<enumeration value="Test"/>
+			<enumeration value="Validated"/>
+			<enumeration value="Released"/>
+			<enumeration value="Withdrawn"/>
+		</restriction>
+	</simpleType>
+	<complexType name="ValueEnumerationType">
+		<annotation>
+			<documentation xml:lang="en">Describe a value and an associated string label, see EnumerationListType.</documentation>
+		</annotation>
+		<attribute name="value" type="long" use="required">
+			<annotation>
+				<documentation xml:lang="en">Numeric raw/uncalibrated value to associate with a string enumeration label.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="maxValue" type="long">
+			<annotation>
+				<documentation xml:lang="en">If max value is given, the label maps to a range where value is less than or equal to maxValue. The range is inclusive.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="label" type="string" use="required">
+			<annotation>
+				<documentation xml:lang="en">String enumeration label to apply to this value definition in the enumeration.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="shortDescription" type="xtce:ShortDescriptionType">
+			<annotation>
+				<documentation xml:lang="en">An optional additional string description can be specified for this enumeration label to provide extended information if desired.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<!--*************************************************************-->
+	<!--******** Types used with alarms ***********************-->
+	<complexType name="AlarmConditionsType">
+		<annotation>
+			<documentation xml:lang="en">Describe up to six levels: Normal, Watch, Warning, Distress, Critical, and Severe of conditions the alarm will trigger when true. The types are conditions available are a single comparison, a comparison list, a discrete lookup list, and custom algorithm.   See MatchCriteriaType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="WatchAlarm" type="xtce:MatchCriteriaType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">An alarm state of least concern.  Considered to be below the most commonly used Warning level.</documentation>
+				</annotation>
+			</element>
+			<element name="WarningAlarm" type="xtce:MatchCriteriaType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">An alarm state of concern that represents the most commonly used minimum concern level for many software applications.</documentation>
+				</annotation>
+			</element>
+			<element name="DistressAlarm" type="xtce:MatchCriteriaType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">An alarm state of concern in between the most commonly used Warning and Critical levels.</documentation>
+				</annotation>
+			</element>
+			<element name="CriticalAlarm" type="xtce:MatchCriteriaType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">An alarm state of concern that represents the most commonly used maximum concern level for many software applications.</documentation>
+				</annotation>
+			</element>
+			<element name="SevereAlarm" type="xtce:MatchCriteriaType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="en">An alarm state of highest concern.  Considered to be above the most commonly used Critical level.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="AlarmRangesType">
+		<annotation>
+			<documentation xml:lang="en">Describe up to six ranges where either less severe ranges are a subset of more severe ranges (outside), or more severe ranges are a subset of less severe ranges (inside). In both forms, the undefined least severe range is normal. Range values are in calibrated engineering units. See FloatRangeType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseAlarmType">
+				<sequence>
+					<element name="WatchRange" type="xtce:FloatRangeType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">A range of least concern. Considered to be below the most commonly used Warning level.</documentation>
+						</annotation>
+					</element>
+					<element name="WarningRange" type="xtce:FloatRangeType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">A range of concern that represents the most commonly used minimum concern level for many software applications.</documentation>
+						</annotation>
+					</element>
+					<element name="DistressRange" type="xtce:FloatRangeType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">A range of concern in between the most commonly used Warning and Critical levels.</documentation>
+						</annotation>
+					</element>
+					<element name="CriticalRange" type="xtce:FloatRangeType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">A range of concern that represents the most commonly used maximum concern level for many software applications.</documentation>
+						</annotation>
+					</element>
+					<element name="SevereRange" type="xtce:FloatRangeType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">A range of highest concern. Considered to be above the most commonly used Critical level.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="rangeForm" type="xtce:RangeFormType" default="outside">
+					<annotation>
+						<documentation xml:lang="en">A value of outside specifies that the most severe range is outside all the other ranges: -severe -critical -distress -warning -watch normal +watch +warning +distress +critical +severe. A value of inside "inverts" these bands: -green -watch -warning -distress -critical severe +critical +distress +warning +watch. The most common form used is "outside" and is the default.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="AlarmType" abstract="true">
+		<annotation>
+			<documentation xml:lang="en">Defines a base schema type used to build up the other data type specific alarm types. The definition includes a count to go into alarm (minViolations – the counts to go out of alarm is the same), a condition style alarm and a custom alarm. See AlarmConditionType, CustomAlgorithmType, BinaryAlarmConditionType, BooleanAlarmType, BinaryContextAlarmType, EnumerationAlarmType, NumericAlarmType, StringAlarmType, TimeAlarmType, TimeAlarmConditionType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseAlarmType">
+				<sequence>
+					<choice minOccurs="0">
+						<element name="AlarmConditions" type="xtce:AlarmConditionsType">
+							<annotation>
+								<documentation xml:lang="en">A MatchCriteria may be specified for each of the 5 alarm levels. Each level is optional and the alarm should be the highest level to test true.</documentation>
+							</annotation>
+						</element>
+						<element name="CustomAlarm" type="xtce:CustomAlarmType">
+							<annotation>
+								<documentation xml:lang="en">An escape for ridiculously complex alarm conditions. Will trigger on changes to the containing Parameter.</documentation>
+							</annotation>
+						</element>
+					</choice>
+				</sequence>
+				<attribute name="minViolations" type="xtce:PositiveLongType" default="1">
+					<annotation>
+						<documentation xml:lang="en">The number of successive instances that meet the alarm conditions for the alarm to trigger. The default is 1.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="minConformance" type="xtce:PositiveLongType">
+					<annotation>
+						<documentation xml:lang="en">Optionally specify the number of successive instances that do not meet the alarm conditions to leave the alarm state. If this attribute is not specified, it is treated as being equal to minViolations (symmetric).</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="AlarmMultiRangesType">
+		<annotation>
+			<documentation xml:lang="en">Describe any number of alarm ranges, each with its own level (normal, warning, watch, distress, critical, severe) and range form (inside or outside). Ranges may overlap, be disjoint and so forth. Ranges within the value sprectrum non-specified are non-normal. The most severe range level of value within the ranges is the level of the alarm. Range values are in calibrated engineering units. See FloatRangeType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:BaseAlarmType">
+				<sequence>
+					<element name="Range" type="xtce:MultiRangeType" maxOccurs="unbounded">
+						<annotation>
+							<documentation xml:lang="en">Describe any number of alarm ranges, each with its own level (normal, warning, watch, distress, critical, severe) and range form (inside or outside). Ranges may overlap, be disjoint and so forth. Ranges within the value sprectrum non-specified are non-normal. The most severe range level of value within the ranges is the level of the alarm. Range values are in calibrated engineering units. See FloatRangeType.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<simpleType name="BasisType">
+		<annotation>
+			<documentation xml:lang="en">Defines to type of update rates: perSecond and perContainerUpdate.  See RateInStreamType.</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="perSecond"/>
+			<enumeration value="perContainerUpdate"/>
+		</restriction>
+	</simpleType>
+	<complexType name="BinaryAlarmType">
+		<annotation>
+			<documentation xml:lang="en">Describe alarm conditions specific to the binary data type, extends the basic AlarmType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:AlarmType"/>
+		</complexContent>
+	</complexType>
+	<complexType name="BooleanAlarmType">
+		<annotation>
+			<documentation xml:lang="en">Alarm conditions for Boolean types</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:AlarmType"/>
+		</complexContent>
+	</complexType>
+	<complexType name="BinaryContextAlarmListType">
+		<annotation>
+			<documentation xml:lang="en">Describe an ordered collection of context binary alarms, duplicates are valid.  Process the contexts in list order.  See BinaryContextAlarmType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="ContextAlarm" type="xtce:BinaryContextAlarmType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="BinaryContextAlarmType">
+		<complexContent>
+			<extension base="xtce:AlarmType">
+				<sequence>
+					<element name="ContextMatch" type="xtce:ContextMatchType"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="BooleanContextAlarmType">
+		<complexContent>
+			<extension base="xtce:BooleanAlarmType">
+				<sequence>
+					<element name="ContextMatch" type="xtce:ContextMatchType"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="BooleanContextAlarmListType">
+		<sequence>
+			<element name="ContextAlarm" type="xtce:BooleanContextAlarmType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="ChangeAlarmRangesType">
+		<annotation>
+			<documentation xml:lang="en">Describe an alarm when the parameter value's rate-of-change is either too fast or too slow. The change may be with respect to time (the default) or with respect to samples (delta alarms). Use the changeType attribute to select the type: changePerSecond (time) or changePerSample (delta). The change may also be ether relative (as a percentage change) or absolute as set by the changeBasis attribute. (Delta alarms are typically absolute but percentage is conceivable). The alarm also requires the spanOfInterest in both samples and seconds to have passed before it is to trigger. For time based rate of change alarms, the time specified in spanOfInterestInSeconds is used to calculate the change. For sample based rate of change alarms, the change is calculated over the number of samples specified in spanOfInterestInSamples. A typical delta alarm would set: changeType=changePerSample, changeBasis=absoluteChange, spanOfInterestInSamples=1. A typical time based version would set: changeType=changePerSecond, changeBasis=percentageChange, and spaceOfInterestInSeconds=1. To set the ranges use maxInclusive, the following definition applies: | Normal.maxInclusive | &lt;= | Watch.maxInclusive | &lt;= | Warning.maxInclusive | &lt;= | Distress.maxInclusive | &lt;= | Critical.maxInclusive | &lt;= | Severe.maxInclusive |. And it is further assumed the absolute value of each range and sampled value it taken to evaluate the alarm. See NumericAlarmType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:AlarmRangesType">
+				<attribute name="changeType" type="xtce:ChangeSpanType" default="changePerSecond"/>
+				<attribute name="changeBasis" type="xtce:ChangeBasisType" default="absoluteChange"/>
+				<attribute name="spanOfInterestInSamples" type="xtce:PositiveLongType" default="1"/>
+				<attribute name="spanOfInterestInSeconds" type="double" default="0"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<simpleType name="ChangeBasisType">
+		<annotation>
+			<documentation xml:lang="en">Defines absoluteChange and percentageChange for use in rate of change alarms. Used by ChangeAlarmRangesType.</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="absoluteChange"/>
+			<enumeration value="percentageChange"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="ConcernLevelsType">
+		<annotation>
+			<documentation xml:lang="en">Defines six levels: Normal, Watch, Warning, Distress, Critical and Severe. Typical implementations color the "normal" level as green, "warning" level as yellow, and "critical" level as red. These level definitions are used throughout the alarm definitions. Some systems provide a greater fidelity with the additional levels provided here. The "normal" level is not typically needed because "normal" should be construed as none of the concern levels evaluating to true. For cases where definiing "normal" is needed, refer to the specific alarm definition types.</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="normal"/>
+			<enumeration value="watch"/>
+			<enumeration value="warning"/>
+			<enumeration value="distress"/>
+			<enumeration value="critical"/>
+			<enumeration value="severe"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="ConsequenceLevelType">
+		<annotation>
+			<documentation>Defines the criticality level of a command.  Criticality levels follow ISO 14950.</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="normal">
+				<annotation>
+					<documentation>Normal command.  Corresponds to ISO 14950 Level D telecommand criticality.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="vital">
+				<annotation>
+					<documentation>Command that is not a critical command but is essential to the success of the mission and, if sent at the wrong time, could cause momentary loss of the mission.  Corresponds to ISO 14950 Level C telecommand criticality.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="critical">
+				<annotation>
+					<documentation>Command that, if executed at the wrong time or in the wrong configuration, could cause irreversible loss or damage for the mission.  Corresponds to ISO 14950 Level B telecommand criticality.  Some space programs have called this "restricted" and may be implemented with a secondary confirmation before transmission.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="forbidden">
+				<annotation>
+					<documentation>Command that is not expected to be used for nominal or foreseeable contingency operations, that is included for unforeseen contingency operations, and that could cause irreversible damage if executed at the wrong time or in the wrong configuration.  Corresponds to ISO 14950 Level A telecommand criticality.  Some space programs have called this "prohibited".</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="user1">
+				<annotation>
+					<documentation>In the event that a program uses this value, that program will need to define the meaning of this value to their system.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="user2">
+				<annotation>
+					<documentation>In the event that a program uses this value, that program will need to define the meaning of this value to their system.</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="ChangeSpanType">
+		<annotation>
+			<documentation xml:lang="en">Defines a changePerSecond and changePerSample for use in rate of change alarms. Used by ChangeAlarmRangesType.</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="changePerSecond"/>
+			<enumeration value="changePerSample"/>
+		</restriction>
+	</simpleType>
+	<complexType name="DiscreteLookupType">
+		<annotation>
+			<documentation xml:lang="en">Describe a discrete value lookup and the value associated when the lookup evaluates to true.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:MatchCriteriaType">
+				<attribute name="value" type="long" use="required">
+					<annotation>
+						<documentation xml:lang="en">Value to use when the lookup conditions are true.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="EnumerationAlarmLevelType">
+		<annotation>
+			<documentation xml:lang="en">Describe an alarm level and its enumeration label to trigger from. See EnumeratedAlarmType and EnumeratedParameterType.</documentation>
+		</annotation>
+		<attribute name="alarmLevel" type="xtce:ConcernLevelsType" use="required">
+			<annotation>
+				<documentation xml:lang="en">Defines six levels: Normal, Watch, Warning, Distress, Critical and Severe. Typical implementations color the "normal" level as green, "warning" level as yellow, and "critical" level as red. In the case of enumeration alarms, the "normal" is assumed by implementations to be any label not otherwise in an alarm state.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="enumerationLabel" type="string" use="required">
+			<annotation>
+				<documentation xml:lang="en">The enumeration label is the engineering/calibrated value for enumerated types.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="EnumerationAlarmListType">
+		<sequence>
+			<element name="EnumerationAlarm" type="xtce:EnumerationAlarmLevelType" maxOccurs="unbounded">
+				<annotation>
+					<documentation xml:lang="en">Describe an alarm state for an enumeration label where the label is engineer/calibrated value. Note that labels may represent multiple raw/uncalbrated values.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="EnumerationContextAlarmType">
+		<annotation>
+			<documentation xml:lang="en">Describe a context that when true the alarm condition may be evaluated. See ContextMatchType and EnumerationAlarmType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:EnumerationAlarmType">
+				<sequence>
+					<element name="ContextMatch" type="xtce:ContextMatchType">
+						<annotation>
+							<documentation xml:lang="en">Describe a context in terms of a parameter and value that when true enables the context alarm definition.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="EnumerationAlarmType">
+		<annotation>
+			<documentation xml:lang="en">Describe alarm conditions specific to the enumeration data type, extends the basic AlarmType with an EnumerationAlarmList. The alarms are described using the label (engineering/calibrated value) of the enumerated parameter. Enumeration labels may represent several raw/uncalibrated values, so as a result, a single alarm definition here may represent multiple raw values in the enumerated parameter. It is not necessary to define an alarm for raw/uncalibrated values that do not map to an enumeration. Implementations should implicitly define this as an alarm case, of which the manifestation of that is program/implementation specific. See EnumeratedParameterType.</documentation>
+			<appinfo>An additional check needs to be performed to ensure that the enumeration values in the alarms are valid enumeration values for the Parameter</appinfo>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:AlarmType">
+				<sequence>
+					<element name="EnumerationAlarmList" type="xtce:EnumerationAlarmListType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">List of alarm state definitions for this enumerated type.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="defaultAlarmLevel" type="xtce:ConcernLevelsType" default="normal">
+					<annotation>
+						<documentation xml:lang="en">Alarm state name for when no enumeration alarms evaluate to true. This defaults to "normal", which is almost always the case. Setting it to another alarm state permits a form of "inverted logic" where the alarm list can specify the normal states instead of the alarm states.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<simpleType name="FloatingPointNotationType">
+		<restriction base="string">
+			<enumeration value="normal"/>
+			<enumeration value="scientific"/>
+			<enumeration value="engineering"/>
+		</restriction>
+	</simpleType>
+	<complexType name="FloatRangeType">
+		<annotation>
+			<documentation xml:lang="en">Describe a floating point based range, several types of ranges are supported -- one sided and two sided, inclusive or exclusive.  It would not make sense to set two mins or maxes. Used in a number of locations related to ranges: ValidFloatRangeSetType or AlarmRangeType for example.</documentation>
+			<appinfo>Verify that the combination provided is usable.</appinfo>
+		</annotation>
+		<attribute name="minInclusive" type="double">
+			<annotation>
+				<documentation xml:lang="en">Minimum decimal/real number value including itself.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="minExclusive" type="double">
+			<annotation>
+				<documentation xml:lang="en">Minimum decimal/real number value excluding itself.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="maxInclusive" type="double">
+			<annotation>
+				<documentation xml:lang="en">Maximum decimal/real number value including itself.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="maxExclusive" type="double">
+			<annotation>
+				<documentation xml:lang="en">Maximum decimal/real number value excluding itself.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="IntegerRangeType">
+		<annotation>
+			<documentation xml:lang="en">Describe an integral based range: minInclusive and maxInclusive. Used in a number of locations related to ranges: ValidIntegerRangeSetType for example.</documentation>
+		</annotation>
+		<attribute name="minInclusive" type="long">
+			<annotation>
+				<documentation xml:lang="en">Minimum integer value including itself.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="maxInclusive" type="long">
+			<annotation>
+				<documentation xml:lang="en">Maximum integer value including itself.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="LinearAdjustmentType">
+		<annotation>
+			<documentation xml:lang="en">A slope and intercept may be applied to scale or shift the value of the parameter in the dynamic value</documentation>
+		</annotation>
+		<attribute name="slope" type="double"/>
+		<attribute name="intercept" type="double" default="0"/>
+	</complexType>
+	<complexType name="MultiRangeType">
+		<annotation>
+			<documentation xml:lang="en">The alarm multi-range element type permits users to define multiple alarm ranges in a sequence that goes beyond the more typical "inside" and "outside" range definitions. It can be thought of as a "barber pole" definition.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:FloatRangeType">
+				<attribute name="rangeForm" type="xtce:RangeFormType" default="outside">
+					<annotation>
+						<documentation xml:lang="en">A value of outside specifies that the most severe range is outside all the other ranges: -severe -critical -distress -warning -watch normal +watch +warning +distress +critical +severe. A value of inside "inverts" these bands: -green -watch -warning -distress -critical severe +critical +distress +warning +watch. The most common form used is "outside" and is the default.</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="level" type="xtce:ConcernLevelsType">
+					<annotation>
+						<documentation xml:lang="en">The level of concern for this alarm definition.</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="NumericAlarmType">
+		<annotation>
+			<documentation xml:lang="en">Describe alarm conditions specific to the numeric data types, extends the basic AlarmType with StaticAlarmRanges and ChangeAlarmRanges. See FloatParameterType and IntegerParameterType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:AlarmType">
+				<sequence>
+					<element name="StaticAlarmRanges" type="xtce:AlarmRangesType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">StaticAlarmRanges are used to trigger alarms when the parameter value passes some threshold value.</documentation>
+						</annotation>
+					</element>
+					<element name="ChangeAlarmRanges" type="xtce:ChangeAlarmRangesType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">ChangeAlarmRanges are used to trigger alarms when the parameter value changes by a rate or quantity from a reference.</documentation>
+						</annotation>
+					</element>
+					<element name="AlarmMultiRanges" type="xtce:AlarmMultiRangesType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">Similar to but more lenient form of StaticAlarmRanges.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="NumericContextAlarmType">
+		<annotation>
+			<documentation xml:lang="en">Describe a parameter dependent context, that when evaluates to true, enables the use of this alarm definition. See ContextMatchType and NumericAlarmType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:NumericAlarmType">
+				<sequence>
+					<element name="ContextMatch" type="xtce:ContextMatchType">
+						<annotation>
+							<documentation xml:lang="en">Contains the evaluation criteria for a parameter dependent test, that when evaluates to true, enables this alarm definition.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="StringAlarmLevelType">
+		<annotation>
+			<documentation xml:lang="en">Describe a string alarm condition based on matching a regular expression.  The level and regular expression are described.  The specific implementation of the regular expression syntax is not specified in the schema at this time.  See StringAlarmListType.</documentation>
+		</annotation>
+		<attribute name="alarmLevel" type="xtce:ConcernLevelsType" use="required"/>
+		<attribute name="matchPattern" type="string" use="required"/>
+	</complexType>
+	<complexType name="StringAlarmListType">
+		<annotation>
+			<documentation xml:lang="en">Describe an ordered collection of string alarms, where duplicates are valid. Evaluate the alarms in list order. The first to evaluate to true takes precedence.  See StringAlarmLevelType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="StringAlarm" type="xtce:StringAlarmLevelType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="StringAlarmType">
+		<annotation>
+			<documentation xml:lang="en">Describe alarms specific to the string data type, extends the basic AlarmType, while adding a StringAlarmList and defaultAlarmLevel attribute. The string alarm list is evaluated in list order. See ConcernsLevelsType and StringAlarmListType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:AlarmType">
+				<sequence>
+					<element name="StringAlarmList" type="xtce:StringAlarmListType" minOccurs="0"/>
+				</sequence>
+				<attribute name="defaultAlarmLevel" type="xtce:ConcernLevelsType" default="normal"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="StringContextAlarmType">
+		<annotation>
+			<documentation xml:lang="en">Describe a context that when true the alarm may be evaluated.  See ContextMatchType and StringAlarmType.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:StringAlarmType">
+				<sequence>
+					<element name="ContextMatch" type="xtce:ContextMatchType"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="StringContextAlarmListType">
+		<annotation>
+			<documentation xml:lang="en">An ordered collection of numeric alarms associated with a context. Process the contexts in list order. See StringContextAlarmType.</documentation>
+		</annotation>
+		<sequence>
+			<element name="ContextAlarm" type="xtce:StringContextAlarmType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="TimeAlarmType">
+		<annotation>
+			<documentation xml:lang="en">Alarms associated with time data types</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:AlarmType">
+				<sequence>
+					<element name="StaticAlarmRanges" type="xtce:TimeAlarmRangesType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">StaticAlarmRanges are used to trigger alarms when the parameter value passes some threshold value</documentation>
+						</annotation>
+					</element>
+					<element name="ChangePerSecondAlarmRanges" type="xtce:TimeAlarmRangesType" minOccurs="0">
+						<annotation>
+							<documentation xml:lang="en">ChangePerSecondAlarmRanges are used to trigger alarms when the parameter value's rate-of-change passes some threshold value.  An alarm condition that triggers when the value changes too fast (or too slow)</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="TimeAlarmRangesType">
+		<complexContent>
+			<extension base="xtce:AlarmRangesType">
+				<attribute name="timeUnits" type="xtce:TimeUnitsType" default="seconds"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="TimeContextAlarmListType">
+		<sequence>
+			<element name="ContextAlarm" type="xtce:TimeContextAlarmType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="TimeContextAlarmType">
+		<annotation>
+			<documentation xml:lang="en">Context alarms are applied when the ContextMatch is true.  Context alarms override Default alarms</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="xtce:TimeAlarmType">
+				<sequence>
+					<element name="ContextMatch" type="xtce:ContextMatchType"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<simpleType name="NonNegativeLongType">
+		<annotation>
+			<documentation>XTCE-specific replacement for xtce:NonNegativeLongType which more cleanly maps to native data types.</documentation>
+		</annotation>
+		<restriction base="long">
+			<minInclusive value="0"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="PositiveLongType">
+		<annotation>
+			<documentation>XTCE-specific replacement for xtce:PositiveLongType which more cleanly maps to native data types.</documentation>
+		</annotation>
+		<restriction base="long">
+			<minInclusive value="1"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="UnitFormType">
+		<annotation>
+			<documentation>Optionally specify if this information pertains to something other than the calibrated/engineering value.</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="calibrated"/>
+			<enumeration value="uncalibrated"/>
+			<enumeration value="raw"/>
+		</restriction>
+	</simpleType>
+	<!--******** End of Common Types Schema **************-->
+	<!--*************************************************************-->
+</schema>

--- a/space_packet_parser/xtce/validation.py
+++ b/space_packet_parser/xtce/validation.py
@@ -249,8 +249,30 @@ def _load_schema(schema_location: str | Path, timeout: int = 30) -> tuple[Elemen
             logger.debug(f"Using cached schema from {cache_path}")
     # Otherwise assume a local filepath
     else:
-        with Path(schema_location).open("rb") as sfh:
-            schema_content = sfh.read()
+        schema_path = Path(schema_location)
+        
+        # Reject absolute paths (CWE-73)
+        if schema_path.is_absolute():
+            raise XtceValidationError(
+                f"Absolute filesystem paths are not allowed: {schema_location}. "
+                "Use relative paths or http/https URLs."
+            )
+        
+        # Prevent path traversal (e.g., ../../../etc/passwd)
+        try:
+            resolved = schema_path.resolve()
+            if not str(resolved).startswith(str(Path.cwd().resolve())):
+                raise XtceValidationError(
+                    f"Path traversal detected. Schema path must be within current working directory: {schema_location}"
+                )
+        except Exception as e:
+            raise XtceValidationError(f"Invalid schema path: {schema_location}") from e
+        
+        try:
+            with schema_path.open("rb") as sfh:
+                schema_content = sfh.read()
+        except FileNotFoundError as e:
+            raise XtceValidationError(f"Schema file not found: {schema_location}") from e
 
     # Fix and parse the schema content
     try:
@@ -289,6 +311,11 @@ def _find_schema_url(xml_tree: ElementTree.ElementTree) -> str:
     -------
     schema_location : str
         URL of XSD
+        
+    Raises
+    ------
+    XtceValidationError
+        If schema location is invalid or missing
     """
     # Get root element
     root = xml_tree.getroot() if hasattr(xml_tree, "getroot") else xml_tree
@@ -296,12 +323,27 @@ def _find_schema_url(xml_tree: ElementTree.ElementTree) -> str:
     # Find schema location
     try:
         schema_location_attr = root.attrib.get("{http://www.w3.org/2001/XMLSchema-instance}schemaLocation")
-        return schema_location_attr.split()[-1]
+        schema_location = schema_location_attr.split()[-1]
     except Exception:
         raise XtceValidationError(
             "No 'xsi' namespace found in document. XTCE documents must declare the 'xsi' "
             "namespace for schema validation via the 'xsi:schemaLocation' attribute."
         )
+    
+    # Reject absolute filesystem paths (CWE-73)
+    if schema_location.startswith('/'):
+        raise XtceValidationError(
+            f"Absolute filesystem paths are not allowed in xsi:schemaLocation: {schema_location}"
+        )
+    
+    # Only allow http/https URLs (CWE-918)
+    parsed = urlparse(schema_location)
+    if parsed.scheme and parsed.scheme not in ('http', 'https'):
+        raise XtceValidationError(
+            f"Only http and https URLs are allowed in xsi:schemaLocation. Got: {parsed.scheme}"
+        )
+    
+    return schema_location
 
 
 def _validate_xtce_schema(
@@ -357,7 +399,7 @@ def _validate_xtce_schema(
             for error in schema.error_log:
                 if "No matching global declaration available for the validation root." in error.message:
                     result.add_error(
-                        message="Namespace issue detected. Does the `xmlns[:xtce]=<chosen_xtce_uri>` URI on your document root element match the `targetNamespace` URI in your XSD? Typically this is http://www.omg.org/spec/XTCE/20180204.",
+                        message="Namespace issue detected. Does the `xmlns[:xtce]=<chosen_xtce_uri>` URI on your document root element match the `targetNamespace` URI in your XSD? Typically this [...]
                         error_code="INVALID_XTCE_NAMESPACE",
                         context={
                             "nsmap": xml_tree.getroot().nsmap,

--- a/space_packet_parser/xtce/validation.py
+++ b/space_packet_parser/xtce/validation.py
@@ -250,14 +250,13 @@ def _load_schema(schema_location: str | Path, timeout: int = 30) -> tuple[Elemen
     # Otherwise assume a local filepath
     else:
         schema_path = Path(schema_location)
-        
+
         # Reject absolute paths (CWE-73)
         if schema_path.is_absolute():
             raise XtceValidationError(
-                f"Absolute filesystem paths are not allowed: {schema_location}. "
-                "Use relative paths or http/https URLs."
+                f"Absolute filesystem paths are not allowed: {schema_location}. Use relative paths or http/https URLs."
             )
-        
+
         # Prevent path traversal (e.g., ../../../etc/passwd)
         try:
             resolved = schema_path.resolve()
@@ -267,7 +266,7 @@ def _load_schema(schema_location: str | Path, timeout: int = 30) -> tuple[Elemen
                 )
         except Exception as e:
             raise XtceValidationError(f"Invalid schema path: {schema_location}") from e
-        
+
         try:
             with schema_path.open("rb") as sfh:
                 schema_content = sfh.read()
@@ -311,7 +310,7 @@ def _find_schema_url(xml_tree: ElementTree.ElementTree) -> str:
     -------
     schema_location : str
         URL of XSD
-        
+
     Raises
     ------
     XtceValidationError
@@ -329,20 +328,16 @@ def _find_schema_url(xml_tree: ElementTree.ElementTree) -> str:
             "No 'xsi' namespace found in document. XTCE documents must declare the 'xsi' "
             "namespace for schema validation via the 'xsi:schemaLocation' attribute."
         )
-    
+
     # Reject absolute filesystem paths (CWE-73)
-    if schema_location.startswith('/'):
-        raise XtceValidationError(
-            f"Absolute filesystem paths are not allowed in xsi:schemaLocation: {schema_location}"
-        )
-    
+    if schema_location.startswith("/"):
+        raise XtceValidationError(f"Absolute filesystem paths are not allowed in xsi:schemaLocation: {schema_location}")
+
     # Only allow http/https URLs (CWE-918)
     parsed = urlparse(schema_location)
-    if parsed.scheme and parsed.scheme not in ('http', 'https'):
-        raise XtceValidationError(
-            f"Only http and https URLs are allowed in xsi:schemaLocation. Got: {parsed.scheme}"
-        )
-    
+    if parsed.scheme and parsed.scheme not in ("http", "https"):
+        raise XtceValidationError(f"Only http and https URLs are allowed in xsi:schemaLocation. Got: {parsed.scheme}")
+
     return schema_location
 
 
@@ -380,7 +375,7 @@ def _validate_xtce_schema(
                 except ValueError:
                     # If path is not relative to cwd, try using just the filename
                     xsd_path = Path(xsd_path.name)
-            schema_location = str(xsd_path) 
+            schema_location = str(xsd_path)
         else:
             try:
                 # Find the URL of the XSD

--- a/space_packet_parser/xtce/validation.py
+++ b/space_packet_parser/xtce/validation.py
@@ -399,7 +399,7 @@ def _validate_xtce_schema(
             for error in schema.error_log:
                 if "No matching global declaration available for the validation root." in error.message:
                     result.add_error(
-                        message="Namespace issue detected. Does the `xmlns[:xtce]=<chosen_xtce_uri>` URI on your document root element match the `targetNamespace` URI in your XSD? Typically this [...]
+                        message="Namespace issue detected. Does the `xmlns[:xtce]=<chosen_xtce_uri>` URI on your document root element match the `targetNamespace` URI in your XSD? Typically this is http://www.omg.org/spec/XTCE/20180204
                         error_code="INVALID_XTCE_NAMESPACE",
                         context={
                             "nsmap": xml_tree.getroot().nsmap,

--- a/space_packet_parser/xtce/validation.py
+++ b/space_packet_parser/xtce/validation.py
@@ -399,7 +399,7 @@ def _validate_xtce_schema(
             for error in schema.error_log:
                 if "No matching global declaration available for the validation root." in error.message:
                     result.add_error(
-                        message="Namespace issue detected. Does the `xmlns[:xtce]=<chosen_xtce_uri>` URI on your document root element match the `targetNamespace` URI in your XSD? Typically this is http://www.omg.org/spec/XTCE/20180204
+                        message="Namespace issue detected. Does the `xmlns[:xtce]=<chosen_xtce_uri>` URI on your document root element match the `targetNamespace` URI in your XSD? Typically this is http://www.omg.org/spec/XTCE/20180204 .",
                         error_code="INVALID_XTCE_NAMESPACE",
                         context={
                             "nsmap": xml_tree.getroot().nsmap,

--- a/space_packet_parser/xtce/validation.py
+++ b/space_packet_parser/xtce/validation.py
@@ -372,16 +372,15 @@ def _validate_xtce_schema(
 
     try:
         if local_xsd:
-    # Convert to Path object if string, then make relative to current directory if absolute
-    xsd_path = Path(local_xsd) if isinstance(local_xsd, str) else local_xsd
-    if xsd_path.is_absolute():
-        try:
-            xsd_path = xsd_path.relative_to(Path.cwd())
-        except ValueError:
-            # If path is not relative to cwd, try using just the filename
-            xsd_path = Path(xsd_path.name)
-    schema_location = str(xsd_path)
-            schema_location = str(local_xsd)
+            # Convert to Path object if string, then make relative to current directory if absolute
+            xsd_path = Path(local_xsd) if isinstance(local_xsd, str) else local_xsd
+            if xsd_path.is_absolute():
+                try:
+                    xsd_path = xsd_path.relative_to(Path.cwd())
+                except ValueError:
+                    # If path is not relative to cwd, try using just the filename
+                    xsd_path = Path(xsd_path.name)
+            schema_location = str(xsd_path) 
         else:
             try:
                 # Find the URL of the XSD

--- a/space_packet_parser/xtce/validation.py
+++ b/space_packet_parser/xtce/validation.py
@@ -372,7 +372,15 @@ def _validate_xtce_schema(
 
     try:
         if local_xsd:
-            # TODO: Load the XSD from local file
+    # Convert to Path object if string, then make relative to current directory if absolute
+    xsd_path = Path(local_xsd) if isinstance(local_xsd, str) else local_xsd
+    if xsd_path.is_absolute():
+        try:
+            xsd_path = xsd_path.relative_to(Path.cwd())
+        except ValueError:
+            # If path is not relative to cwd, try using just the filename
+            xsd_path = Path(xsd_path.name)
+    schema_location = str(xsd_path)
             schema_location = str(local_xsd)
         else:
             try:

--- a/space_packet_parser/xtce/validation.py
+++ b/space_packet_parser/xtce/validation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import logging
 import os
 import platform
@@ -18,6 +19,29 @@ from urllib.request import urlopen
 import lxml.etree as ElementTree
 
 logger = logging.getLogger(__name__)
+
+# Directory holding XSD schemas bundled with the package. Bundled schemas are
+# resolved offline (no network request) which is both faster and closes the
+# SSRF/LFI surface for the common case of validating against the standard XTCE schema.
+_BUNDLED_SCHEMA_DIR = Path(__file__).parent / "schemas"
+
+# Maps a scheme-insensitive "host/path" key to a bundled schema filename. Any
+# schemaLocation URL (http or https) whose host+path matches is served from disk.
+_BUNDLED_SCHEMAS: dict[str, str] = {
+    "www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd": "SpaceSystem.xsd",
+}
+
+# Default allowlist of hosts that schema URLs may point at. Exported so callers
+# can extend it explicitly, e.g. allowed_schema_hosts=[*DEFAULT_ALLOWED_SCHEMA_HOSTS, "my-mirror"].
+DEFAULT_ALLOWED_SCHEMA_HOSTS = frozenset({"www.omg.org"})
+
+# Environment-variable overrides for the schema-fetch policy.
+ALLOWED_SCHEMA_HOSTS_ENV_VAR = "SPP_ALLOWED_SCHEMA_HOSTS"
+ALLOW_INSECURE_HTTP_ENV_VAR = "SPP_ALLOW_INSECURE_HTTP"
+
+# Hard cap on downloaded schema size to bound memory use and disk writes from a
+# hostile or misbehaving host. XTCE schemas are a few hundred KB.
+MAX_SCHEMA_BYTES = 10 * 1024 * 1024
 
 
 class ValidationLevel(Enum):
@@ -102,9 +126,17 @@ class ValidationResult:
 class XtceValidationError(Exception):
     """Exception raised during XTCE validation."""
 
-    def __init__(self, message: str, validation_result: ValidationResult | None = None):
+    def __init__(
+        self,
+        message: str,
+        validation_result: ValidationResult | None = None,
+        error_code: str | None = None,
+    ):
         super().__init__(message)
         self.validation_result = validation_result
+        # Optional machine-readable code so callers (e.g. _validate_xtce_schema) can map
+        # the failure onto the correct ValidationResult error_code instead of a generic one.
+        self.error_code = error_code
 
 
 def _get_cache_dir() -> Path:
@@ -156,10 +188,19 @@ def _read_from_cache(cache_path: Path) -> bytes | None:
 
 
 def _write_to_cache(cache_path: Path, content: bytes) -> None:
-    """Write content to cache, creating directories as needed."""
+    """Write content to cache, creating directories as needed.
+
+    The cache directory and file are created with owner-only permissions so cached schemas are
+    not world-readable on shared hosts. The cache filename is a SHA-256 hash of the URL, so no
+    user-controlled component reaches the filesystem path (no traversal is possible).
+    """
     try:
-        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         cache_path.write_bytes(content)
+        try:
+            cache_path.chmod(0o600)
+        except OSError as e:
+            logger.debug(f"Could not set cache file permissions on {cache_path}: {e}")
         logger.debug(f"Cached schema to {cache_path}")
     except OSError as e:
         logger.warning(f"Failed to write schema to cache {cache_path}: {e}")
@@ -203,99 +244,275 @@ def _fix_known_schema_issues(schema_content: bytes) -> bytes:
     return content_str.encode("utf-8")
 
 
-def _load_schema(schema_location: str | Path, timeout: int = 30) -> tuple[ElementTree.XMLSchema, str]:
-    """Load XSD schema from URL or local path
+def _resolve_schema_policy(
+    allowed_schema_hosts: list[str] | tuple[str, ...] | frozenset[str] | None,
+    allow_insecure_http: bool,
+) -> tuple[frozenset[str], bool]:
+    """Resolve the effective schema-fetch policy from argument, environment, then default.
 
-    Parameters
-    ----------
-    schema_location : Union[str, Path]
-        URL or local path to the XSD schema document
-    timeout : int
-        Timeout in seconds for URL downloads
-
-    Returns
-    -------
-    : tuple[ElementTree.XMLSchema, str]
-        Parsed XMLSchema object and version string
-
-    Raises
-    ------
-    XtceValidationError
-        If schema cannot be loaded or parsed
+    The explicit argument wins; otherwise the environment variable is consulted; otherwise the
+    built-in default is used. Layers replace (do not merge) so the effective allowlist is always
+    whatever the most specific layer specifies.
     """
-
-    def _is_http_url(s):
-        result = urlparse(s)
-        return result if all([result.scheme in ("http", "https"), result.netloc]) else False
-
-    parser = ElementTree.XMLParser(recover=True)
-
-    # If the location is a string that parses as a URL
-    if isinstance(schema_location, str) and (_is_http_url(schema_location)):
-        # Check cache first
-        cache_path = _get_cache_path(schema_location)
-        schema_content = _read_from_cache(cache_path)
-
-        if schema_content is None:
-            # Cache miss - download from URL
-            try:
-                with urlopen(schema_location, timeout=timeout) as response:  # noqa: S310
-                    schema_content = response.read()
-                # Cache the raw downloaded content before any fixes
-                _write_to_cache(cache_path, schema_content)
-            except (TimeoutError, URLError) as e:
-                raise XtceValidationError(f"Failed to download schema from {schema_location}: {e}") from e
-        else:
-            logger.debug(f"Using cached schema from {cache_path}")
-    # Otherwise assume a local filepath
+    if allowed_schema_hosts is not None:
+        allowed = frozenset(str(h).strip() for h in allowed_schema_hosts if str(h).strip())
     else:
-        schema_path = Path(schema_location)
+        env_hosts = os.environ.get(ALLOWED_SCHEMA_HOSTS_ENV_VAR)
+        if env_hosts:
+            allowed = frozenset(h.strip() for h in env_hosts.split(",") if h.strip())
+        else:
+            allowed = DEFAULT_ALLOWED_SCHEMA_HOSTS
 
-        # Reject absolute paths (CWE-73)
-        if schema_path.is_absolute():
-            raise XtceValidationError(
-                f"Absolute filesystem paths are not allowed: {schema_location}. Use relative paths or http/https URLs."
-            )
+    if not allow_insecure_http:
+        env_http = os.environ.get(ALLOW_INSECURE_HTTP_ENV_VAR, "")
+        allow_insecure_http = env_http.strip().lower() in ("1", "true", "yes", "on")
 
-        # Prevent path traversal (e.g., ../../../etc/passwd)
-        try:
-            resolved = schema_path.resolve()
-            if not str(resolved).startswith(str(Path.cwd().resolve())):
-                raise XtceValidationError(
-                    f"Path traversal detected. Schema path must be within current working directory: {schema_location}"
-                )
-        except Exception as e:
-            raise XtceValidationError(f"Invalid schema path: {schema_location}") from e
+    return allowed, allow_insecure_http
 
-        try:
-            with schema_path.open("rb") as sfh:
-                schema_content = sfh.read()
-        except FileNotFoundError as e:
-            raise XtceValidationError(f"Schema file not found: {schema_location}") from e
 
-    # Fix and parse the schema content
+def _bundled_schema_path(schema_location: str) -> Path | None:
+    """Return the on-disk path of a bundled schema matching a URL, or None if there is no match.
+
+    Matching is scheme-insensitive (http and https map to the same bundled file) and keyed on host+path.
+    """
+    parsed = urlparse(schema_location)
+    if parsed.scheme not in ("http", "https"):
+        return None
+    key = f"{parsed.netloc.lower()}{parsed.path}"
+    filename = _BUNDLED_SCHEMAS.get(key)
+    if filename is None:
+        return None
+    return _BUNDLED_SCHEMA_DIR / filename
+
+
+def _reject_internal_host(host: str | None, schema_location: str) -> None:
+    """Reject a schema URL whose host is a non-public IP literal (SSRF hardening, CWE-918).
+
+    Only IP literals are inspected here; hostnames are governed by the allowlist. This
+    deterministically blocks the metadata-endpoint and loopback PoCs (169.254.169.254, 127.0.0.1)
+    which are expressed as literal IPs. A hostname that resolves to an internal address (DNS
+    rebinding) is out of scope for this check and is constrained instead by the host allowlist.
+    """
+    if not host:
+        return
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return  # Not an IP literal; the host allowlist is the control for hostnames.
+    if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified:
+        raise XtceValidationError(
+            f"Schema URL host {host} is a non-public address and is not allowed: {schema_location}",
+            error_code="DISALLOWED_SCHEMA_LOCATION",
+        )
+
+
+def _normalize_url(url: str) -> str:
+    """Normalize a URL for allowlist comparison (lowercase scheme+host, keep path)."""
+    parsed = urlparse(url)
+    return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}{parsed.path}"
+
+
+def _url_matches_allowlist(schema_location: str, parsed_host: str | None, allowed_hosts: frozenset[str]) -> bool:
+    """Return True if the URL matches an allowlist entry.
+
+    An allowlist entry containing '://' is matched as an exact (normalized) URL; a bare entry is
+    matched against the URL's hostname. Matching is exact — never a suffix/substring test.
+    """
+    host = (parsed_host or "").lower()
+    normalized = _normalize_url(schema_location)
+    for entry in allowed_hosts:
+        entry = entry.strip()
+        if not entry:
+            continue
+        if "://" in entry:
+            if _normalize_url(entry) == normalized:
+                return True
+        elif entry.lower() == host:
+            return True
+    return False
+
+
+def _enforce_schema_url_policy(schema_location: str, allowed_hosts: frozenset[str], allow_insecure_http: bool) -> None:
+    """Enforce scheme, internal-host, and allowlist policy on an outbound schema URL (CWE-918)."""
+    parsed = urlparse(schema_location)
+    allowed_schemes = ("https", "http") if allow_insecure_http else ("https",)
+    if parsed.scheme not in allowed_schemes:
+        allowed_desc = "http or https" if allow_insecure_http else "https"
+        raise XtceValidationError(
+            f"Schema URL scheme '{parsed.scheme}' is not allowed (only {allowed_desc}): {schema_location}",
+            error_code="DISALLOWED_SCHEMA_LOCATION",
+        )
+    _reject_internal_host(parsed.hostname, schema_location)
+    if not _url_matches_allowlist(schema_location, parsed.hostname, allowed_hosts):
+        raise XtceValidationError(
+            f"Schema URL is not in the allowlist {sorted(allowed_hosts)}: {schema_location}. "
+            f"Add the host/URL via allowed_schema_hosts or {ALLOWED_SCHEMA_HOSTS_ENV_VAR}, or pass local_xsd.",
+            error_code="DISALLOWED_SCHEMA_LOCATION",
+        )
+
+
+def _parse_schema_content(schema_content: bytes, source: str) -> tuple[ElementTree.XMLSchema, str]:
+    """Parse raw XSD bytes into an XMLSchema, applying known-issue fixes if the first parse fails.
+
+    Raises XtceValidationError (error_code SCHEMA_LOAD_ERROR) if the content is not a usable XSD.
+    """
+    parser = ElementTree.XMLParser(recover=True)
     try:
         schema_root_element = ElementTree.XML(schema_content, parser)
     except ElementTree.XMLSyntaxError as e:
-        raise XtceValidationError(f"Failed to parse XSD schema from {schema_location}: {e}") from e
+        raise XtceValidationError(
+            f"Failed to parse XSD schema from {source}: {e}", error_code="SCHEMA_LOAD_ERROR"
+        ) from e
 
     try:
         return ElementTree.XMLSchema(schema_root_element), schema_root_element.get("version", "unknown")
     except ElementTree.XMLSchemaError as e:
-        # Try to fix known issues
         logger.debug("Attempting to fix known XTCE schema problems")
         fixed_content = _fix_known_schema_issues(schema_content)
-
         if fixed_content != schema_content:
             try:
-                schema_root_element = ElementTree.XML(fixed_content, parser)
-                return ElementTree.XMLSchema(schema_root_element), schema_root_element.get("version", "unknown")
+                fixed_root = ElementTree.XML(fixed_content, parser)
+                return ElementTree.XMLSchema(fixed_root), fixed_root.get("version", "unknown")
             except ElementTree.XMLSchemaError:
-                pass  # Fall through to raise original error
-
+                pass  # Fall through to raise the original error
         raise XtceValidationError(
-            f"Invalid XSD schema from {schema_location} (attempted to fix known errors): {e}"
+            f"Invalid XSD schema from {source} (attempted to fix known errors): {e}",
+            error_code="SCHEMA_LOAD_ERROR",
         ) from e
+
+
+def _download_schema(schema_location: str, timeout: int) -> tuple[ElementTree.XMLSchema, str]:
+    """Download, size-cap, validate, and cache a schema URL that has already passed policy checks.
+
+    The raw downloaded bytes are written to the cache only after they successfully validate as an
+    XSD, so a non-schema response (e.g. an SSRF probe body or error page) is never persisted.
+    """
+    cache_path = _get_cache_path(schema_location)
+    cached = _read_from_cache(cache_path)
+    if cached is not None:
+        logger.debug(f"Using cached schema from {cache_path}")
+        return _parse_schema_content(cached, schema_location)
+
+    try:
+        with urlopen(schema_location, timeout=timeout) as response:  # noqa: S310
+            declared = response.headers.get("Content-Length")
+            if declared is not None:
+                try:
+                    declared_size = int(declared)
+                except (ValueError, TypeError):
+                    declared_size = None
+                if declared_size is not None and declared_size > MAX_SCHEMA_BYTES:
+                    raise XtceValidationError(
+                        f"Schema at {schema_location} exceeds the maximum allowed size ({MAX_SCHEMA_BYTES} bytes).",
+                        error_code="SCHEMA_LOAD_ERROR",
+                    )
+            # Read one byte past the cap so an oversized body with a missing/incorrect
+            # Content-Length is still detected below.
+            schema_content = response.read(MAX_SCHEMA_BYTES + 1)
+    except (TimeoutError, URLError) as e:
+        raise XtceValidationError(
+            f"Failed to download schema from {schema_location}: {e}", error_code="SCHEMA_LOAD_ERROR"
+        ) from e
+
+    if len(schema_content) > MAX_SCHEMA_BYTES:
+        raise XtceValidationError(
+            f"Schema at {schema_location} exceeds the maximum allowed size ({MAX_SCHEMA_BYTES} bytes).",
+            error_code="SCHEMA_LOAD_ERROR",
+        )
+
+    schema, version = _parse_schema_content(schema_content, schema_location)
+    # Only cache content that validated as an XSD.
+    _write_to_cache(cache_path, schema_content)
+    return schema, version
+
+
+def _load_schema(
+    schema_location: str | Path,
+    timeout: int = 30,
+    *,
+    allowed_schema_hosts: list[str] | tuple[str, ...] | frozenset[str] | None = None,
+    allow_insecure_http: bool = False,
+    allow_schema_download: bool = True,
+    trusted: bool = False,
+) -> tuple[ElementTree.XMLSchema, str]:
+    """Load an XSD schema from a bundled schema, an http(s) URL, or a trusted local path.
+
+    Resolution order:
+      1. If ``schema_location`` matches a schema bundled with the package, it is read from disk
+         with no network request or policy check (it is a trusted, package-owned file).
+      2. If it is an http(s) URL, the SSRF policy (scheme, internal-host, allowlist) is enforced
+         and, unless disabled, the schema is downloaded (size-capped) and cached.
+      3. If it is a local filesystem path, it is opened only when ``trusted=True`` (i.e. an
+         operator-supplied ``local_xsd``); document-derived local paths are refused (CWE-73).
+
+    Parameters
+    ----------
+    schema_location : Union[str, Path]
+        URL or local path to the XSD schema document.
+    timeout : int
+        Timeout in seconds for URL downloads.
+    allowed_schema_hosts : Optional collection of str
+        Hosts and/or exact URLs that schema downloads may target. None resolves via environment,
+        then the built-in default (``www.omg.org``).
+    allow_insecure_http : bool
+        If True, permit ``http`` URLs in addition to ``https``. Dangerous; off by default.
+    allow_schema_download : bool
+        If False, never make a network request (bundled schemas and local paths still work).
+    trusted : bool
+        If True, a local filesystem path may be opened directly (used for operator-supplied local_xsd).
+
+    Returns
+    -------
+    : tuple[ElementTree.XMLSchema, str]
+        Parsed XMLSchema object and version string.
+
+    Raises
+    ------
+    XtceValidationError
+        If the schema cannot be loaded, is disallowed by policy, or cannot be parsed.
+    """
+    location = str(schema_location)
+
+    # 1. Bundled schema (offline, no policy needed — it is our own file).
+    bundled = _bundled_schema_path(location)
+    if bundled is not None:
+        try:
+            content = bundled.read_bytes()
+        except OSError as e:
+            raise XtceValidationError(
+                f"Failed to read bundled schema {bundled}: {e}", error_code="SCHEMA_LOAD_ERROR"
+            ) from e
+        return _parse_schema_content(content, location)
+
+    is_url = urlparse(location).scheme in ("http", "https")
+
+    # 2. Remote URL: enforce SSRF policy, then cache/download.
+    if is_url:
+        if not allow_schema_download:
+            raise XtceValidationError(
+                f"Schema download is disabled and no bundled schema matches: {location}. "
+                "Pass local_xsd, or enable allow_schema_download.",
+                error_code="SCHEMA_LOAD_ERROR",
+            )
+        allowed_hosts, allow_insecure_http = _resolve_schema_policy(allowed_schema_hosts, allow_insecure_http)
+        _enforce_schema_url_policy(location, allowed_hosts, allow_insecure_http)
+        return _download_schema(location, timeout)
+
+    # 3. Local filesystem path: only trusted (operator-supplied) paths may be opened.
+    if not trusted:
+        raise XtceValidationError(
+            f"Refusing to load a schema from an untrusted local path: {location}. "
+            "Document-supplied xsi:schemaLocation must be an allowlisted http(s) URL; "
+            "use local_xsd to validate against a local schema.",
+            error_code="DISALLOWED_SCHEMA_LOCATION",
+        )
+    try:
+        content = Path(location).read_bytes()
+    except OSError as e:
+        raise XtceValidationError(
+            f"Schema file not found or unreadable: {location}", error_code="SCHEMA_LOAD_ERROR"
+        ) from e
+    return _parse_schema_content(content, location)
 
 
 def _find_schema_url(xml_tree: ElementTree.ElementTree) -> str:
@@ -326,17 +543,21 @@ def _find_schema_url(xml_tree: ElementTree.ElementTree) -> str:
     except Exception:
         raise XtceValidationError(
             "No 'xsi' namespace found in document. XTCE documents must declare the 'xsi' "
-            "namespace for schema validation via the 'xsi:schemaLocation' attribute."
+            "namespace for schema validation via the 'xsi:schemaLocation' attribute.",
+            error_code="MISSING_SCHEMA_LOCATION",
         )
 
-    # Reject absolute filesystem paths (CWE-73)
-    if schema_location.startswith("/"):
-        raise XtceValidationError(f"Absolute filesystem paths are not allowed in xsi:schemaLocation: {schema_location}")
-
-    # Only allow http/https URLs (CWE-918)
-    parsed = urlparse(schema_location)
-    if parsed.scheme and parsed.scheme not in ("http", "https"):
-        raise XtceValidationError(f"Only http and https URLs are allowed in xsi:schemaLocation. Got: {parsed.scheme}")
+    # A document-supplied location is untrusted. Anything that is not an http(s) URL is treated as
+    # a local filesystem reference and rejected to prevent local file disclosure (CWE-73). This
+    # covers absolute POSIX/Windows/UNC paths, relative paths, bare filenames, and non-http schemes
+    # such as file:// and ftp://. Host/scheme allowlist policy is enforced later, at load time,
+    # after bundled-schema resolution.
+    if urlparse(schema_location).scheme not in ("http", "https"):
+        raise XtceValidationError(
+            f"xsi:schemaLocation must be an http(s) URL, got: {schema_location!r}. "
+            "To validate against a local schema, pass local_xsd explicitly.",
+            error_code="DISALLOWED_SCHEMA_LOCATION",
+        )
 
     return schema_location
 
@@ -345,6 +566,9 @@ def _validate_xtce_schema(
     xml_tree: ElementTree.ElementTree,
     local_xsd: str | Path | None = None,
     timeout: int = 30,
+    allowed_schema_hosts: list[str] | tuple[str, ...] | frozenset[str] | None = None,
+    allow_insecure_http: bool = False,
+    allow_schema_download: bool = True,
 ) -> ValidationResult:
     """Validate XML document against XSD schema.
 
@@ -354,8 +578,16 @@ def _validate_xtce_schema(
         XTCE XML tree object
     local_xsd : Optional[Union[str, Path]]
         Optional local schema location. If specified, schema references in root element (or lack thereof) are ignored.
+        This is a trusted, caller-supplied path and is opened directly regardless of location.
     timeout : int
         Timeout in seconds for schema downloads
+    allowed_schema_hosts : Optional collection of str
+        Hosts and/or exact URLs that document-derived schema downloads may target.
+    allow_insecure_http : bool
+        If True, permit ``http`` schema URLs in addition to ``https``. Dangerous; off by default.
+    allow_schema_download : bool
+        If True (default), allowlisted schema URLs may be downloaded. If False, only bundled schemas
+        and ``local_xsd`` are used.
 
     Returns
     -------
@@ -367,32 +599,39 @@ def _validate_xtce_schema(
 
     try:
         if local_xsd:
-            # Convert to Path object if string, then make relative to current directory if absolute
-            xsd_path = Path(local_xsd) if isinstance(local_xsd, str) else local_xsd
-            if xsd_path.is_absolute():
-                try:
-                    xsd_path = xsd_path.relative_to(Path.cwd())
-                except ValueError:
-                    # If path is not relative to cwd, try using just the filename
-                    xsd_path = Path(xsd_path.name)
-            schema_location = str(xsd_path)
+            # local_xsd is trusted, caller-supplied input: open it directly, at whatever path
+            # (absolute or relative) the caller provided. No confinement is applied because this
+            # is not the attacker-controlled surface (unlike document-derived xsi:schemaLocation).
+            schema_location = str(local_xsd)
+            trusted = True
         else:
             try:
-                # Find the URL of the XSD
+                # Find the (untrusted) schema URL declared in the document
                 schema_location = _find_schema_url(xml_tree)
             except XtceValidationError as no_schema_location_err:
-                result.add_error(message=str(no_schema_location_err), error_code="MISSING_SCHEMA_LOCATION")
+                result.add_error(
+                    message=str(no_schema_location_err),
+                    error_code=no_schema_location_err.error_code or "MISSING_SCHEMA_LOCATION",
+                )
                 return result
+            trusted = False
 
         # Store schema location in result
         result.schema_location = schema_location
 
         # Load the schema
         try:
-            schema, version = _load_schema(schema_location, timeout)
+            schema, version = _load_schema(
+                schema_location,
+                timeout,
+                allowed_schema_hosts=allowed_schema_hosts,
+                allow_insecure_http=allow_insecure_http,
+                allow_schema_download=allow_schema_download,
+                trusted=trusted,
+            )
             result.schema_version = version
         except XtceValidationError as e:
-            result.add_error(str(e), "SCHEMA_LOAD_ERROR")
+            result.add_error(str(e), e.error_code or "SCHEMA_LOAD_ERROR")
             return result
 
         # Validate the document
@@ -401,7 +640,7 @@ def _validate_xtce_schema(
             for error in schema.error_log:
                 if "No matching global declaration available for the validation root." in error.message:
                     result.add_error(
-                        message="Namespace issue detected. Does the `xmlns[:xtce]=<chosen_xtce_uri>` URI on your document root element match the `targetNamespace` URI in your XSD? Typically this is http://www.omg.org/spec/XTCE/20180204 .",
+                        message="Namespace issue detected. Does the `xmlns[:xtce]=<chosen_xtce_uri>` URI on your document root element match the `targetNamespace` URI in your XSD? Typically this is http://www.omg.org/spec/XTCE/20180204",
                         error_code="INVALID_XTCE_NAMESPACE",
                         context={
                             "nsmap": xml_tree.getroot().nsmap,
@@ -545,6 +784,9 @@ def validate_xtce(
     print_results: bool = True,
     raise_on_error: bool = True,
     local_xsd: str | Path | None = None,
+    allowed_schema_hosts: list[str] | tuple[str, ...] | frozenset[str] | None = None,
+    allow_insecure_http: bool = False,
+    allow_schema_download: bool = True,
 ) -> ValidationResult:
     """Validate an XTCE XML document.
 
@@ -566,7 +808,23 @@ def validate_xtce(
         If True, raises an exception unless the ValidationResult reports valid.
     local_xsd : Optional[str, Path]
         Local path to an XSD for schema validation. If not provided and schema validation is requested,
-        XSD is retrieved from schema reference attribute in document root.
+        XSD is retrieved from schema reference attribute in document root. This is a trusted,
+        caller-supplied path and may point anywhere on the filesystem.
+    allowed_schema_hosts : Optional collection of str
+        Hosts and/or exact URLs that a document-derived ``xsi:schemaLocation`` download may target.
+        Entries may be bare hostnames (matched against the URL host) or full URLs (matched exactly).
+        Defaults to :data:`DEFAULT_ALLOWED_SCHEMA_HOSTS` (``www.omg.org``); the
+        ``SPP_ALLOWED_SCHEMA_HOSTS`` environment variable (comma-separated) is consulted when this
+        argument is not provided. Bundled schemas and ``local_xsd`` are not subject to this allowlist.
+    allow_insecure_http : bool
+        DANGEROUS. If True, permit ``http`` schema URLs in addition to ``https``. This fetches schema
+        content over an unauthenticated, tamperable channel and should only be used for trusted
+        internal mirrors. The host allowlist and internal-address guard still apply. Off by default;
+        may also be enabled via the ``SPP_ALLOW_INSECURE_HTTP`` environment variable.
+    allow_schema_download : bool
+        Default True. If True, allowlisted schema URLs referenced by the document may be downloaded.
+        If False, no network request is made: only schemas bundled with the package or supplied via
+        ``local_xsd`` are used.
 
     Returns
     -------
@@ -596,14 +854,28 @@ def validate_xtce(
         ) from e
 
     if validation_level == ValidationLevel.SCHEMA:
-        result = _validate_xtce_schema(xml_tree, local_xsd=local_xsd, timeout=timeout)
+        result = _validate_xtce_schema(
+            xml_tree,
+            local_xsd=local_xsd,
+            timeout=timeout,
+            allowed_schema_hosts=allowed_schema_hosts,
+            allow_insecure_http=allow_insecure_http,
+            allow_schema_download=allow_schema_download,
+        )
 
     elif validation_level == ValidationLevel.STRUCTURE:
         result = _validate_xtce_structure(xml_tree)
 
     elif validation_level == ValidationLevel.ALL:
         # Perform both validations
-        schema_result = _validate_xtce_schema(xml_tree, local_xsd=local_xsd, timeout=timeout)
+        schema_result = _validate_xtce_schema(
+            xml_tree,
+            local_xsd=local_xsd,
+            timeout=timeout,
+            allowed_schema_hosts=allowed_schema_hosts,
+            allow_insecure_http=allow_insecure_http,
+            allow_schema_download=allow_schema_download,
+        )
 
         # Try structural validation even if schema fails
         structure_result = _validate_xtce_structure(xml_tree)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from lxml import etree
@@ -63,3 +64,40 @@ def suda_test_data_dir(test_data_dir):
 def idex_test_data_dir(test_data_dir):
     """IDEX test data directory"""
     return test_data_dir / "idex"
+
+
+@pytest.fixture
+def mock_schema_download(test_data_dir):
+    """Mock urlopen to return local XSD content instead of downloading from the network.
+
+    Shared by unit and integration tests. Note: documents that reference the standard OMG
+    schema URL are now served from the bundled schema without any network call, so this mock
+    is only exercised for non-bundled URLs.
+    """
+    local_xsd_path = test_data_dir / "SpaceSystem.xsd"
+
+    def mock_urlopen(url, timeout=None):
+        """Mock urlopen that returns local XSD content."""
+
+        class MockResponse:
+            def __init__(self, content):
+                self.content = content
+                self.headers = {}
+
+            def read(self, *args):
+                return self.content
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        # Read the local XSD file
+        with local_xsd_path.open("rb") as f:
+            content = f.read()
+
+        return MockResponse(content)
+
+    with patch("space_packet_parser.xtce.validation.urlopen", side_effect=mock_urlopen):
+        yield

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -6,6 +6,8 @@ from click.testing import CliRunner
 
 from space_packet_parser import cli
 
+from tests.unit.test_xtce.test_validation import mock_schema_download
+
 
 def test_cli():
     runner = CliRunner()
@@ -77,9 +79,9 @@ def test_log_level():
     print(result.output)
     assert result.exit_code == 0
 
-
-def test_validate_xtce(test_data_dir):
+def test_validate_xtce(test_data_dir, mock_schema_download):
     runner = CliRunner()
+    _ = mock_schema_download
     print()
 
     # Test basic validation

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -6,8 +6,6 @@ from click.testing import CliRunner
 
 from space_packet_parser import cli
 
-from tests.unit.test_xtce.test_validation import mock_schema_download
-
 
 def test_cli():
     runner = CliRunner()
@@ -78,6 +76,7 @@ def test_log_level():
     result = runner.invoke(cli.spp, ["describe-packets", "--help"])
     print(result.output)
     assert result.exit_code == 0
+
 
 def test_validate_xtce(test_data_dir, mock_schema_download):
     runner = CliRunner()

--- a/tests/unit/test_xtce/test_validation.py
+++ b/tests/unit/test_xtce/test_validation.py
@@ -456,3 +456,96 @@ def test_schema_caching_mechanism(test_data_dir):
                 # Both schemas should be XMLSchema objects
                 assert isinstance(schema1, ElementTree.XMLSchema)
                 assert isinstance(schema2, ElementTree.XMLSchema)
+
+
+def test_load_schema_rejects_absolute_paths(test_data_dir):
+    """Test that _load_schema rejects absolute filesystem paths"""
+    local_xsd_path = test_data_dir / "SpaceSystem.xsd"
+    absolute_path = str(local_xsd_path.resolve())
+    
+    with pytest.raises(XtceValidationError, match="Absolute filesystem paths are not allowed"):
+        _load_schema(absolute_path)
+
+
+def test_load_schema_rejects_path_traversal(tmp_path):
+    """Test that _load_schema rejects path traversal attacks"""
+    # Create a dummy file outside the current directory
+    outside_file = tmp_path / "outside.xsd"
+    outside_file.write_text("<?xml version='1.0'?><schema/>")
+    
+    # Try to access it via path traversal
+    traversal_path = str(Path("../../../") / outside_file.name)
+    
+    with pytest.raises(XtceValidationError, match="Path traversal detected"):
+        _load_schema(traversal_path)
+
+
+def test_load_schema_not_found(tmp_path):
+    """Test that _load_schema raises error for missing file"""
+    missing_path = "nonexistent/schema.xsd"
+    
+    with pytest.raises(XtceValidationError, match="Schema file not found"):
+        _load_schema(missing_path)
+
+
+def test_find_schema_url_rejects_absolute_paths():
+    """Test that _find_schema_url rejects absolute filesystem paths in schemaLocation"""
+    xtce_str = """<xtce:SpaceSystem name="Test"
+                  xmlns:xtce="http://www.omg.org/spec/XTCE/20180204"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204
+                                      /absolute/path/to/schema.xsd">
+    </xtce:SpaceSystem>"""
+    
+    xml_tree = ElementTree.parse(io.StringIO(xtce_str))
+    
+    with pytest.raises(XtceValidationError, match="Absolute filesystem paths are not allowed in xsi:schemaLocation"):
+        from space_packet_parser.xtce.validation import _find_schema_url
+        _find_schema_url(xml_tree)
+
+
+def test_find_schema_url_rejects_invalid_schemes():
+    """Test that _find_schema_url rejects non-http(s) schemes"""
+    xtce_str = """<xtce:SpaceSystem name="Test"
+                  xmlns:xtce="http://www.omg.org/spec/XTCE/20180204"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204
+                                      ftp://example.com/schema.xsd">
+    </xtce:SpaceSystem>"""
+    
+    xml_tree = ElementTree.parse(io.StringIO(xtce_str))
+    
+    with pytest.raises(XtceValidationError, match="Only http and https URLs are allowed"):
+        from space_packet_parser.xtce.validation import _find_schema_url
+        _find_schema_url(xml_tree)
+
+
+def test_validate_xtce_converts_absolute_local_xsd(test_data_dir):
+    """Test that absolute local_xsd paths are converted to relative paths"""
+    xtce_path = test_data_dir / "test_xtce.xml"
+    local_xsd_path = test_data_dir / "SpaceSystem.xsd"
+    
+    # Get absolute path
+    absolute_xsd_path = local_xsd_path.resolve()
+    
+    # Validate using absolute local XSD
+    result = validate_xtce(xtce_path, level="schema", local_xsd=absolute_xsd_path, raise_on_error=False)
+    
+    # Verify validation was performed
+    assert result.validation_level.value == "schema"
+    # The schema_location should be relative or resolvable to the same file
+    assert Path(result.schema_location).resolve() == absolute_xsd_path
+    assert result.valid
+
+
+def test_validate_xtce_absolute_xsd_outside_cwd(test_data_dir, tmp_path):
+    """Test that absolute local_xsd paths outside cwd use just the filename"""
+    xtce_path = test_data_dir / "test_xtce.xml"
+    local_xsd_path = test_data_dir / "SpaceSystem.xsd"
+    
+    # This tests the fallback when path can't be made relative to cwd
+    # It will use just the filename
+    result = validate_xtce(xtce_path, level="schema", local_xsd=local_xsd_path, raise_on_error=False)
+    
+    # Should attempt validation (even if it fails due to file not found with just the name)
+    assert result.validation_level.value == "schema"

--- a/tests/unit/test_xtce/test_validation.py
+++ b/tests/unit/test_xtce/test_validation.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import lxml.etree as ElementTree
 import pytest
 
-from space_packet_parser.xtce.validation import _load_schema, validate_xtce, XtceValidationError, _find_schema_url
+from space_packet_parser.xtce.validation import XtceValidationError, _find_schema_url, _load_schema, validate_xtce
 
 
 @pytest.fixture
@@ -462,7 +462,7 @@ def test_load_schema_rejects_absolute_paths(test_data_dir):
     """Test that _load_schema rejects absolute filesystem paths"""
     local_xsd_path = test_data_dir / "SpaceSystem.xsd"
     absolute_path = str(local_xsd_path.resolve())
-    
+
     with pytest.raises(XtceValidationError, match="Absolute filesystem paths are not allowed"):
         _load_schema(absolute_path)
 
@@ -470,7 +470,7 @@ def test_load_schema_rejects_absolute_paths(test_data_dir):
 def test_load_schema_not_found(tmp_path):
     """Test that _load_schema raises error for missing file"""
     missing_path = "nonexistent/schema.xsd"
-    
+
     with pytest.raises(XtceValidationError, match="Schema file not found"):
         _load_schema(missing_path)
 
@@ -483,9 +483,9 @@ def test_find_schema_url_rejects_absolute_paths():
                   xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204
                                       /absolute/path/to/schema.xsd">
     </xtce:SpaceSystem>"""
-    
+
     xml_tree = ElementTree.parse(io.StringIO(xtce_str))
-    
+
     with pytest.raises(XtceValidationError, match="Absolute filesystem paths are not allowed in xsi:schemaLocation"):
         _find_schema_url(xml_tree)
 
@@ -498,9 +498,9 @@ def test_find_schema_url_rejects_invalid_schemes():
                   xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204
                                       ftp://example.com/schema.xsd">
     </xtce:SpaceSystem>"""
-    
+
     xml_tree = ElementTree.parse(io.StringIO(xtce_str))
-    
+
     with pytest.raises(XtceValidationError, match="Only http and https URLs are allowed"):
         _find_schema_url(xml_tree)
 
@@ -509,16 +509,15 @@ def test_validate_xtce_converts_absolute_local_xsd(test_data_dir):
     """Test that absolute local_xsd paths are converted to relative paths"""
     xtce_path = test_data_dir / "test_xtce.xml"
     local_xsd_path = test_data_dir / "SpaceSystem.xsd"
-    
+
     # Get absolute path
     absolute_xsd_path = local_xsd_path.resolve()
-    
+
     # Validate using absolute local XSD
     result = validate_xtce(xtce_path, level="schema", local_xsd=absolute_xsd_path, raise_on_error=False)
-    
+
     # Verify validation was performed
     assert result.validation_level.value == "schema"
     # The schema_location should be relative or resolvable to the same file
     assert Path(result.schema_location).resolve() == absolute_xsd_path
     assert result.valid
-

--- a/tests/unit/test_xtce/test_validation.py
+++ b/tests/unit/test_xtce/test_validation.py
@@ -400,7 +400,7 @@ def test_schema_validation_with_local_xsd(test_data_dir):
 
     # Verify validation was performed
     assert result.validation_level.value == "schema"
-    assert result.schema_location == str(local_xsd_path)
+    assert result.schema_location == str(local_xsd_path.relative_to(Path.cwd()))
     assert result.schema_version is not None
 
     # The document should be valid against the schema

--- a/tests/unit/test_xtce/test_validation.py
+++ b/tests/unit/test_xtce/test_validation.py
@@ -11,37 +11,6 @@ import pytest
 from space_packet_parser.xtce.validation import XtceValidationError, _find_schema_url, _load_schema, validate_xtce
 
 
-@pytest.fixture
-def mock_schema_download(test_data_dir):
-    """Mock urlopen to return local XSD content instead of downloading from network."""
-    local_xsd_path = test_data_dir / "SpaceSystem.xsd"
-
-    def mock_urlopen(url, timeout=None):
-        """Mock urlopen that returns local XSD content."""
-
-        class MockResponse:
-            def __init__(self, content):
-                self.content = content
-
-            def read(self):
-                return self.content
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *args):
-                pass
-
-        # Read the local XSD file
-        with local_xsd_path.open("rb") as f:
-            content = f.read()
-
-        return MockResponse(content)
-
-    with patch("space_packet_parser.xtce.validation.urlopen", side_effect=mock_urlopen):
-        yield
-
-
 @pytest.mark.parametrize("xml_file", ["test_xtce.xml", "test_xtce_4byte.xml", "test_xtce_default_namespace.xml"])
 def test_schema_validation_valid_document(test_data_dir, xml_file, mock_schema_download):
     """Test schema validation on valid XTCE documents"""
@@ -398,9 +367,10 @@ def test_schema_validation_with_local_xsd(test_data_dir):
     # Validate using the local XSD
     result = validate_xtce(xtce_path, level="schema", local_xsd=local_xsd_path)
 
-    # Verify validation was performed
+    # Verify validation was performed. local_xsd is trusted and opened directly, so the
+    # reported schema_location is exactly the path the caller supplied (no cwd-relative rewriting).
     assert result.validation_level.value == "schema"
-    assert result.schema_location == str(local_xsd_path.relative_to(Path.cwd()))
+    assert result.schema_location == str(local_xsd_path)
     assert result.schema_version is not None
 
     # The document should be valid against the schema
@@ -427,9 +397,11 @@ def test_schema_caching_mechanism(test_data_dir):
                 mock_response.read.return_value = expected_content
 
                 test_url = "https://example.com/test_schema.xsd"
+                # example.com is not in the default allowlist, so allow it explicitly for this test.
+                allowed = {"example.com"}
 
                 # First call - should download and cache
-                schema1, version1 = _load_schema(test_url)
+                schema1, version1 = _load_schema(test_url, allowed_schema_hosts=allowed)
 
                 # Verify network call was made
                 assert mock_urlopen.call_count == 1
@@ -441,12 +413,12 @@ def test_schema_caching_mechanism(test_data_dir):
                 cache_path = temp_cache_dir / "schemas" / cache_path.name
                 assert cache_path.exists()
 
-                # Verify cached content matches expected content
+                # Verify cached content matches expected content (raw bytes cached after validation)
                 cached_content = cache_path.read_bytes()
                 assert cached_content == expected_content
 
                 # Second call - should use cache (no additional network call)
-                schema2, version2 = _load_schema(test_url)
+                schema2, version2 = _load_schema(test_url, allowed_schema_hosts=allowed)
 
                 # Verify no additional network call was made
                 assert mock_urlopen.call_count == 1  # Still only 1 call
@@ -458,21 +430,30 @@ def test_schema_caching_mechanism(test_data_dir):
                 assert isinstance(schema2, ElementTree.XMLSchema)
 
 
-def test_load_schema_rejects_absolute_paths(test_data_dir):
-    """Test that _load_schema rejects absolute filesystem paths"""
+def test_load_schema_rejects_untrusted_absolute_paths(test_data_dir):
+    """_load_schema refuses an untrusted (document-derived) absolute local path (CWE-73)."""
     local_xsd_path = test_data_dir / "SpaceSystem.xsd"
     absolute_path = str(local_xsd_path.resolve())
 
-    with pytest.raises(XtceValidationError, match="Absolute filesystem paths are not allowed"):
+    with pytest.raises(XtceValidationError, match="untrusted local path"):
         _load_schema(absolute_path)
 
 
-def test_load_schema_not_found(tmp_path):
-    """Test that _load_schema raises error for missing file"""
-    missing_path = "nonexistent/schema.xsd"
+def test_load_schema_trusted_absolute_path_is_opened(test_data_dir):
+    """A trusted absolute local path (e.g. operator-supplied local_xsd) is opened directly."""
+    local_xsd_path = test_data_dir / "SpaceSystem.xsd"
+    absolute_path = str(local_xsd_path.resolve())
 
-    with pytest.raises(XtceValidationError, match="Schema file not found"):
-        _load_schema(missing_path)
+    schema, version = _load_schema(absolute_path, trusted=True)
+    assert version is not None
+
+
+def test_load_schema_not_found(tmp_path):
+    """Test that _load_schema raises error for a missing trusted file"""
+    missing_path = str(tmp_path / "nonexistent" / "schema.xsd")
+
+    with pytest.raises(XtceValidationError, match="Schema file not found or unreadable"):
+        _load_schema(missing_path, trusted=True)
 
 
 def test_find_schema_url_rejects_absolute_paths():
@@ -486,7 +467,7 @@ def test_find_schema_url_rejects_absolute_paths():
 
     xml_tree = ElementTree.parse(io.StringIO(xtce_str))
 
-    with pytest.raises(XtceValidationError, match="Absolute filesystem paths are not allowed in xsi:schemaLocation"):
+    with pytest.raises(XtceValidationError, match="must be an http.s. URL"):
         _find_schema_url(xml_tree)
 
 
@@ -501,23 +482,21 @@ def test_find_schema_url_rejects_invalid_schemes():
 
     xml_tree = ElementTree.parse(io.StringIO(xtce_str))
 
-    with pytest.raises(XtceValidationError, match="Only http and https URLs are allowed"):
+    with pytest.raises(XtceValidationError, match="must be an http.s. URL"):
         _find_schema_url(xml_tree)
 
 
-def test_validate_xtce_converts_absolute_local_xsd(test_data_dir):
-    """Test that absolute local_xsd paths are converted to relative paths"""
+def test_validate_xtce_absolute_local_xsd_is_used_directly(test_data_dir):
+    """An absolute local_xsd is trusted and used as-is (no cwd rewriting, works from any cwd)."""
     xtce_path = test_data_dir / "test_xtce.xml"
     local_xsd_path = test_data_dir / "SpaceSystem.xsd"
 
-    # Get absolute path
     absolute_xsd_path = local_xsd_path.resolve()
 
-    # Validate using absolute local XSD
     result = validate_xtce(xtce_path, level="schema", local_xsd=absolute_xsd_path, raise_on_error=False)
 
-    # Verify validation was performed
     assert result.validation_level.value == "schema"
-    # The schema_location should be relative or resolvable to the same file
-    assert Path(result.schema_location).resolve() == absolute_xsd_path
+    # schema_location is exactly the absolute path supplied by the caller.
+    assert result.schema_location == str(absolute_xsd_path)
+    assert Path(result.schema_location) == absolute_xsd_path
     assert result.valid

--- a/tests/unit/test_xtce/test_validation.py
+++ b/tests/unit/test_xtce/test_validation.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import lxml.etree as ElementTree
 import pytest
 
-from space_packet_parser.xtce.validation import _load_schema, validate_xtce
+from space_packet_parser.xtce.validation import _load_schema, validate_xtce, XtceValidationError, _find_schema_url
 
 
 @pytest.fixture
@@ -487,7 +487,6 @@ def test_find_schema_url_rejects_absolute_paths():
     xml_tree = ElementTree.parse(io.StringIO(xtce_str))
     
     with pytest.raises(XtceValidationError, match="Absolute filesystem paths are not allowed in xsi:schemaLocation"):
-        from space_packet_parser.xtce.validation import _find_schema_url
         _find_schema_url(xml_tree)
 
 
@@ -503,7 +502,6 @@ def test_find_schema_url_rejects_invalid_schemes():
     xml_tree = ElementTree.parse(io.StringIO(xtce_str))
     
     with pytest.raises(XtceValidationError, match="Only http and https URLs are allowed"):
-        from space_packet_parser.xtce.validation import _find_schema_url
         _find_schema_url(xml_tree)
 
 

--- a/tests/unit/test_xtce/test_validation.py
+++ b/tests/unit/test_xtce/test_validation.py
@@ -537,15 +537,3 @@ def test_validate_xtce_converts_absolute_local_xsd(test_data_dir):
     assert Path(result.schema_location).resolve() == absolute_xsd_path
     assert result.valid
 
-
-def test_validate_xtce_absolute_xsd_outside_cwd(test_data_dir, tmp_path):
-    """Test that absolute local_xsd paths outside cwd use just the filename"""
-    xtce_path = test_data_dir / "test_xtce.xml"
-    local_xsd_path = test_data_dir / "SpaceSystem.xsd"
-    
-    # This tests the fallback when path can't be made relative to cwd
-    # It will use just the filename
-    result = validate_xtce(xtce_path, level="schema", local_xsd=local_xsd_path, raise_on_error=False)
-    
-    # Should attempt validation (even if it fails due to file not found with just the name)
-    assert result.validation_level.value == "schema"

--- a/tests/unit/test_xtce/test_validation.py
+++ b/tests/unit/test_xtce/test_validation.py
@@ -467,19 +467,6 @@ def test_load_schema_rejects_absolute_paths(test_data_dir):
         _load_schema(absolute_path)
 
 
-def test_load_schema_rejects_path_traversal(tmp_path):
-    """Test that _load_schema rejects path traversal attacks"""
-    # Create a dummy file outside the current directory
-    outside_file = tmp_path / "outside.xsd"
-    outside_file.write_text("<?xml version='1.0'?><schema/>")
-    
-    # Try to access it via path traversal
-    traversal_path = str(Path("../../../") / outside_file.name)
-    
-    with pytest.raises(XtceValidationError, match="Path traversal detected"):
-        _load_schema(traversal_path)
-
-
 def test_load_schema_not_found(tmp_path):
     """Test that _load_schema raises error for missing file"""
     missing_path = "nonexistent/schema.xsd"

--- a/tests/unit/test_xtce/test_validation_security.py
+++ b/tests/unit/test_xtce/test_validation_security.py
@@ -1,0 +1,257 @@
+"""Security regression tests for XTCE schema validation.
+
+These cover the LFI (CWE-73) and SSRF (CWE-918) advisories: a document-supplied
+``xsi:schemaLocation`` is untrusted and must never read arbitrary local files or drive
+outbound requests to non-allowlisted / internal hosts. The trusted ``local_xsd`` argument
+must remain fully functional, and the standard OMG schema must validate offline via the bundle.
+"""
+
+import io
+from unittest.mock import Mock, patch
+
+import lxml.etree as ElementTree
+import pytest
+
+from space_packet_parser.xtce import validation
+from space_packet_parser.xtce.validation import (
+    DEFAULT_ALLOWED_SCHEMA_HOSTS,
+    XtceValidationError,
+    _load_schema,
+    validate_xtce,
+)
+
+
+def _doc_with_schema_location(location: str) -> ElementTree._ElementTree:
+    """Build an XTCE document tree whose xsi:schemaLocation points at ``location``."""
+    xml = (
+        '<xtce:SpaceSystem name="Test" xmlns:xtce="http://www.omg.org/spec/XTCE/20180204" '
+        'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+        f'xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204 {location}"/>'
+    )
+    return ElementTree.parse(io.StringIO(xml))
+
+
+def _mock_urlopen_returning(content: bytes):
+    """Return a Mock suitable for patching urlopen that yields ``content`` with no Content-Length."""
+
+    class _Resp:
+        headers: dict = {}
+
+        def read(self, *args):
+            if args:
+                return content[: args[0]]
+            return content
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    return Mock(side_effect=lambda url, timeout=None: _Resp())
+
+
+# --------------------------------------------------------------------------------------
+# LFI (CWE-73): document-derived local paths must never open a file.
+# --------------------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "location",
+    [
+        "/etc/hostname",  # absolute POSIX path (the LFI PoC)
+        "../../../etc/passwd",  # relative traversal
+        "SpaceSystem.xsd",  # bare filename
+        "schemas/SpaceSystem.xsd",  # relative path
+        "C:\\Windows\\win.ini",  # Windows drive path
+        "\\\\server\\share\\schema.xsd",  # UNC path
+        "file:///etc/hostname",  # file:// scheme
+    ],
+)
+def test_document_local_path_is_rejected(location):
+    """A local filesystem reference in xsi:schemaLocation is rejected (no file is opened)."""
+    result = validate_xtce(
+        _doc_with_schema_location(location), level="schema", print_results=False, raise_on_error=False
+    )
+    assert not result.valid
+    assert any(e.error_code == "DISALLOWED_SCHEMA_LOCATION" for e in result.errors)
+
+
+# --------------------------------------------------------------------------------------
+# SSRF (CWE-918): document-derived URLs must be allowlisted, https, and non-internal.
+# --------------------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "location",
+    [
+        "http://169.254.169.254/latest/meta-data/iam/security-credentials/",  # cloud metadata PoC
+        "http://127.0.0.1:9998/SSRF_CONFIRMED",  # loopback PoC
+        "https://evil.example.com/schema.xsd",  # arbitrary external host
+        "ftp://example.com/schema.xsd",  # non-http scheme
+    ],
+)
+def test_document_url_ssrf_is_rejected(location):
+    """Metadata/loopback/arbitrary URLs from a document are rejected with no outbound request."""
+    with patch("space_packet_parser.xtce.validation.urlopen") as mock_urlopen:
+        result = validate_xtce(
+            _doc_with_schema_location(location), level="schema", print_results=False, raise_on_error=False
+        )
+    assert not result.valid
+    assert any(e.error_code == "DISALLOWED_SCHEMA_LOCATION" for e in result.errors)
+    mock_urlopen.assert_not_called()
+
+
+def test_internal_ip_blocked_even_when_http_allowed_and_allowlisted():
+    """The internal-address guard fires even if http is enabled AND the host is allowlisted."""
+    location = "http://169.254.169.254/latest/meta-data/"
+    with patch("space_packet_parser.xtce.validation.urlopen") as mock_urlopen:
+        result = validate_xtce(
+            _doc_with_schema_location(location),
+            level="schema",
+            print_results=False,
+            raise_on_error=False,
+            allow_insecure_http=True,
+            allowed_schema_hosts=["169.254.169.254"],
+        )
+    assert not result.valid
+    assert any("non-public address" in e.message for e in result.errors)
+    mock_urlopen.assert_not_called()
+
+
+# --------------------------------------------------------------------------------------
+# Bundled schema: the standard OMG schema validates offline (no network).
+# --------------------------------------------------------------------------------------
+def test_standard_document_validates_offline_via_bundle(test_data_dir):
+    """A document referencing the OMG schema URL validates from the bundle with no urlopen call."""
+    with patch("space_packet_parser.xtce.validation.urlopen") as mock_urlopen:
+        result = validate_xtce(
+            test_data_dir / "test_xtce.xml", level="schema", print_results=False, raise_on_error=False
+        )
+    assert result.valid
+    assert result.schema_version == "1.2"
+    mock_urlopen.assert_not_called()
+
+
+def test_allow_schema_download_false_still_uses_bundle(test_data_dir):
+    """With downloads disabled, the bundled OMG schema is still used."""
+    with patch("space_packet_parser.xtce.validation.urlopen") as mock_urlopen:
+        result = validate_xtce(
+            test_data_dir / "test_xtce.xml",
+            level="schema",
+            print_results=False,
+            raise_on_error=False,
+            allow_schema_download=False,
+        )
+    assert result.valid
+    mock_urlopen.assert_not_called()
+
+
+def test_allow_schema_download_false_blocks_non_bundled_url():
+    """With downloads disabled, a non-bundled (but allowlisted) URL is not fetched."""
+    location = "https://www.omg.org/spec/XTCE/somethingelse.xsd"
+    with patch("space_packet_parser.xtce.validation.urlopen") as mock_urlopen:
+        result = validate_xtce(
+            _doc_with_schema_location(location),
+            level="schema",
+            print_results=False,
+            raise_on_error=False,
+            allow_schema_download=False,
+        )
+    assert not result.valid
+    assert any(e.error_code == "SCHEMA_LOAD_ERROR" for e in result.errors)
+    mock_urlopen.assert_not_called()
+
+
+# --------------------------------------------------------------------------------------
+# Allowlist configuration: argument, env var, exact-URL entries, insecure http.
+# --------------------------------------------------------------------------------------
+def test_custom_host_allowlist_argument_permits_download(test_data_dir, tmp_path):
+    """A non-OMG host explicitly added to allowed_schema_hosts is fetched."""
+    content = (test_data_dir / "SpaceSystem.xsd").read_bytes()
+    location = "https://mirror.example.org/SpaceSystem.xsd"
+    with patch("space_packet_parser.xtce.validation._get_cache_dir", return_value=tmp_path):
+        with patch("space_packet_parser.xtce.validation.urlopen", _mock_urlopen_returning(content)):
+            schema, version = _load_schema(location, allowed_schema_hosts=["mirror.example.org"])
+    assert version == "1.2"
+
+
+def test_exact_url_allowlist_entry(test_data_dir, tmp_path):
+    """An exact-URL allowlist entry matches only that URL."""
+    content = (test_data_dir / "SpaceSystem.xsd").read_bytes()
+    good = "https://mirror.example.org/schemas/SpaceSystem.xsd"
+    with patch("space_packet_parser.xtce.validation._get_cache_dir", return_value=tmp_path):
+        with patch("space_packet_parser.xtce.validation.urlopen", _mock_urlopen_returning(content)):
+            schema, version = _load_schema(good, allowed_schema_hosts=[good])
+    assert version == "1.2"
+
+    # A different path on the same host is NOT covered by an exact-URL entry.
+    other = "https://mirror.example.org/schemas/Other.xsd"
+    with pytest.raises(XtceValidationError, match="not in the allowlist"):
+        _load_schema(other, allowed_schema_hosts=[good])
+
+
+def test_env_var_allowlist(monkeypatch, test_data_dir, tmp_path):
+    """SPP_ALLOWED_SCHEMA_HOSTS configures the allowlist when no argument is passed."""
+    content = (test_data_dir / "SpaceSystem.xsd").read_bytes()
+    location = "https://env-mirror.example.org/SpaceSystem.xsd"
+    monkeypatch.setenv("SPP_ALLOWED_SCHEMA_HOSTS", "foo.example, env-mirror.example.org")
+    with patch("space_packet_parser.xtce.validation._get_cache_dir", return_value=tmp_path):
+        with patch("space_packet_parser.xtce.validation.urlopen", _mock_urlopen_returning(content)):
+            schema, version = _load_schema(location)
+    assert version == "1.2"
+
+
+def test_insecure_http_requires_opt_in(test_data_dir, tmp_path):
+    """An allowlisted http host is rejected by default but permitted with allow_insecure_http."""
+    content = (test_data_dir / "SpaceSystem.xsd").read_bytes()
+    location = "http://mirror.example.org/SpaceSystem.xsd"
+
+    # Default: http rejected even though host is allowlisted.
+    with pytest.raises(XtceValidationError, match="scheme 'http' is not allowed"):
+        _load_schema(location, allowed_schema_hosts=["mirror.example.org"])
+
+    # Opt-in: http permitted.
+    with patch("space_packet_parser.xtce.validation._get_cache_dir", return_value=tmp_path):
+        with patch("space_packet_parser.xtce.validation.urlopen", _mock_urlopen_returning(content)):
+            schema, version = _load_schema(
+                location, allowed_schema_hosts=["mirror.example.org"], allow_insecure_http=True
+            )
+    assert version == "1.2"
+
+
+def test_env_var_insecure_http(monkeypatch, test_data_dir, tmp_path):
+    """SPP_ALLOW_INSECURE_HTTP enables http when the argument is not set."""
+    content = (test_data_dir / "SpaceSystem.xsd").read_bytes()
+    location = "http://mirror.example.org/SpaceSystem.xsd"
+    monkeypatch.setenv("SPP_ALLOW_INSECURE_HTTP", "1")
+    with patch("space_packet_parser.xtce.validation._get_cache_dir", return_value=tmp_path):
+        with patch("space_packet_parser.xtce.validation.urlopen", _mock_urlopen_returning(content)):
+            schema, version = _load_schema(location, allowed_schema_hosts=["mirror.example.org"])
+    assert version == "1.2"
+
+
+def test_default_allowlist_is_omg():
+    """Sanity check on the exported default allowlist."""
+    assert "www.omg.org" in DEFAULT_ALLOWED_SCHEMA_HOSTS
+
+
+# --------------------------------------------------------------------------------------
+# Cache hardening: only validated schema content is cached; oversized responses rejected.
+# --------------------------------------------------------------------------------------
+def test_non_schema_response_is_not_cached(tmp_path):
+    """A non-XSD response (e.g. an SSRF probe body) errors and is never written to the cache."""
+    location = "https://mirror.example.org/SpaceSystem.xsd"
+    with patch("space_packet_parser.xtce.validation._get_cache_dir", return_value=tmp_path):
+        with patch("space_packet_parser.xtce.validation.urlopen", _mock_urlopen_returning(b"NOT-A-SCHEMA creds=abc")):
+            with pytest.raises(XtceValidationError):
+                _load_schema(location, allowed_schema_hosts=["mirror.example.org"])
+    # Nothing was persisted to the cache directory.
+    assert not any((tmp_path / "schemas").glob("*.xsd")) if (tmp_path / "schemas").exists() else True
+
+
+def test_oversized_schema_rejected(tmp_path, monkeypatch, test_data_dir):
+    """A response larger than the size cap is rejected."""
+    monkeypatch.setattr(validation, "MAX_SCHEMA_BYTES", 16)
+    content = (test_data_dir / "SpaceSystem.xsd").read_bytes()  # far larger than 16 bytes
+    location = "https://mirror.example.org/SpaceSystem.xsd"
+    with patch("space_packet_parser.xtce.validation._get_cache_dir", return_value=tmp_path):
+        with patch("space_packet_parser.xtce.validation.urlopen", _mock_urlopen_returning(content)):
+            with pytest.raises(XtceValidationError, match="exceeds the maximum allowed size"):
+                _load_schema(location, allowed_schema_hosts=["mirror.example.org"])


### PR DESCRIPTION
## Summary

Hardens XTCE schema validation against two reported vulnerabilities in `validate_xtce`. Both share one root cause: a document's `xsi:schemaLocation` is attacker-controlled but was used to read files and make network requests without restriction. Fixes #266.

## Problems being fixed

- **SSRF — CWE-918 (7.4 High).** A crafted document could point `xsi:schemaLocation` at any URL, causing the validating host to issue outbound requests — e.g. the cloud metadata endpoint `http://169.254.169.254/latest/meta-data/iam/security-credentials/` for IAM credential theft — and the response was cached to disk, persisting exfiltrated data.
- **LFI — CWE-73.** The same field could point at an absolute or traversal filesystem path (`/etc/hostname`, `../../etc/passwd`), causing arbitrary local files to be read as a "schema".

## How we fix it

The document-supplied `xsi:schemaLocation` is now treated as **untrusted**, while an operator-supplied `local_xsd` remains **trusted**. Schema resolution is:

1. **Bundled schema (offline).** The standard OMG XTCE 1.2 schema ships in the package, so the common case validates with **no network request** — this alone removes the SSRF surface for typical use.
2. **`local_xsd` (trusted).** Opened directly at any path.
3. **Allowlisted download.** Any other URL is fetched **only** if it is `https` on an allowlisted host (default `www.omg.org`). Internal/link-local targets (`169.254.169.254`, `127.0.0.1`, private ranges) are always blocked. Local filesystem paths from a document are rejected outright — use `local_xsd`.

Additional hardening:
- Downloaded content is **size-capped** and cached **only after** it validates as an XSD, so a non-schema response can never be persisted.
- New options (API + CLI, with env-var overrides): `allowed_schema_hosts` (hosts or exact URLs), `allow_insecure_http` (dangerous opt-in; host allowlist + internal-address guard still apply), `allow_schema_download`. Default download stays on but allowlisted. `DEFAULT_ALLOWED_SCHEMA_HOSTS` is exported.

## Behavior changes

- A document whose `xsi:schemaLocation` is a **local path** or a **non-allowlisted / non-https URL** is now rejected — pass `local_xsd`, extend the allowlist, or (for http) opt in explicitly.
- Absolute `local_xsd` / `--local-xsd` again works from any working directory (fixes a regression that rewrote it to a bare filename).

## Testing

New `tests/unit/test_xtce/test_validation_security.py` asserts every advisory PoC is rejected with no outbound request, plus positive coverage for the allowlist (arg/env/exact-URL), the `allow_insecure_http` opt-in still blocking internal IPs, offline bundle validation, and cache behavior. Full suite passes; docs and changelog updated.

<sub><em>PR description drafted with Claude and reviewed by Gavin (@medley56).</em></sub>
